### PR TITLE
[DRAFT — needs your review] onboarding: provision login user on install + shop_domain on enroll

### DIFF
--- a/app/routes/api.enroll.tsx
+++ b/app/routes/api.enroll.tsx
@@ -305,6 +305,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       nfc_uid: serial_number,
       order_details: {
         order_number: numericOrderId,
+        // Stamp the store domain onto the proof so the backend can later call
+        // the Shopify app's /api/return-status (which needs shop_domain to load
+        // that store's session) for returns back-and-forth.
+        shop_domain: session.shop,
         customer_email: orderData?.data?.order?.customer?.email || "unknown@example.com",
         customer_phone: customer_phone_last4 || "1234",
         shipping_address,

--- a/app/routes/app.payment.callback.tsx
+++ b/app/routes/app.payment.callback.tsx
@@ -1,7 +1,23 @@
 import { type LoaderFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
-import { createMerchant } from "../services/ink-api.server";
+import { createMerchant, adminCreateUser } from "../services/ink-api.server";
 import { updateMerchant } from "../services/merchant.server";
+
+// Temp password for the merchant's Parallel login. 16 chars, mixed classes
+// (excludes ambiguous chars) to satisfy typical complexity rules. The merchant
+// changes it on first login; it's stored on the merchant doc so onboarding can
+// surface it.
+function generateTempPassword(): string {
+  const upper = "ABCDEFGHJKMNPQRSTUVWXYZ";
+  const lower = "abcdefghijkmnpqrstuvwxyz";
+  const digit = "23456789";
+  const sym = "!@#$%^&*";
+  const all = upper + lower + digit + sym;
+  const pick = (s: string) => s[Math.floor(Math.random() * s.length)];
+  let pw = pick(upper) + pick(lower) + pick(digit) + pick(sym);
+  for (let i = 0; i < 12; i++) pw += pick(all);
+  return pw;
+}
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { session, admin } = await authenticate.admin(request);
@@ -38,6 +54,33 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         });
     } else {
         throw new Error("No API key returned from INK");
+    }
+
+    // Provision a Parallel login USER so the merchant can sign into
+    // parallel.in.ink. Install creates a merchant but no user otherwise, so
+    // there's no credential to log in with. Soft-fail: this must NEVER block
+    // the install/billing callback — if it fails, the install still completes
+    // and we log it. Credential is stored on the merchant doc for onboarding
+    // to surface (merchant changes it on first login).
+    try {
+        const merchantId = inkData.merchant_id ?? inkData.shop_id ?? inkData.id;
+        if (merchantId) {
+            const tempPassword = generateTempPassword();
+            await adminCreateUser(merchantId, name || myshopifyDomain, email, tempPassword);
+            await updateMerchant(session.shop, {
+                parallel_login_email: email,
+                parallel_temp_password: tempPassword,
+                parallel_user_provisioned_at: new Date().toISOString(),
+            });
+            console.log(`[payment.callback] Provisioned Parallel login user for ${email}`);
+        } else {
+            console.warn("[payment.callback] No merchant_id in createMerchant response — skipped user provisioning");
+        }
+    } catch (provisionErr) {
+        console.warn(
+            "[payment.callback] User provisioning soft-failed (install continues):",
+            provisionErr instanceof Error ? provisionErr.message : provisionErr,
+        );
     }
 
   } catch (error) {


### PR DESCRIPTION
## ⚠️ DRAFT — do NOT merge as-is. Needs your decision + security review.

Two changes bundled:

### 1. Login user on install (the blocker) — NEEDS DECISION
Install now calls `adminCreateUser` + a generated temp password (soft-fail). **Security concern I introduced:** it stores the **plaintext temp password** on the merchant Firestore doc so onboarding can show it. That's a placeholder, not a good long-term pattern.
**Better options for you to pick:**
- a **magic-login link** (one-time token → parallel.in.ink auto-login), or
- reuse the existing **worker temp-cred-once** flow (mint, return once, wipe — like pilot redeem), or
- email the credential and store only a hash/flag.
Also **unverified** — no live install to confirm `adminCreateUser` succeeds against Alan's password constraints (soft-fail keeps it safe regardless).

### 2. shop_domain on enroll (safe)
Stamps `order_details.shop_domain` onto the proof so the backend can call `/api/return-status`. This part is benign and could be split out + merged independently.

## Recommendation
Tell me the credential-delivery approach (magic link is my pick) and I'll rebuild #1 properly + test. Merge #2 separately if you want it now.