### PR TITLE
landing: rewrite under Parallel / live receipt / built on ink.

### DIFF
--- a/app/components/CurrentPlanCard.tsx
+++ b/app/components/CurrentPlanCard.tsx
@@ -1,8 +1,8 @@
-import { Clock } from "lucide-react";
+import { Clock, Loader2 } from "lucide-react";
+import { useFetcher } from "react-router";
+import { useEffect } from "react";
 
 interface CurrentPlanCardProps {
-  enrollments?: number;
-  taps?: number;
   enrollmentRate?: number;
   tapRate?: number;
   tagsCost?: number;
@@ -15,8 +15,6 @@ interface CurrentPlanCardProps {
 }
 
 const CurrentPlanCard = ({
-  enrollments = 1247,
-  taps = 843,
   enrollmentRate = 0.99,
   tapRate = 2.99,
   tagsCost = 997.60,
@@ -27,6 +25,22 @@ const CurrentPlanCard = ({
   paymentMethod = "•••• 4242",
   className = "",
 }: CurrentPlanCardProps) => {
+  // Real verified-tap + enrollment counts, summed from the merchant's proofs
+  // (replaces the old hardcoded 843/1247 mock — "the tap count wasn't coming through").
+  // NOTE: the dollar/account figures below (tags pass-through, payment method,
+  // invoice dates, customer-since) are still placeholders; a full billing wire-up
+  // is a separate task from the tap count.
+  const fetcher = useFetcher<{ totalTaps: number; enrollments: number }>();
+  useEffect(() => {
+    if (fetcher.state === "idle" && !fetcher.data) {
+      fetcher.load(`/app/api/dashboard/tap-stats?_t=${Date.now()}`);
+    }
+  }, [fetcher]);
+
+  const isLoading = fetcher.state === "loading" || !fetcher.data;
+  const taps = fetcher.data?.totalTaps ?? 0;
+  const enrollments = fetcher.data?.enrollments ?? 0;
+
   const enrollmentRevenue = enrollments * enrollmentRate;
   const tapRevenue = taps * tapRate;
   const totalInkCharges = enrollmentRevenue + tapRevenue + tagsCost;
@@ -36,7 +50,12 @@ const CurrentPlanCard = ({
     `$${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
   return (
-    <div className={`bg-card border border-border rounded-sm overflow-hidden ${className}`}>
+    <div className={`relative bg-card border border-border rounded-sm overflow-hidden ${className}`}>
+      {isLoading && (
+        <div className="absolute inset-0 bg-background/50 backdrop-blur-[1px] flex items-center justify-center z-10 transition-all duration-300">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
       {/* Header */}
       <div className="px-5 py-4 border-b border-border">
         <div className="flex items-center justify-between flex-wrap gap-2">
@@ -83,7 +102,7 @@ const CurrentPlanCard = ({
 
         {/* Total */}
         <div className="flex items-center justify-between pt-3 border-t border-border">
-          <p className="text-sm font-semibold text-foreground">Total INK Charges</p>
+          <p className="text-sm font-semibold text-foreground">Total ink. Charges</p>
           <span className="text-sm font-semibold text-foreground">{fmt(totalInkCharges)}</span>
         </div>
 

--- a/app/components/EngagementFunnel.tsx
+++ b/app/components/EngagementFunnel.tsx
@@ -1,4 +1,6 @@
-import { ArrowDown } from "lucide-react";
+import { ArrowDown, Loader2 } from "lucide-react";
+import { useFetcher } from "react-router";
+import { useEffect } from "react";
 
 interface FunnelStep {
   label: string;
@@ -6,30 +8,43 @@ interface FunnelStep {
   color: string;
 }
 
-interface EngagementFunnelProps {
-  steps?: FunnelStep[];
-}
+const EngagementFunnel = () => {
+  // Real funnel from the merchant's proofs (replaces the 1247/843/158 mock):
+  // Enrolled = all proofs, Tapped = proofs tapped at least once. Shared source
+  // with CurrentPlanCard + BillingWidget.
+  const fetcher = useFetcher<{ totalTaps: number; enrollments: number; engaged: number }>();
+  useEffect(() => {
+    if (fetcher.state === "idle" && !fetcher.data) {
+      fetcher.load(`/app/api/dashboard/tap-stats?_t=${Date.now()}`);
+    }
+  }, [fetcher]);
 
-const defaultSteps: FunnelStep[] = [
-  { label: "Enrolled", count: 1247, color: "bg-amber-500" },
-  { label: "Active", count: 843, color: "bg-emerald-500" },
-  { label: "Expired", count: 158, color: "bg-gray-400" },
-];
+  const isLoading = fetcher.state === "loading" || !fetcher.data;
+  const enrollments = fetcher.data?.enrollments ?? 0;
+  const engaged = fetcher.data?.engaged ?? 0;
 
-const EngagementFunnel = ({ steps = defaultSteps }: EngagementFunnelProps) => {
+  const steps: FunnelStep[] = [
+    { label: "Enrolled", count: enrollments, color: "bg-amber-500" },
+    { label: "Tapped", count: engaged, color: "bg-emerald-500" },
+  ];
   const maxCount = steps[0]?.count || 1;
 
   return (
     <div
-      className="bg-card border border-border rounded-md p-4 sm:p-6 shadow-[0_1px_2px_rgba(0,0,0,0.04)]"
+      className="relative bg-card border border-border rounded-md p-4 sm:p-6 shadow-[0_1px_2px_rgba(0,0,0,0.04)]"
       role="region"
       aria-label="Engagement funnel"
     >
+      {isLoading && (
+        <div className="absolute inset-0 bg-background/50 backdrop-blur-[1px] flex items-center justify-center z-10 rounded-md">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
       {/* Header */}
       <div className="mb-5">
         <h3 className="text-sm font-semibold text-foreground">Engagement Funnel</h3>
         <p className="text-xs text-muted-foreground mt-0.5">
-          How shipments move through the verification lifecycle
+          How many enrolled shipments were tapped
         </p>
       </div>
 
@@ -38,7 +53,7 @@ const EngagementFunnel = ({ steps = defaultSteps }: EngagementFunnelProps) => {
         {steps.map((step, index) => {
           const widthPercent = Math.max((step.count / maxCount) * 100, 12);
           const dropoff = index > 0
-            ? (((steps[index - 1].count - step.count) / steps[index - 1].count) * 100).toFixed(0)
+            ? (((steps[index - 1].count - step.count) / (steps[index - 1].count || 1)) * 100).toFixed(0)
             : null;
           const isLast = index === steps.length - 1;
 
@@ -79,7 +94,7 @@ const EngagementFunnel = ({ steps = defaultSteps }: EngagementFunnelProps) => {
       <div className="mt-5 pt-4 border-t border-border flex items-center justify-between">
         <span className="text-xs text-muted-foreground">Overall engagement rate</span>
         <span className="text-sm font-semibold text-foreground tabular-nums">
-          {((steps[1]?.count || 0) / maxCount * 100).toFixed(1)}%
+          {((engaged / maxCount) * 100).toFixed(1)}%
         </span>
       </div>
     </div>

--- a/app/components/LandingPageContent.tsx
+++ b/app/components/LandingPageContent.tsx
@@ -29,24 +29,51 @@ export const LandingPageContent = ({
   signInLink = "/app",
   showSignIn = true,
 }: LandingPageContentProps) => {
-  const sec04 = [
+  const sec03 = [
     {
       num: "01",
-      title: "A receipt that's alive.",
+      title: "Tap to unlock.",
       desc:
-        "NFC sticker on the box. Customer taps. The receipt opens on their phone, branded to your store. No app. No login. No download.",
+        "Phone meets sticker. A native browser opens. No app. No download. No login. Under a second to portal.",
     },
     {
       num: "02",
-      title: "Proof before anything ships.",
+      title: "Branded portal.",
       desc:
-        "Pre-shipment photos tie what you packed to the sticker's unique ID. A tamper-evident, timestamped record. Created at the warehouse, not reconstructed after a dispute.",
+        "The page renders in your typography, colors, and voice. Care guides. Product story. Related items from your catalog.",
     },
     {
       num: "03",
-      title: "One merchant view.",
+      title: "Proof of arrival.",
       desc:
-        "Enrollment status. Tap rates. Time to engagement. Sticker inventory with auto-refill. One dashboard.",
+        "Tap captures GPS, time, and device. Chain of custody from the warehouse photo to the customer's hand.",
+    },
+    {
+      num: "04",
+      title: "Returns at the source.",
+      desc:
+        "One QR for any carrier, or the in-store passport at your counter. Refund at scan.",
+    },
+  ];
+
+  const sec04 = [
+    {
+      num: "01",
+      title: "The receipt is alive.",
+      desc:
+        "NFC sticker on the box. Tap to open. The receipt renders on the customer's phone, branded to your store. No app. No download.",
+    },
+    {
+      num: "02",
+      title: "Returns run from the receipt.",
+      desc:
+        "In-store passport at your counter, live today. Universal QR for FedEx, UPS, USPS rolling out with the next ink. update. The customer never sees a PDF.",
+    },
+    {
+      num: "03",
+      title: "The brand owns the surface.",
+      desc:
+        "Your typography, colors, and voice in the post-purchase moment. The merchant dashboard tracks enrollment, taps, and engagement.",
     },
   ];
 
@@ -80,21 +107,21 @@ export const LandingPageContent = ({
   const sec08 = [
     {
       num: "01",
-      title: "One tap to open the receipt.",
-      desc:
-        "Phone touches sticker. The receipt opens on the customer's phone, full screen, your brand. No app. No login. One tap and they close the phone and go about their day.",
-    },
-    {
-      num: "02",
       title: "Refund at scan.",
       desc:
         "Tappers get the express tier. The refund clears at the moment of return scan, not after a multi-day inspection cycle.",
     },
     {
-      num: "03",
-      title: "Returns from the receipt.",
+      num: "02",
+      title: "In-store passport.",
       desc:
-        "Two ways. At your store, show the passport at the counter and refund at scan. Live today. At any carrier, GPS detects the drop-off and generates a scannable QR. Rolling out with the next ink. update.",
+        "Customer brings the item to your store. Shows the passport on their phone. Counter scans, refund clears. No login. No receipt search. Live today.",
+    },
+    {
+      num: "03",
+      title: "Carrier-agnostic QR.",
+      desc:
+        "GPS detects the carrier. A universal QR generates on the phone. Walk into any FedEx, UPS, or USPS. The associate scans it. No printer, no portal. Rolling out with the next ink. update.",
     },
     {
       num: "04",
@@ -140,9 +167,10 @@ export const LandingPageContent = ({
           >
             Every order ships with a live receipt.
           </h1>
-          <p className="max-w-[54ch] pt-8 text-[14px] sm:text-[15px] leading-[1.6] text-neutral-700">
-            The live receipt for every Shopify order. Branded post-purchase, proof of delivery,
-            Amazon-style returns. Built on ink.
+          <p className="max-w-[58ch] pt-8 text-[14px] sm:text-[15px] leading-[1.6] text-neutral-700">
+            Traditional e-commerce cuts ties when the box hits the porch. Parallel keeps the loop
+            alive. Every order becomes a live checkout counter and a return drop-off box,
+            unlocked by one tap. Built on ink.
           </p>
           <div className="pt-10">
             <Link
@@ -157,88 +185,81 @@ export const LandingPageContent = ({
         </div>
       </section>
 
-      {/* ───── No 02 — The Receipt You Already Send ───── */}
+      {/* ───── No 02 — The continuous loop ───── */}
       <section className={`${sectionBorder} ${containerX} py-16 sm:py-24`}>
         <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-[1fr_2fr] gap-x-10 gap-y-8`}>
           <div>
-            <div className={`${eyebrow} pb-4`}>No 02 · The receipt you already send</div>
+            <div className={`${eyebrow} pb-4`}>No 02 · The continuous loop</div>
             <h2
               className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)]`}
               style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
             >
-              Parallel upgrades the receipt. Nothing else has to change.
+              Most e-commerce cuts ties when the box hits the porch.
             </h2>
           </div>
           <div className="max-w-[60ch]">
             <p className="text-[14px] sm:text-[15px] leading-[1.7] text-neutral-700">
-              The warehouse stays. The carrier stays. Shopify stays. You install one app and the
-              receipt becomes a branded page that taps open, runs returns, and proves delivery.
-              Live in days.
+              The receipt becomes a forwarded email. The brand becomes a tracking number. The
+              return becomes a printed label and a counter no one wants to visit. Parallel keeps
+              the loop alive. Every product gets a live twin that taps open into a branded portal.
+              The warehouse, carrier, and Shopify all stay. You install one app. Live in days.
             </p>
           </div>
         </div>
       </section>
 
-      {/* ───── No 03 — Two sides of the same receipt ───── */}
+      {/* ───── No 03 — The tap journey ───── */}
       <section className={sectionBorder}>
         <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-10`}>
-          <div className={`${eyebrow} pb-4`}>No 03 · Two sides of the same receipt</div>
+          <div className={`${eyebrow} pb-4`}>No 03 · The tap journey</div>
           <h2
-            className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)] max-w-[20ch]`}
+            className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)] max-w-[18ch]`}
             style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
           >
-            Your customer opens it. You see the truth.
+            One tap. Four moments.
           </h2>
         </div>
         <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-2 border-t ${colBorder}`}>
-          <div className={`${containerX} py-12 sm:py-16 sm:border-r ${colBorder}`}>
-            <div
-              className={`${mono} text-[11px] text-neutral-500 pb-4`}
-              style={{ fontFamily: FONT_MONO }}
-            >
-              Customer side
-            </div>
-            <h3
-              className={`m-0 ${display} text-[22px] sm:text-[28px] pb-5`}
-              style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-            >
-              A receipt that opens.
-            </h3>
-            <p className="text-[14px] leading-[1.65] text-neutral-700 max-w-[44ch]">
-              Phone touches sticker. Your logo, your colors, your message. Full screen. No app. No
-              login. One tap and they close their phone and go about their day.
-            </p>
-          </div>
-          <div className={`${containerX} py-12 sm:py-16 border-t sm:border-t-0 ${colBorder}`}>
-            <div
-              className={`${mono} text-[11px] text-neutral-500 pb-4`}
-              style={{ fontFamily: FONT_MONO }}
-            >
-              Merchant side
-            </div>
-            <h3
-              className={`m-0 ${display} text-[22px] sm:text-[28px] pb-5`}
-              style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-            >
-              Proof on every delivery.
-            </h3>
-            <p className="text-[14px] leading-[1.65] text-neutral-700 max-w-[44ch]">
-              On screen: their order is confirmed. In the background, the tap records GPS, time,
-              and device. Your customer sees a premium experience. You see a verified record.
-            </p>
-          </div>
+          {sec03.map((step, i) => {
+            const isRight = i % 2 === 1;
+            const isLastRow = i >= 2;
+            return (
+              <div
+                key={step.num}
+                className={`${containerX} py-12 sm:py-16 ${
+                  !isRight ? `sm:border-r ${colBorder}` : ""
+                } ${!isLastRow ? `border-b ${colBorder}` : ""}`}
+              >
+                <div
+                  className={`${mono} text-[12px] text-neutral-500 pb-4`}
+                  style={{ fontFamily: FONT_MONO }}
+                >
+                  {step.num}
+                </div>
+                <h3
+                  className={`m-0 ${display} text-[22px] sm:text-[26px] pb-5 max-w-[22ch]`}
+                  style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+                >
+                  {step.title}
+                </h3>
+                <p className="text-[14px] leading-[1.65] text-neutral-700 max-w-[44ch]">
+                  {step.desc}
+                </p>
+              </div>
+            );
+          })}
         </div>
       </section>
 
       {/* ───── No 04 — What Parallel does ───── */}
       <section className={sectionBorder}>
         <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-10`}>
-          <div className={`${eyebrow} pb-4`}>No 04 · What Parallel does</div>
+          <div className={`${eyebrow} pb-4`}>No 04 · What ships with Parallel</div>
           <h2
             className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)] max-w-[22ch]`}
             style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
           >
-            Branded receipt. Proof of delivery. Amazon-style returns.
+            Live receipt. Carrier-agnostic returns. Branded post-purchase.
           </h2>
         </div>
         <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-3 border-t ${colBorder}`}>
@@ -385,12 +406,12 @@ export const LandingPageContent = ({
       {/* ───── No 08 — From opening to refund ───── */}
       <section className={sectionBorder}>
         <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-10`}>
-          <div className={`${eyebrow} pb-4`}>No 08 · The receipt does the work</div>
+          <div className={`${eyebrow} pb-4`}>No 08 · Returns from the receipt</div>
           <h2
             className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)] max-w-[20ch]`}
             style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
           >
-            From opening to refund. One surface.
+            Four ways the customer returns.
           </h2>
         </div>
         <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-2 border-t ${colBorder}`}>

--- a/app/components/LandingPageContent.tsx
+++ b/app/components/LandingPageContent.tsx
@@ -1,145 +1,42 @@
-// Parallel landing — editorial system mirrored from parallel.in.ink.
-// Brutalist paper + ink. Archivo Black display for the masthead spine,
-// Geist sans for chrome and body, JetBrains Mono for micro-labels.
-// Hairline dividers, no rounded cards, no scroll-zoom drama.
+// Parallel landing — one screen, one door.
+// Brand top-left, optional sign-in top-right, big Archivo Black
+// headline centered, short Geist deck, single black enter button.
+// Used by both the public landing (_index) and the in-admin landing
+// (app/_index). Routes vary the props; the surface stays minimal.
 
 import { Link } from "react-router";
 
 interface LandingPageContentProps {
   ctaLink?: string;
+  ctaLabel?: string;
   signInLink?: string;
   showSignIn?: boolean;
+  headline?: string;
+  sub?: string;
+  footnote?: string;
 }
 
 const FONT_BODY = "'Geist', 'Space Grotesk', ui-sans-serif, system-ui, sans-serif";
 const FONT_DISPLAY = "'Archivo Black', 'Space Grotesk', system-ui, sans-serif";
 const FONT_MONO = "'JetBrains Mono', ui-monospace, monospace";
 
-const display = "uppercase tracking-[-0.028em] leading-[0.92] text-black";
-const eyebrow = "uppercase tracking-[0.22em] text-[11px] font-semibold text-neutral-500";
-const mono = "uppercase tracking-[0.18em]";
-
-const sectionBorder = "border-b border-black/10";
-const colBorder = "border-black/10";
-const containerX = "px-5 sm:px-9";
-const containerWidth = "max-w-[1280px] mx-auto";
-
 export const LandingPageContent = ({
   ctaLink = "/app",
+  ctaLabel = "Get started",
   signInLink = "/app",
   showSignIn = true,
+  headline = "Every order ships with a live receipt.",
+  sub = "Traditional e-commerce cuts ties when the box hits the porch. Parallel keeps the loop alive. Built on ink.",
+  footnote,
 }: LandingPageContentProps) => {
-  const sec03 = [
-    {
-      num: "01",
-      title: "Tap to unlock.",
-      desc:
-        "Phone meets sticker. A native browser opens. No app. No download. No login. Under a second to portal.",
-    },
-    {
-      num: "02",
-      title: "Branded portal.",
-      desc:
-        "The page renders in your typography, colors, and voice. Care guides. Product story. Related items from your catalog.",
-    },
-    {
-      num: "03",
-      title: "Proof of arrival.",
-      desc:
-        "Tap captures GPS, time, and device. Chain of custody from the warehouse photo to the customer's hand.",
-    },
-    {
-      num: "04",
-      title: "Returns at the source.",
-      desc:
-        "One QR for any carrier, or the in-store passport at your counter. Refund at scan.",
-    },
-  ];
-
-  const sec04 = [
-    {
-      num: "01",
-      title: "The receipt is alive.",
-      desc:
-        "NFC sticker on the box. Tap to open. The receipt renders on the customer's phone, branded to your store. No app. No download.",
-    },
-    {
-      num: "02",
-      title: "Returns run from the receipt.",
-      desc:
-        "In-store passport at your counter, live today. Universal QR for FedEx, UPS, USPS rolling out with the next ink. update. The customer never sees a PDF.",
-    },
-    {
-      num: "03",
-      title: "The brand owns the surface.",
-      desc:
-        "Your typography, colors, and voice in the post-purchase moment. The merchant dashboard tracks enrollment, taps, and engagement.",
-    },
-  ];
-
-  const sec05 = [
-    {
-      status: "Available now",
-      title: "Photo.",
-      desc:
-        "Photograph each item. Apply the sticker. Ship. Maximum documentation for high-value orders.",
-    },
-    {
-      status: "Coming soon",
-      title: "High speed.",
-      desc:
-        "Scan the order. Scan the sticker. Ship. Two beeps. For volume operations where speed matters.",
-    },
-  ];
-
-  const pricing = [
-    { val: "$0.99", label: "per enrollment" },
-    { val: "$2.99", label: "per verified tap" },
-    { val: "$0.80", label: "per sticker" },
-  ];
-
-  const verticals = [
-    { title: "Luxury · Beauty · Jewelry", desc: "High-value items that deserve documentation before they ship." },
-    { title: "Electronics · Collectibles", desc: "Categories where disputes are costly and proof changes outcomes." },
-    { title: "High-AOV DTC", desc: "Anything worth documenting before it ships." },
-  ];
-
-  const sec08 = [
-    {
-      num: "01",
-      title: "Refund at scan.",
-      desc:
-        "Tappers get the express tier. The refund clears at the moment of return scan, not after a multi-day inspection cycle.",
-    },
-    {
-      num: "02",
-      title: "In-store passport.",
-      desc:
-        "Customer brings the item to your store. Shows the passport on their phone. Counter scans, refund clears. No login. No receipt search. Live today.",
-    },
-    {
-      num: "03",
-      title: "Carrier-agnostic QR.",
-      desc:
-        "GPS detects the carrier. A universal QR generates on the phone. Walk into any FedEx, UPS, or USPS. The associate scans it. No printer, no portal. Rolling out with the next ink. update.",
-    },
-    {
-      num: "04",
-      title: "Return Passport at retail.",
-      badge: "Coming soon",
-      desc:
-        "Walk into a retail partner instead of your own store. GPS detects the location. A Return Passport generates on the customer's phone. No ID, no receipt search, instant verification at the counter.",
-    },
-  ];
-
   return (
     <div
-      className="min-h-screen bg-white text-black antialiased"
+      className="min-h-screen bg-white text-black antialiased flex flex-col"
       style={{ fontFamily: FONT_BODY }}
     >
-      {/* ───── Header ───── */}
-      <header className={`${sectionBorder} bg-white`}>
-        <div className={`${containerWidth} ${containerX} flex items-center justify-between py-5`}>
+      {/* Header */}
+      <header className="border-b border-black/10 bg-white">
+        <div className="max-w-[1280px] mx-auto px-5 sm:px-9 flex items-center justify-between py-5">
           <Link
             to="/"
             className="text-[13px] font-semibold uppercase tracking-[0.18em] hover:opacity-70 transition-opacity"
@@ -149,7 +46,7 @@ export const LandingPageContent = ({
           {showSignIn && (
             <Link
               to={signInLink}
-              className={`${eyebrow} hover:text-black transition-colors`}
+              className="text-[11px] font-semibold uppercase tracking-[0.22em] text-neutral-500 hover:text-black transition-colors"
             >
               Sign in
             </Link>
@@ -157,330 +54,47 @@ export const LandingPageContent = ({
         </div>
       </header>
 
-      {/* ───── Masthead — No 01 ───── */}
-      <section className={`${sectionBorder} ${containerX} pt-12 sm:pt-20 pb-12 sm:pb-20`}>
-        <div className={containerWidth}>
-          <div className={`${eyebrow} pb-4 sm:pb-6`}>No 01 · Live receipt</div>
+      {/* Center stage — the door */}
+      <main className="flex-1 flex items-center justify-center px-5 sm:px-9 py-16">
+        <div className="w-full max-w-[820px] text-center">
           <h1
-            className={`m-0 ${display} text-[40px] sm:text-[clamp(56px,7.5vw,108px)]`}
+            className="m-0 uppercase tracking-[-0.028em] leading-[0.92] text-black text-[44px] sm:text-[clamp(56px,7vw,104px)]"
             style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
           >
-            Every order ships with a live receipt.
+            {headline}
           </h1>
-          <p className="max-w-[58ch] pt-8 text-[14px] sm:text-[15px] leading-[1.6] text-neutral-700">
-            Traditional e-commerce cuts ties when the box hits the porch. Parallel keeps the loop
-            alive. Every order becomes a live checkout counter and a return drop-off box,
-            unlocked by one tap. Built on ink.
+          <p className="pt-7 text-[14px] sm:text-[15px] leading-[1.6] text-neutral-700 max-w-[52ch] mx-auto">
+            {sub}
           </p>
           <div className="pt-10">
             <Link
               to={ctaLink}
-              className={`inline-flex items-center gap-2 bg-black text-white px-5 py-3 text-[11px] font-semibold ${mono} hover:bg-neutral-800 transition-colors`}
+              className="inline-flex items-center gap-3 bg-black text-white px-7 py-4 text-[12px] font-semibold uppercase tracking-[0.22em] hover:bg-neutral-800 transition-colors"
               style={{ fontFamily: FONT_BODY }}
             >
-              Get started
+              {ctaLabel}
               <span aria-hidden style={{ fontFamily: FONT_MONO }}>↗</span>
             </Link>
           </div>
-        </div>
-      </section>
-
-      {/* ───── No 02 — The continuous loop ───── */}
-      <section className={`${sectionBorder} ${containerX} py-16 sm:py-24`}>
-        <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-[1fr_2fr] gap-x-10 gap-y-8`}>
-          <div>
-            <div className={`${eyebrow} pb-4`}>No 02 · The continuous loop</div>
-            <h2
-              className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)]`}
-              style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-            >
-              Most e-commerce cuts ties when the box hits the porch.
-            </h2>
-          </div>
-          <div className="max-w-[60ch]">
-            <p className="text-[14px] sm:text-[15px] leading-[1.7] text-neutral-700">
-              The receipt becomes a forwarded email. The brand becomes a tracking number. The
-              return becomes a printed label and a counter no one wants to visit. Parallel keeps
-              the loop alive. Every product gets a live twin that taps open into a branded portal.
-              The warehouse, carrier, and Shopify all stay. You install one app. Live in days.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      {/* ───── No 03 — The tap journey ───── */}
-      <section className={sectionBorder}>
-        <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-10`}>
-          <div className={`${eyebrow} pb-4`}>No 03 · The tap journey</div>
-          <h2
-            className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)] max-w-[18ch]`}
-            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-          >
-            One tap. Four moments.
-          </h2>
-        </div>
-        <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-2 border-t ${colBorder}`}>
-          {sec03.map((step, i) => {
-            const isRight = i % 2 === 1;
-            const isLastRow = i >= 2;
-            return (
-              <div
-                key={step.num}
-                className={`${containerX} py-12 sm:py-16 ${
-                  !isRight ? `sm:border-r ${colBorder}` : ""
-                } ${!isLastRow ? `border-b ${colBorder}` : ""}`}
-              >
-                <div
-                  className={`${mono} text-[12px] text-neutral-500 pb-4`}
-                  style={{ fontFamily: FONT_MONO }}
-                >
-                  {step.num}
-                </div>
-                <h3
-                  className={`m-0 ${display} text-[22px] sm:text-[26px] pb-5 max-w-[22ch]`}
-                  style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-                >
-                  {step.title}
-                </h3>
-                <p className="text-[14px] leading-[1.65] text-neutral-700 max-w-[44ch]">
-                  {step.desc}
-                </p>
-              </div>
-            );
-          })}
-        </div>
-      </section>
-
-      {/* ───── No 04 — What Parallel does ───── */}
-      <section className={sectionBorder}>
-        <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-10`}>
-          <div className={`${eyebrow} pb-4`}>No 04 · What ships with Parallel</div>
-          <h2
-            className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)] max-w-[22ch]`}
-            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-          >
-            Live receipt. Carrier-agnostic returns. Branded post-purchase.
-          </h2>
-        </div>
-        <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-3 border-t ${colBorder}`}>
-          {sec04.map((step, i) => (
+          {footnote && (
             <div
-              key={step.num}
-              className={`${containerX} py-12 sm:py-16 ${
-                i < sec04.length - 1 ? `sm:border-r ${colBorder} border-b sm:border-b-0` : ""
-              }`}
+              className="pt-12 text-[10px] uppercase tracking-[0.22em] text-neutral-400 max-w-[54ch] mx-auto"
+              style={{ fontFamily: FONT_MONO }}
             >
-              <div
-                className={`${mono} text-[12px] text-neutral-500 pb-4`}
-                style={{ fontFamily: FONT_MONO }}
-              >
-                {step.num}
-              </div>
-              <h3
-                className={`m-0 ${display} text-[20px] sm:text-[24px] pb-4`}
-                style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-              >
-                {step.title}
-              </h3>
-              <p className="text-[14px] leading-[1.65] text-neutral-700">{step.desc}</p>
+              {footnote}
             </div>
-          ))}
+          )}
         </div>
-      </section>
+      </main>
 
-      {/* ───── No 05 — Enrollment ───── */}
-      <section className={sectionBorder}>
-        <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-10`}>
-          <div className={`${eyebrow} pb-4`}>No 05 · How you enroll</div>
-          <h2
-            className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)]`}
-            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-          >
-            Two methods. Both simple.
-          </h2>
-        </div>
-        <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-2 border-t ${colBorder}`}>
-          {sec05.map((m, i) => (
-            <div
-              key={m.title}
-              className={`${containerX} py-12 sm:py-16 ${
-                i === 0 ? `sm:border-r ${colBorder} border-b sm:border-b-0` : ""
-              }`}
-            >
-              <div
-                className={`${mono} text-[11px] text-neutral-500 pb-4`}
-                style={{ fontFamily: FONT_MONO }}
-              >
-                {m.status}
-              </div>
-              <h3
-                className={`m-0 ${display} text-[24px] sm:text-[30px] pb-5`}
-                style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-              >
-                {m.title}
-              </h3>
-              <p className="text-[14px] leading-[1.65] text-neutral-700 max-w-[42ch]">{m.desc}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ───── No 06 — Pricing ───── */}
-      <section className={`${sectionBorder} bg-[#fafafa]`}>
-        <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-16 sm:pb-24`}>
-          <div className={`${eyebrow} pb-4`}>No 06 · Pricing</div>
-          <h2
-            className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)] pb-10`}
-            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-          >
-            No monthly fee. No tiers. Pay per package.
-          </h2>
-          <div className={`grid grid-cols-1 sm:grid-cols-3 pt-8 border-t ${colBorder}`}>
-            {pricing.map((p, i) => (
-              <div
-                key={p.val}
-                className={`pt-8 sm:pt-10 pb-2 ${
-                  i < pricing.length - 1 ? `sm:border-r sm:pr-8 ${colBorder}` : ""
-                } ${i > 0 ? "sm:pl-8" : ""}`}
-              >
-                <div
-                  className={`text-[48px] sm:text-[64px] tabular-nums ${display}`}
-                  style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-                >
-                  {p.val}
-                </div>
-                <div
-                  className={`${mono} text-[11px] text-neutral-500 pt-2`}
-                  style={{ fontFamily: FONT_MONO }}
-                >
-                  {p.label}
-                </div>
-              </div>
-            ))}
-          </div>
-          <div className={`grid grid-cols-1 sm:grid-cols-3 gap-x-8 gap-y-6 pt-16`}>
-            {verticals.map((v) => (
-              <div key={v.title}>
-                <div
-                  className="text-[13px] font-semibold text-black pb-2"
-                  style={{ fontFamily: FONT_BODY }}
-                >
-                  {v.title}
-                </div>
-                <p className="text-[13px] leading-[1.65] text-neutral-600 max-w-[34ch]">{v.desc}</p>
-              </div>
-            ))}
-          </div>
-          <div className="pt-12">
-            <Link
-              to={ctaLink}
-              className={`inline-flex items-center gap-2 bg-black text-white px-5 py-3 text-[11px] font-semibold ${mono} hover:bg-neutral-800 transition-colors`}
-              style={{ fontFamily: FONT_BODY }}
-            >
-              Get started
-              <span aria-hidden style={{ fontFamily: FONT_MONO }}>↗</span>
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* ───── No 07 — The hero refrain ───── */}
-      <section className={`${sectionBorder} ${containerX} py-28 sm:py-44 text-center`}>
-        <div className={containerWidth}>
-          <div className={`${eyebrow} pb-6`}>No 07</div>
-          <h2
-            className={`m-0 ${display} text-[44px] sm:text-[clamp(72px,10vw,148px)]`}
-            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-          >
-            Every receipt, alive.
-          </h2>
-          <p
-            className={`pt-8 text-[12px] sm:text-[13px] ${mono} text-neutral-500`}
-            style={{ fontFamily: FONT_MONO }}
-          >
-            Parallel · Built on ink.
-          </p>
-        </div>
-      </section>
-
-      {/* ───── No 08 — From opening to refund ───── */}
-      <section className={sectionBorder}>
-        <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-10`}>
-          <div className={`${eyebrow} pb-4`}>No 08 · Returns from the receipt</div>
-          <h2
-            className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)] max-w-[20ch]`}
-            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-          >
-            Four ways the customer returns.
-          </h2>
-        </div>
-        <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-2 border-t ${colBorder}`}>
-          {sec08.map((card, i) => {
-            const isRight = i % 2 === 1;
-            const isLastRow = i >= 2;
-            return (
-              <div
-                key={card.num}
-                className={`${containerX} py-12 sm:py-16 ${
-                  !isRight ? `sm:border-r ${colBorder}` : ""
-                } ${!isLastRow ? `border-b ${colBorder}` : ""}`}
-              >
-                <div
-                  className={`${mono} text-[12px] text-neutral-500 pb-4 flex items-center gap-3`}
-                  style={{ fontFamily: FONT_MONO }}
-                >
-                  <span>{card.num}</span>
-                  {card.badge && (
-                    <span className="border border-black/20 px-2 py-0.5 text-[10px] tracking-[0.22em]">
-                      {card.badge}
-                    </span>
-                  )}
-                </div>
-                <h3
-                  className={`m-0 ${display} text-[22px] sm:text-[28px] pb-5 max-w-[22ch]`}
-                  style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-                >
-                  {card.title}
-                </h3>
-                <p className="text-[14px] leading-[1.65] text-neutral-700 max-w-[44ch]">
-                  {card.desc}
-                </p>
-              </div>
-            );
-          })}
-        </div>
-        <div
-          className={`${containerWidth} ${containerX} py-10 text-[12px] leading-[1.65] text-neutral-500 max-w-[64ch] text-center mx-auto`}
-        >
-          Customers who never tap go through your standard return process. Single-carrier label,
-          standard return window. The tap is the unlock.
-        </div>
-      </section>
-
-      {/* ───── Footer ───── */}
-      <footer className="bg-white">
-        <div
-          className={`${containerWidth} ${containerX} py-10 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4`}
-        >
+      {/* Footer */}
+      <footer className="bg-white border-t border-black/10">
+        <div className="max-w-[1280px] mx-auto px-5 sm:px-9 py-6 flex items-center justify-between">
           <div
-            className={`${mono} text-[11px] text-neutral-500`}
+            className="text-[10px] uppercase tracking-[0.22em] text-neutral-400"
             style={{ fontFamily: FONT_MONO }}
           >
             © 2026 Parallel · Built on ink.
-          </div>
-          <div
-            className={`flex items-center gap-6 text-[11px] ${mono} text-neutral-500`}
-            style={{ fontFamily: FONT_MONO }}
-          >
-            <Link to="/app/help" className="hover:text-black transition-colors">
-              Support
-            </Link>
-            <a href="#" className="hover:text-black transition-colors">
-              Privacy
-            </a>
-            <a href="#" className="hover:text-black transition-colors">
-              Terms
-            </a>
           </div>
         </div>
       </footer>

--- a/app/components/LandingPageContent.tsx
+++ b/app/components/LandingPageContent.tsx
@@ -1,8 +1,9 @@
-import { useRef } from "react";
+// Parallel landing — editorial system mirrored from parallel.in.ink.
+// Brutalist paper + ink. Archivo Black display for the masthead spine,
+// Geist sans for chrome and body, JetBrains Mono for micro-labels.
+// Hairline dividers, no rounded cards, no scroll-zoom drama.
+
 import { Link } from "react-router";
-import { Button } from "./ui/button";
-import { ArrowRight, Shield, Film } from "lucide-react";
-import { motion, useScroll, useTransform } from "framer-motion";
 
 interface LandingPageContentProps {
   ctaLink?: string;
@@ -10,424 +11,458 @@ interface LandingPageContentProps {
   showSignIn?: boolean;
 }
 
+const FONT_BODY = "'Geist', 'Space Grotesk', ui-sans-serif, system-ui, sans-serif";
+const FONT_DISPLAY = "'Archivo Black', 'Space Grotesk', system-ui, sans-serif";
+const FONT_MONO = "'JetBrains Mono', ui-monospace, monospace";
+
+const display = "uppercase tracking-[-0.028em] leading-[0.92] text-black";
+const eyebrow = "uppercase tracking-[0.22em] text-[11px] font-semibold text-neutral-500";
+const mono = "uppercase tracking-[0.18em]";
+
+const sectionBorder = "border-b border-black/10";
+const colBorder = "border-black/10";
+const containerX = "px-5 sm:px-9";
+const containerWidth = "max-w-[1280px] mx-auto";
+
 export const LandingPageContent = ({
   ctaLink = "/app",
   signInLink = "/app",
   showSignIn = true,
 }: LandingPageContentProps) => {
-  const heroRef = useRef<HTMLElement>(null);
-  const problemRef = useRef<HTMLElement>(null);
-  const valueRef = useRef<HTMLElement>(null);
-  const howItWorksRef = useRef<HTMLElement>(null);
-  const statsRef = useRef<HTMLElement>(null);
-  const quoteRef = useRef<HTMLElement>(null);
-  const dropCardsRef = useRef<HTMLElement>(null);
+  const sec04 = [
+    {
+      num: "01",
+      title: "A receipt that's alive.",
+      desc:
+        "NFC sticker on the box. Customer taps. The receipt opens on their phone, branded to your store. No app. No login. No download.",
+    },
+    {
+      num: "02",
+      title: "Proof before anything ships.",
+      desc:
+        "Pre-shipment photos tie what you packed to the sticker's unique ID. A tamper-evident, timestamped record. Created at the warehouse, not reconstructed after a dispute.",
+    },
+    {
+      num: "03",
+      title: "One merchant view.",
+      desc:
+        "Enrollment status. Tap rates. Time to engagement. Sticker inventory with auto-refill. One dashboard.",
+    },
+  ];
 
-  // Hero: dramatic zoom out and fade as you scroll
-  const { scrollYProgress: heroProgress } = useScroll({
-    target: heroRef,
-    offset: ["start start", "end start"],
-  });
-  const heroY = useTransform(heroProgress, [0, 1], ["0%", "-40%"]);
-  const heroOpacity = useTransform(heroProgress, [0, 1], [1, 1]);
+  const sec05 = [
+    {
+      status: "Available now",
+      title: "Photo.",
+      desc:
+        "Photograph each item. Apply the sticker. Ship. Maximum documentation for high-value orders.",
+    },
+    {
+      status: "Coming soon",
+      title: "High speed.",
+      desc:
+        "Scan the order. Scan the sticker. Ship. Two beeps. For volume operations where speed matters.",
+    },
+  ];
 
-  // Problem section - zoom in from far away
-  const { scrollYProgress: problemProgress } = useScroll({
-    target: problemRef,
-    offset: ["start end", "center center"],
-  });
-  const problemY = useTransform(problemProgress, [0, 1], [120, 0]);
-  const problemScale = useTransform(problemProgress, [0, 1], [0.8, 1]);
-  const problemOpacity = useTransform(problemProgress, [0, 0.3, 1], [0, 0.5, 1]);
+  const pricing = [
+    { val: "$0.99", label: "per enrollment" },
+    { val: "$2.99", label: "per verified tap" },
+    { val: "$0.80", label: "per sticker" },
+  ];
 
-  // Value cards - dramatic stagger with zoom
-  const { scrollYProgress: valueProgress } = useScroll({
-    target: valueRef,
-    offset: ["start end", "center center"],
-  });
-  const cardY = useTransform(valueProgress, [0, 1], [150, 0]);
-  const cardScale = useTransform(valueProgress, [0, 1], [0.85, 1]);
-  const cardOpacity = useTransform(valueProgress, [0, 0.2, 1], [0, 0.3, 1]);
+  const verticals = [
+    { title: "Luxury · Beauty · Jewelry", desc: "High-value items that deserve documentation before they ship." },
+    { title: "Electronics · Collectibles", desc: "Categories where disputes are costly and proof changes outcomes." },
+    { title: "High-AOV DTC", desc: "Anything worth documenting before it ships." },
+  ];
 
-  // How it works - parallax offset
-  const { scrollYProgress: howProgress } = useScroll({
-    target: howItWorksRef,
-    offset: ["start end", "end start"],
-  });
-  const howY = useTransform(howProgress, [0, 1], [80, -80]);
-
-  // Stats - scale up dramatically
-  const { scrollYProgress: statsProgress } = useScroll({
-    target: statsRef,
-    offset: ["start end", "center center"],
-  });
-  const statsScale = useTransform(statsProgress, [0, 1], [0.7, 1]);
-  const statsOpacity = useTransform(statsProgress, [0, 0.3, 1], [0, 0.5, 1]);
-
-  // ink. Drop hero — same pattern as top hero
-  const { scrollYProgress: quoteProgress } = useScroll({
-    target: quoteRef,
-    offset: ["start start", "end start"],
-  });
-  const quoteY = useTransform(quoteProgress, [0, 1], ["0%", "-40%"]);
-  const quoteOpacity = useTransform(quoteProgress, [0, 1], [1, 1]);
-
-  // Drop cards - aggressive stagger with zoom
-  const { scrollYProgress: dropCardsProgress } = useScroll({
-    target: dropCardsRef,
-    offset: ["start end", "center center"],
-  });
-  const dropCardY = useTransform(dropCardsProgress, [0, 1], [200, 0]);
-  const dropCardScale = useTransform(dropCardsProgress, [0, 1], [0.7, 1]);
-  const dropCardOpacity = useTransform(dropCardsProgress, [0, 0.3, 1], [0, 0.2, 1]);
+  const sec08 = [
+    {
+      num: "01",
+      title: "One tap to open the receipt.",
+      desc:
+        "Phone touches sticker. The receipt opens on the customer's phone, full screen, your brand. No app. No login. One tap and they close the phone and go about their day.",
+    },
+    {
+      num: "02",
+      title: "Refund at scan.",
+      desc:
+        "Tappers get the express tier. The refund clears at the moment of return scan, not after a multi-day inspection cycle.",
+    },
+    {
+      num: "03",
+      title: "Returns from the receipt.",
+      desc:
+        "Two ways. At your store, show the passport at the counter and refund at scan. Live today. At any carrier, GPS detects the drop-off and generates a scannable QR. Rolling out with the next ink. update.",
+    },
+    {
+      num: "04",
+      title: "Return Passport at retail.",
+      badge: "Coming soon",
+      desc:
+        "Walk into a retail partner instead of your own store. GPS detects the location. A Return Passport generates on the customer's phone. No ID, no receipt search, instant verification at the counter.",
+    },
+  ];
 
   return (
-    <div className="landing-typography min-h-screen bg-warm-white overflow-x-hidden">
-      {/* Header */}
-      <header className="bg-foreground text-background py-6 px-6 relative z-20">
-        <div className="max-w-7xl mx-auto flex items-center justify-between">
-          <Link to="/" className="text-2xl font-serif font-medium tracking-tight">
+    <div
+      className="min-h-screen bg-white text-black antialiased"
+      style={{ fontFamily: FONT_BODY }}
+    >
+      {/* ───── Header ───── */}
+      <header className={`${sectionBorder} bg-white`}>
+        <div className={`${containerWidth} ${containerX} flex items-center justify-between py-5`}>
+          <Link
+            to="/"
+            className="text-[13px] font-semibold uppercase tracking-[0.18em] hover:opacity-70 transition-opacity"
+          >
             Parallel
           </Link>
           {showSignIn && (
-            <Link to={signInLink}>
-              <Button variant="ghost" className="text-background hover:bg-white/10 text-xs uppercase tracking-widest font-medium">
-                Sign In
-              </Button>
+            <Link
+              to={signInLink}
+              className={`${eyebrow} hover:text-black transition-colors`}
+            >
+              Sign in
             </Link>
           )}
         </div>
       </header>
 
-      {/* Hero Section - Sticky, content scrolls over it */}
-      <section ref={heroRef} className="relative h-[100vh]">
-        <motion.div
-          style={{ y: heroY, opacity: heroOpacity }}
-          className="fixed top-0 left-0 right-0 h-screen bg-foreground text-background flex items-center justify-center px-6 will-change-transform origin-center"
-        >
-          <div className="relative max-w-4xl mx-auto text-center">
-            <motion.h1
-              initial={{ opacity: 0, y: 30 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, ease: "easeOut" }}
-              className="text-sm md:text-base font-serif font-light leading-snug tracking-tight mb-3"
-            >
-              Every order ships with a live receipt.
-            </motion.h1>
-            <motion.p
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, delay: 0.2, ease: "easeOut" }}
-              className="text-xs md:text-sm text-white/70 max-w-md mx-auto leading-relaxed mb-10"
-            >
-              The live receipt for every Shopify order. Built on ink.
-            </motion.p>
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, delay: 0.4, ease: "easeOut" }}
-            >
-              <Link to={ctaLink}>
-                <Button className="bg-white text-black hover:bg-gray-100 px-4 py-2 h-auto text-xs uppercase tracking-wider font-medium rounded-none hover:-translate-y-0.5 hover:shadow-lg transition-all">
-                  Get Started
-                  <ArrowRight className="ml-1.5 h-3 w-3" />
-                </Button>
-              </Link>
-            </motion.div>
-          </div>
-        </motion.div>
-      </section>
-
-      {/* The Problem */}
-      <section ref={problemRef} className="bg-warm-white py-24 px-6 relative z-10">
-        <motion.div
-          style={{ y: problemY, scale: problemScale, opacity: problemOpacity }}
-          className="max-w-4xl mx-auto text-center will-change-transform"
-        >
-          <p className="text-xs uppercase tracking-wider text-gray-400 mb-6 font-medium">The Receipt You Already Send</p>
-          <h2 className="text-4xl md:text-5xl font-serif font-light tracking-tight mb-8 leading-tight">
-            Parallel upgrades the receipt. Nothing else has to change.
-          </h2>
-          <p className="text-lg text-gray-600 leading-relaxed max-w-2xl mx-auto">
-            The warehouse stays. The carrier stays. Shopify stays. You install one app and the receipt becomes a branded page that taps open, runs returns, and proves delivery. Live in days.
+      {/* ───── Masthead — No 01 ───── */}
+      <section className={`${sectionBorder} ${containerX} pt-12 sm:pt-20 pb-12 sm:pb-20`}>
+        <div className={containerWidth}>
+          <div className={`${eyebrow} pb-4 sm:pb-6`}>No 01 · Live receipt</div>
+          <h1
+            className={`m-0 ${display} text-[40px] sm:text-[clamp(56px,7.5vw,108px)]`}
+            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+          >
+            Every order ships with a live receipt.
+          </h1>
+          <p className="max-w-[54ch] pt-8 text-[14px] sm:text-[15px] leading-[1.6] text-neutral-700">
+            The live receipt for every Shopify order. Branded post-purchase, proof of delivery,
+            Amazon-style returns. Built on ink.
           </p>
-        </motion.div>
-      </section>
-
-      {/* Two-Sided Value */}
-      <section ref={valueRef} className="bg-card py-20 px-6 relative z-10">
-        <div className="max-w-5xl mx-auto">
-          <motion.div
-            style={{ scale: cardScale, opacity: cardOpacity }}
-            className="text-center mb-16 will-change-transform"
-          >
-            <p className="text-xs uppercase tracking-wider text-gray-400 mb-6 font-medium">Two Sides of the Same Receipt</p>
-            <h2 className="text-4xl font-serif font-light tracking-tight leading-tight">
-              Your customer opens it. You see the truth.
-            </h2>
-          </motion.div>
-
-          <div className="grid md:grid-cols-2 gap-16">
-            {/* Advertising Side */}
-            <motion.div
-              style={{ y: cardY, scale: cardScale, opacity: cardOpacity }}
-              className="group will-change-transform"
+          <div className="pt-10">
+            <Link
+              to={ctaLink}
+              className={`inline-flex items-center gap-2 bg-black text-white px-5 py-3 text-[11px] font-semibold ${mono} hover:bg-neutral-800 transition-colors`}
+              style={{ fontFamily: FONT_BODY }}
             >
-              <div className="w-14 h-14 bg-foreground flex items-center justify-center mb-8">
-                <Film className="h-7 w-7 text-background" />
-              </div>
-              <h3 className="text-3xl font-serif font-medium mb-5">A receipt that opens.</h3>
-              <p className="text-gray-600 leading-relaxed mb-8 text-lg">
-                Phone touches sticker. Your logo, your colors, your message. Full screen. No app. No login. One tap and they close their phone and go about their day.
-              </p>
-            </motion.div>
-
-            {/* Fraud Protection Side */}
-            <motion.div
-              style={{ y: cardY, scale: cardScale, opacity: cardOpacity }}
-              className="group will-change-transform"
-            >
-              <div className="w-14 h-14 bg-foreground flex items-center justify-center mb-8">
-                <Shield className="h-7 w-7 text-background" />
-              </div>
-              <h3 className="text-3xl font-serif font-medium mb-5">Proof on every delivery.</h3>
-              <p className="text-gray-600 leading-relaxed mb-8 text-lg">
-                On screen: their order is confirmed. In the background, the tap records GPS, time, and device. Your customer sees a premium experience. You see a verified record.
-              </p>
-            </motion.div>
-          </div>
-        </div>
-      </section>
-
-      {/* How It Works */}
-      <section ref={howItWorksRef} className="bg-warm-white py-20 px-6 relative z-10 overflow-hidden">
-        <motion.div
-          style={{ y: howY }}
-          className="max-w-4xl mx-auto text-center will-change-transform"
-        >
-          <p className="text-xs uppercase tracking-wider text-gray-400 mb-6 font-medium">What Parallel Does</p>
-          <h2 className="text-4xl font-serif font-light tracking-tight mb-16 leading-tight">
-            Branded receipt. Proof of delivery. Amazon-style returns. One install.
-          </h2>
-
-          <div className="grid md:grid-cols-3 gap-12 text-left">
-            {[
-              { num: "01", title: "A receipt that's alive.", desc: "NFC sticker on the box. Customer taps. The receipt opens on their phone, branded to your store. No app. No login. No download." },
-              { num: "02", title: "Proof before anything ships.", desc: "Pre-shipment photos tie what you packed to the sticker's unique ID. A tamper-evident, timestamped record. Created at the warehouse, not reconstructed after a dispute." },
-              { num: "03", title: "One merchant view.", desc: "Enrollment status. Tap rates. Time to engagement. Sticker inventory with auto-refill. One dashboard." },
-            ].map((step, i) => (
-              <motion.div
-                key={step.num}
-                initial={{ opacity: 0, y: 60, scale: 0.9 }}
-                whileInView={{ opacity: 1, y: 0, scale: 1 }}
-                viewport={{ once: true, margin: "-100px" }}
-                transition={{ duration: 0.7, delay: i * 0.2 }}
-                className="will-change-transform"
-              >
-                <div className="text-6xl font-serif font-light text-gray-200 mb-4">{step.num}</div>
-                <h3 className="text-xl font-serif font-medium mb-3">{step.title}</h3>
-                <p className="text-gray-600 leading-relaxed">{step.desc}</p>
-              </motion.div>
-            ))}
-          </div>
-        </motion.div>
-      </section>
-
-      {/* The Stakes / Stats */}
-      <section ref={statsRef} className="bg-card py-20 px-6 relative z-10 overflow-hidden">
-        <motion.div
-          style={{ scale: statsScale, opacity: statsOpacity }}
-          className="max-w-4xl mx-auto will-change-transform"
-        >
-          <div className="text-center mb-12">
-            <p className="text-xs uppercase tracking-wider text-gray-400 mb-6 font-medium">How You Enroll</p>
-            <h2 className="text-4xl font-serif font-light tracking-tight">
-              Two enrollment methods. Both simple.
-            </h2>
-          </div>
-
-          <div className="grid md:grid-cols-2 gap-8 text-center max-w-2xl mx-auto">
-            {[
-              { value: "Photo", label: "Photograph each item. Apply the sticker. Ship. Maximum documentation for high-value orders. Available now." },
-              { value: "High Speed", label: "Scan the order. Scan the sticker. Ship. Two beeps. For volume operations where speed matters. Coming soon." },
-            ].map((stat, i) => (
-              <motion.div
-                key={stat.value}
-                initial={{ opacity: 0, scale: 0.5, y: 40 }}
-                whileInView={{ opacity: 1, scale: 1, y: 0 }}
-                viewport={{ once: true, margin: "-50px" }}
-                transition={{ duration: 0.6, delay: i * 0.15 }}
-                className="p-6 will-change-transform"
-              >
-                <div className="text-5xl md:text-6xl font-serif font-light mb-2">
-                  {stat.value}
-                </div>
-                <p className="text-gray-500 text-sm">{stat.label}</p>
-              </motion.div>
-            ))}
-          </div>
-        </motion.div>
-      </section>
-
-      {/* Enterprise / Pricing */}
-      <section className="bg-secondary text-foreground py-24 px-6 relative z-10 overflow-hidden">
-        <div className="max-w-5xl mx-auto relative">
-          <motion.div
-            initial={{ opacity: 0, y: 40 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: "-100px" }}
-            transition={{ duration: 0.7 }}
-            className="text-center mb-16"
-          >
-            <p className="text-xs uppercase tracking-wider text-foreground/40 mb-6 font-medium">Pricing</p>
-            <h2 className="text-4xl md:text-5xl font-serif font-light tracking-tight leading-tight mb-8">
-              No monthly fee. No tiers. Pay per package.
-            </h2>
-            <p className="text-lg text-foreground/60 max-w-3xl mx-auto leading-relaxed">
-              $0.99 per enrollment · $2.99 per verified tap · $0.80 per sticker
-            </p>
-          </motion.div>
-
-          <div className="grid md:grid-cols-3 gap-8 mb-16">
-            {[
-              { title: "Luxury · Beauty · Jewelry", desc: "High-value items that deserve documentation before they ship." },
-              { title: "Electronics · Collectibles", desc: "Categories where disputes are costly and proof changes outcomes." },
-              { title: "High-AOV DTC", desc: "Anything worth documenting before it ships." },
-            ].map((item, i) => (
-              <motion.div
-                key={item.title}
-                initial={{ opacity: 0, y: 50 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, margin: "-50px" }}
-                transition={{ duration: 0.6, delay: i * 0.15 }}
-                className="border border-border/30 p-8"
-              >
-                <h3 className="text-xl font-serif font-medium mb-4 text-foreground">{item.title}</h3>
-                <p className="text-muted-foreground leading-relaxed text-sm">{item.desc}</p>
-              </motion.div>
-            ))}
-          </div>
-
-          <motion.div
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.6, delay: 0.3 }}
-            className="text-center"
-          >
-            <Link to={ctaLink}>
-              <Button className="bg-foreground text-background hover:bg-foreground/90 px-4 py-2 h-auto text-xs uppercase tracking-wider font-medium rounded-none hover:-translate-y-0.5 hover:shadow-lg transition-all">
-                Get Started
-                <ArrowRight className="ml-1.5 h-3 w-3" />
-              </Button>
+              Get started
+              <span aria-hidden style={{ fontFamily: FONT_MONO }}>↗</span>
             </Link>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* ink. Drop Hero */}
-      <section ref={quoteRef} className="relative z-10">
-        <div className="sticky top-0 h-screen bg-foreground text-background flex items-center justify-center px-6 overflow-hidden">
-          <div className="relative max-w-4xl mx-auto text-center">
-            <motion.h2
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.8, ease: "easeOut" }}
-              style={{ fontSize: "3.75rem" }}
-              className="font-serif font-light leading-snug tracking-tight mb-3"
-            >
-              Every receipt, alive.
-            </motion.h2>
-            <motion.p
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.8, delay: 0.2, ease: "easeOut" }}
-              className="text-base md:text-lg text-white/70 max-w-lg mx-auto leading-relaxed mb-10"
-            >
-              Parallel, built on ink.
-            </motion.p>
           </div>
         </div>
       </section>
 
-      {/* ink. Drop Cards */}
-      <section ref={dropCardsRef} className="bg-secondary py-24 md:py-32 px-6 relative z-10">
-        <div className="max-w-5xl mx-auto">
-          <div className="grid md:grid-cols-2 gap-8 md:gap-12">
-            {[
-              {
-                title: "One tap to open the receipt.",
-                desc: "Phone touches sticker. The receipt opens on the customer's phone, full screen, your brand. No app. No login. One tap and they close the phone and go about their day.",
-              },
-              {
-                title: "Refund at scan.",
-                desc: "Tappers get the express tier. The refund clears at the moment of return scan, not after a multi-day inspection cycle.",
-              },
-              {
-                title: "Returns from the receipt.",
-                desc: "Two ways. At your store, show the passport at the counter and refund at scan. Live today. At any carrier, GPS detects the drop-off and generates a scannable QR. Rolling out with the next ink. update.",
-              },
-              {
-                title: "Return Passport at retail.",
-                desc: "Walk into a retail partner instead of your own store. GPS detects the location. A Return Passport generates on the customer's phone. No ID, no receipt search, instant verification at the counter.",
-                badge: "Coming Soon",
-              },
-            ].map((card, i) => (
-              <motion.div
-                key={card.title}
-                initial={{ opacity: 0, y: 100, scale: 0.85 }}
-                whileInView={{ opacity: 1, y: 0, scale: 1 }}
-                viewport={{ once: true, margin: "-50px" }}
-                transition={{ duration: 0.8, delay: i * 0.15, ease: "easeOut" }}
-                className="border border-border/30 p-10 will-change-transform hover:-translate-y-1 hover:shadow-xl transition-all duration-300"
+      {/* ───── No 02 — The Receipt You Already Send ───── */}
+      <section className={`${sectionBorder} ${containerX} py-16 sm:py-24`}>
+        <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-[1fr_2fr] gap-x-10 gap-y-8`}>
+          <div>
+            <div className={`${eyebrow} pb-4`}>No 02 · The receipt you already send</div>
+            <h2
+              className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)]`}
+              style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+            >
+              Parallel upgrades the receipt. Nothing else has to change.
+            </h2>
+          </div>
+          <div className="max-w-[60ch]">
+            <p className="text-[14px] sm:text-[15px] leading-[1.7] text-neutral-700">
+              The warehouse stays. The carrier stays. Shopify stays. You install one app and the
+              receipt becomes a branded page that taps open, runs returns, and proves delivery.
+              Live in days.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ───── No 03 — Two sides of the same receipt ───── */}
+      <section className={sectionBorder}>
+        <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-10`}>
+          <div className={`${eyebrow} pb-4`}>No 03 · Two sides of the same receipt</div>
+          <h2
+            className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)] max-w-[20ch]`}
+            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+          >
+            Your customer opens it. You see the truth.
+          </h2>
+        </div>
+        <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-2 border-t ${colBorder}`}>
+          <div className={`${containerX} py-12 sm:py-16 sm:border-r ${colBorder}`}>
+            <div
+              className={`${mono} text-[11px] text-neutral-500 pb-4`}
+              style={{ fontFamily: FONT_MONO }}
+            >
+              Customer side
+            </div>
+            <h3
+              className={`m-0 ${display} text-[22px] sm:text-[28px] pb-5`}
+              style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+            >
+              A receipt that opens.
+            </h3>
+            <p className="text-[14px] leading-[1.65] text-neutral-700 max-w-[44ch]">
+              Phone touches sticker. Your logo, your colors, your message. Full screen. No app. No
+              login. One tap and they close their phone and go about their day.
+            </p>
+          </div>
+          <div className={`${containerX} py-12 sm:py-16 border-t sm:border-t-0 ${colBorder}`}>
+            <div
+              className={`${mono} text-[11px] text-neutral-500 pb-4`}
+              style={{ fontFamily: FONT_MONO }}
+            >
+              Merchant side
+            </div>
+            <h3
+              className={`m-0 ${display} text-[22px] sm:text-[28px] pb-5`}
+              style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+            >
+              Proof on every delivery.
+            </h3>
+            <p className="text-[14px] leading-[1.65] text-neutral-700 max-w-[44ch]">
+              On screen: their order is confirmed. In the background, the tap records GPS, time,
+              and device. Your customer sees a premium experience. You see a verified record.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ───── No 04 — What Parallel does ───── */}
+      <section className={sectionBorder}>
+        <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-10`}>
+          <div className={`${eyebrow} pb-4`}>No 04 · What Parallel does</div>
+          <h2
+            className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)] max-w-[22ch]`}
+            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+          >
+            Branded receipt. Proof of delivery. Amazon-style returns.
+          </h2>
+        </div>
+        <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-3 border-t ${colBorder}`}>
+          {sec04.map((step, i) => (
+            <div
+              key={step.num}
+              className={`${containerX} py-12 sm:py-16 ${
+                i < sec04.length - 1 ? `sm:border-r ${colBorder} border-b sm:border-b-0` : ""
+              }`}
+            >
+              <div
+                className={`${mono} text-[12px] text-neutral-500 pb-4`}
+                style={{ fontFamily: FONT_MONO }}
               >
-                <div className="flex items-center gap-3 mb-5">
-                  <span className="text-xs text-muted-foreground font-medium tabular-nums">0{i + 1}</span>
-                  <h3 className="text-xl md:text-2xl font-serif font-medium">{card.title}</h3>
+                {step.num}
+              </div>
+              <h3
+                className={`m-0 ${display} text-[20px] sm:text-[24px] pb-4`}
+                style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+              >
+                {step.title}
+              </h3>
+              <p className="text-[14px] leading-[1.65] text-neutral-700">{step.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ───── No 05 — Enrollment ───── */}
+      <section className={sectionBorder}>
+        <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-10`}>
+          <div className={`${eyebrow} pb-4`}>No 05 · How you enroll</div>
+          <h2
+            className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)]`}
+            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+          >
+            Two methods. Both simple.
+          </h2>
+        </div>
+        <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-2 border-t ${colBorder}`}>
+          {sec05.map((m, i) => (
+            <div
+              key={m.title}
+              className={`${containerX} py-12 sm:py-16 ${
+                i === 0 ? `sm:border-r ${colBorder} border-b sm:border-b-0` : ""
+              }`}
+            >
+              <div
+                className={`${mono} text-[11px] text-neutral-500 pb-4`}
+                style={{ fontFamily: FONT_MONO }}
+              >
+                {m.status}
+              </div>
+              <h3
+                className={`m-0 ${display} text-[24px] sm:text-[30px] pb-5`}
+                style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+              >
+                {m.title}
+              </h3>
+              <p className="text-[14px] leading-[1.65] text-neutral-700 max-w-[42ch]">{m.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ───── No 06 — Pricing ───── */}
+      <section className={`${sectionBorder} bg-[#fafafa]`}>
+        <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-16 sm:pb-24`}>
+          <div className={`${eyebrow} pb-4`}>No 06 · Pricing</div>
+          <h2
+            className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)] pb-10`}
+            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+          >
+            No monthly fee. No tiers. Pay per package.
+          </h2>
+          <div className={`grid grid-cols-1 sm:grid-cols-3 pt-8 border-t ${colBorder}`}>
+            {pricing.map((p, i) => (
+              <div
+                key={p.val}
+                className={`pt-8 sm:pt-10 pb-2 ${
+                  i < pricing.length - 1 ? `sm:border-r sm:pr-8 ${colBorder}` : ""
+                } ${i > 0 ? "sm:pl-8" : ""}`}
+              >
+                <div
+                  className={`text-[48px] sm:text-[64px] tabular-nums ${display}`}
+                  style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+                >
+                  {p.val}
+                </div>
+                <div
+                  className={`${mono} text-[11px] text-neutral-500 pt-2`}
+                  style={{ fontFamily: FONT_MONO }}
+                >
+                  {p.label}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className={`grid grid-cols-1 sm:grid-cols-3 gap-x-8 gap-y-6 pt-16`}>
+            {verticals.map((v) => (
+              <div key={v.title}>
+                <div
+                  className="text-[13px] font-semibold text-black pb-2"
+                  style={{ fontFamily: FONT_BODY }}
+                >
+                  {v.title}
+                </div>
+                <p className="text-[13px] leading-[1.65] text-neutral-600 max-w-[34ch]">{v.desc}</p>
+              </div>
+            ))}
+          </div>
+          <div className="pt-12">
+            <Link
+              to={ctaLink}
+              className={`inline-flex items-center gap-2 bg-black text-white px-5 py-3 text-[11px] font-semibold ${mono} hover:bg-neutral-800 transition-colors`}
+              style={{ fontFamily: FONT_BODY }}
+            >
+              Get started
+              <span aria-hidden style={{ fontFamily: FONT_MONO }}>↗</span>
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ───── No 07 — The hero refrain ───── */}
+      <section className={`${sectionBorder} ${containerX} py-28 sm:py-44 text-center`}>
+        <div className={containerWidth}>
+          <div className={`${eyebrow} pb-6`}>No 07</div>
+          <h2
+            className={`m-0 ${display} text-[44px] sm:text-[clamp(72px,10vw,148px)]`}
+            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+          >
+            Every receipt, alive.
+          </h2>
+          <p
+            className={`pt-8 text-[12px] sm:text-[13px] ${mono} text-neutral-500`}
+            style={{ fontFamily: FONT_MONO }}
+          >
+            Parallel · Built on ink.
+          </p>
+        </div>
+      </section>
+
+      {/* ───── No 08 — From opening to refund ───── */}
+      <section className={sectionBorder}>
+        <div className={`${containerWidth} ${containerX} pt-16 sm:pt-24 pb-10`}>
+          <div className={`${eyebrow} pb-4`}>No 08 · The receipt does the work</div>
+          <h2
+            className={`m-0 ${display} text-[28px] sm:text-[clamp(36px,4.4vw,56px)] max-w-[20ch]`}
+            style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+          >
+            From opening to refund. One surface.
+          </h2>
+        </div>
+        <div className={`${containerWidth} grid grid-cols-1 sm:grid-cols-2 border-t ${colBorder}`}>
+          {sec08.map((card, i) => {
+            const isRight = i % 2 === 1;
+            const isLastRow = i >= 2;
+            return (
+              <div
+                key={card.num}
+                className={`${containerX} py-12 sm:py-16 ${
+                  !isRight ? `sm:border-r ${colBorder}` : ""
+                } ${!isLastRow ? `border-b ${colBorder}` : ""}`}
+              >
+                <div
+                  className={`${mono} text-[12px] text-neutral-500 pb-4 flex items-center gap-3`}
+                  style={{ fontFamily: FONT_MONO }}
+                >
+                  <span>{card.num}</span>
                   {card.badge && (
-                    <span className="text-[10px] uppercase tracking-wider text-foreground/40 border border-foreground/20 px-2 py-0.5 font-medium">
+                    <span className="border border-black/20 px-2 py-0.5 text-[10px] tracking-[0.22em]">
                       {card.badge}
                     </span>
                   )}
                 </div>
-                <p className="text-muted-foreground leading-relaxed text-sm">{card.desc}</p>
-              </motion.div>
-            ))}
-          </div>
-
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.6, delay: 0.3 }}
-            className="text-sm text-foreground/40 max-w-2xl mx-auto text-center mt-12"
-          >
-            Customers who never tap go through your standard return process. Single-carrier label, standard return window. The tap is the unlock.
-          </motion.p>
+                <h3
+                  className={`m-0 ${display} text-[22px] sm:text-[28px] pb-5 max-w-[22ch]`}
+                  style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+                >
+                  {card.title}
+                </h3>
+                <p className="text-[14px] leading-[1.65] text-neutral-700 max-w-[44ch]">
+                  {card.desc}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+        <div
+          className={`${containerWidth} ${containerX} py-10 text-[12px] leading-[1.65] text-neutral-500 max-w-[64ch] text-center mx-auto`}
+        >
+          Customers who never tap go through your standard return process. Single-carrier label,
+          standard return window. The tap is the unlock.
         </div>
       </section>
 
-      {/* Footer */}
-      <motion.footer
-        initial={{ opacity: 0 }}
-        whileInView={{ opacity: 1 }}
-        viewport={{ once: true }}
-        transition={{ duration: 0.5 }}
-        className="bg-foreground text-white/60 py-10 px-6 relative z-10"
-      >
-        <div className="max-w-7xl mx-auto text-center">
-          <div className="flex items-center justify-center gap-6 text-xs uppercase tracking-wider">
-            <Link to="/app/help" className="hover:text-white transition-colors">Support</Link>
-            <span>·</span>
-            <a href="#" className="hover:text-white transition-colors">Privacy</a>
-            <span>·</span>
-            <a href="#" className="hover:text-white transition-colors">Terms</a>
+      {/* ───── Footer ───── */}
+      <footer className="bg-white">
+        <div
+          className={`${containerWidth} ${containerX} py-10 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4`}
+        >
+          <div
+            className={`${mono} text-[11px] text-neutral-500`}
+            style={{ fontFamily: FONT_MONO }}
+          >
+            © 2026 Parallel · Built on ink.
           </div>
-          <p className="mt-6 text-xs">© 2026 Parallel. Built on ink.</p>
+          <div
+            className={`flex items-center gap-6 text-[11px] ${mono} text-neutral-500`}
+            style={{ fontFamily: FONT_MONO }}
+          >
+            <Link to="/app/help" className="hover:text-black transition-colors">
+              Support
+            </Link>
+            <a href="#" className="hover:text-black transition-colors">
+              Privacy
+            </a>
+            <a href="#" className="hover:text-black transition-colors">
+              Terms
+            </a>
+          </div>
         </div>
-      </motion.footer>
+      </footer>
     </div>
   );
 };

--- a/app/components/LandingPageContent.tsx
+++ b/app/components/LandingPageContent.tsx
@@ -1,4 +1,4 @@
-// Parallel landing — one screen, one door.
+// ink. landing — one screen, one door.
 // Brand top-left, optional sign-in top-right, big Archivo Black
 // headline centered, short Geist deck, single black enter button.
 // Used by both the public landing (_index) and the in-admin landing
@@ -25,8 +25,8 @@ export const LandingPageContent = ({
   ctaLabel = "Get started",
   signInLink = "/app",
   showSignIn = true,
-  headline = "Every order ships with a live receipt.",
-  sub = "Traditional e-commerce cuts ties when the box hits the porch. Parallel keeps the loop alive. Built on ink.",
+  headline = "Every order opens a living page.",
+  sub = "Traditional e-commerce cuts ties when the box hits the porch. ink. keeps the loop alive — a living page for every order, opened on a tap.",
   footnote,
 }: LandingPageContentProps) => {
   return (
@@ -41,7 +41,7 @@ export const LandingPageContent = ({
             to="/"
             className="text-[13px] font-semibold uppercase tracking-[0.18em] hover:opacity-70 transition-opacity"
           >
-            Parallel
+            ink.
           </Link>
           {showSignIn && (
             <Link
@@ -94,7 +94,7 @@ export const LandingPageContent = ({
             className="text-[10px] uppercase tracking-[0.22em] text-neutral-400"
             style={{ fontFamily: FONT_MONO }}
           >
-            © 2026 Parallel · Built on ink.
+            © 2026 ink.
           </div>
         </div>
       </footer>

--- a/app/components/LandingPageContent.tsx
+++ b/app/components/LandingPageContent.tsx
@@ -87,7 +87,7 @@ export const LandingPageContent = ({
       <header className="bg-foreground text-background py-6 px-6 relative z-20">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <Link to="/" className="text-2xl font-serif font-medium tracking-tight">
-            ink.
+            Parallel
           </Link>
           {showSignIn && (
             <Link to={signInLink}>
@@ -112,7 +112,7 @@ export const LandingPageContent = ({
               transition={{ duration: 0.8, ease: "easeOut" }}
               className="text-sm md:text-base font-serif font-light leading-snug tracking-tight mb-3"
             >
-              Smart/ Delivery + Returns
+              Every order ships with a live receipt.
             </motion.h1>
             <motion.p
               initial={{ opacity: 0, y: 20 }}
@@ -120,7 +120,7 @@ export const LandingPageContent = ({
               transition={{ duration: 0.8, delay: 0.2, ease: "easeOut" }}
               className="text-xs md:text-sm text-white/70 max-w-md mx-auto leading-relaxed mb-10"
             >
-              The verification layer for commerce.
+              The live receipt for every Shopify order. Built on ink.
             </motion.p>
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -144,12 +144,12 @@ export const LandingPageContent = ({
           style={{ y: problemY, scale: problemScale, opacity: problemOpacity }}
           className="max-w-4xl mx-auto text-center will-change-transform"
         >
-          <p className="text-xs uppercase tracking-wider text-gray-400 mb-6 font-medium">The Missing Layer</p>
+          <p className="text-xs uppercase tracking-wider text-gray-400 mb-6 font-medium">The Receipt You Already Send</p>
           <h2 className="text-4xl md:text-5xl font-serif font-light tracking-tight mb-8 leading-tight">
-            ink. sits on top of infrastructure already in place.
+            Parallel upgrades the receipt. Nothing else has to change.
           </h2>
           <p className="text-lg text-gray-600 leading-relaxed max-w-2xl mx-auto">
-            The warehouse stays. The carrier stays. The POS stays. No IT integration, no vendor coordination, no workflow changes. Merchants can be running in weeks, not months.
+            The warehouse stays. The carrier stays. Shopify stays. You install one app and the receipt becomes a branded page that taps open, runs returns, and proves delivery. Live in days.
           </p>
         </motion.div>
       </section>
@@ -161,9 +161,9 @@ export const LandingPageContent = ({
             style={{ scale: cardScale, opacity: cardOpacity }}
             className="text-center mb-16 will-change-transform"
           >
-            <p className="text-xs uppercase tracking-wider text-gray-400 mb-6 font-medium">What Your Customer Gets</p>
+            <p className="text-xs uppercase tracking-wider text-gray-400 mb-6 font-medium">Two Sides of the Same Receipt</p>
             <h2 className="text-4xl font-serif font-light tracking-tight leading-tight">
-              A branded moment on arrival.
+              Your customer opens it. You see the truth.
             </h2>
           </motion.div>
 
@@ -176,9 +176,9 @@ export const LandingPageContent = ({
               <div className="w-14 h-14 bg-foreground flex items-center justify-center mb-8">
                 <Film className="h-7 w-7 text-background" />
               </div>
-              <h3 className="text-3xl font-serif font-medium mb-5">A Branded Moment on Arrival</h3>
+              <h3 className="text-3xl font-serif font-medium mb-5">A receipt that opens.</h3>
               <p className="text-gray-600 leading-relaxed mb-8 text-lg">
-                Phone touches sticker. Your logo, your colors, your message — full screen. No app. No login. One tap and they close their phone and go about their day.
+                Phone touches sticker. Your logo, your colors, your message. Full screen. No app. No login. One tap and they close their phone and go about their day.
               </p>
             </motion.div>
 
@@ -190,9 +190,9 @@ export const LandingPageContent = ({
               <div className="w-14 h-14 bg-foreground flex items-center justify-center mb-8">
                 <Shield className="h-7 w-7 text-background" />
               </div>
-              <h3 className="text-3xl font-serif font-medium mb-5">A Delivery Confirmation They Can Trust</h3>
+              <h3 className="text-3xl font-serif font-medium mb-5">Proof on every delivery.</h3>
               <p className="text-gray-600 leading-relaxed mb-8 text-lg">
-                On screen: their order is confirmed. In the background, ink. captures GPS, timestamp, and device data. Your customer sees a premium experience. You see verified proof.
+                On screen: their order is confirmed. In the background, the tap records GPS, time, and device. Your customer sees a premium experience. You see a verified record.
               </p>
             </motion.div>
           </div>
@@ -205,16 +205,16 @@ export const LandingPageContent = ({
           style={{ y: howY }}
           className="max-w-4xl mx-auto text-center will-change-transform"
         >
-          <p className="text-xs uppercase tracking-wider text-gray-400 mb-6 font-medium">What You Get</p>
+          <p className="text-xs uppercase tracking-wider text-gray-400 mb-6 font-medium">What Parallel Does</p>
           <h2 className="text-4xl font-serif font-light tracking-tight mb-16 leading-tight">
-            A record of every shipment. Evidence before anything ships. A dashboard that shows you everything.
+            Branded receipt. Proof of delivery. Amazon-style returns. One install.
           </h2>
 
           <div className="grid md:grid-cols-3 gap-12 text-left">
             {[
-              { num: "01", title: "A Record of Every Shipment", desc: "What was in the box. When it was delivered. That your customer received it. Cryptographically signed and timestamped." },
-              { num: "02", title: "Evidence Before Anything Ships", desc: "Pre-shipment photos lock what you packed to the sticker's unique ID. The record is created at your warehouse — not reconstructed after a dispute." },
-              { num: "03", title: "One Dashboard", desc: "Enrollment status. Tap rates. Time to engagement. Sticker inventory with auto-refill. One view." },
+              { num: "01", title: "A receipt that's alive.", desc: "NFC sticker on the box. Customer taps. The receipt opens on their phone, branded to your store. No app. No login. No download." },
+              { num: "02", title: "Proof before anything ships.", desc: "Pre-shipment photos tie what you packed to the sticker's unique ID. A tamper-evident, timestamped record. Created at the warehouse, not reconstructed after a dispute." },
+              { num: "03", title: "One merchant view.", desc: "Enrollment status. Tap rates. Time to engagement. Sticker inventory with auto-refill. One dashboard." },
             ].map((step, i) => (
               <motion.div
                 key={step.num}
@@ -337,7 +337,7 @@ export const LandingPageContent = ({
               style={{ fontSize: "3.75rem" }}
               className="font-serif font-light leading-snug tracking-tight mb-3"
             >
-              The verification layer for commerce.
+              Every receipt, alive.
             </motion.h2>
             <motion.p
               initial={{ opacity: 0, y: 20 }}
@@ -346,7 +346,7 @@ export const LandingPageContent = ({
               transition={{ duration: 0.8, delay: 0.2, ease: "easeOut" }}
               className="text-base md:text-lg text-white/70 max-w-lg mx-auto leading-relaxed mb-10"
             >
-              The hardware bolt-on that turns every delivery into a retention event.
+              Parallel, built on ink.
             </motion.p>
           </div>
         </div>
@@ -358,20 +358,20 @@ export const LandingPageContent = ({
           <div className="grid md:grid-cols-2 gap-8 md:gap-12">
             {[
               {
-                title: "One Tap at Delivery",
-                desc: "That's it. The customer sees a branded confirmation. In the background, ink. pre-authorizes a future return and sends the customer a return link — by email, text, or saved from the confirmation screen.",
+                title: "One tap to open the receipt.",
+                desc: "Phone touches sticker. The receipt opens on the customer's phone, full screen, your brand. No app. No login. One tap and they close the phone and go about their day.",
               },
               {
-                title: "Extended Return Window",
-                desc: "Customers who tap get a longer return window than customers who don't. The tap is the incentive. The tap is the unlock.",
+                title: "Refund at scan.",
+                desc: "Tappers get the express tier. The refund clears at the moment of return scan, not after a multi-day inspection cycle.",
               },
               {
-                title: "Any Carrier. Any Location.",
-                desc: "When the customer is ready to return, they open the link. No sticker needed. The system confirms eligibility. They walk into any FedEx, UPS, or USPS. GPS detects the carrier. A carrier-native QR generates in seconds. The associate scans it through their existing system. No printing. No portal. No receipt.",
+                title: "Returns from the receipt.",
+                desc: "Two ways. At your store, show the passport at the counter and refund at scan. Live today. At any carrier, GPS detects the drop-off and generates a scannable QR. Rolling out with the next ink. update.",
               },
               {
-                title: "Return Passport",
-                desc: "Walk into a retail partner instead? GPS detects the store. A Return Passport generates. No ID. No receipt. Instant verification.",
+                title: "Return Passport at retail.",
+                desc: "Walk into a retail partner instead of your own store. GPS detects the location. A Return Passport generates on the customer's phone. No ID, no receipt search, instant verification at the counter.",
                 badge: "Coming Soon",
               },
             ].map((card, i) => (
@@ -404,7 +404,7 @@ export const LandingPageContent = ({
             transition={{ duration: 0.6, delay: 0.3 }}
             className="text-sm text-foreground/40 max-w-2xl mx-auto text-center mt-12"
           >
-            Customers who never tap go through your standard return process — single-carrier label, standard return window. The tap is the unlock.
+            Customers who never tap go through your standard return process. Single-carrier label, standard return window. The tap is the unlock.
           </motion.p>
         </div>
       </section>
@@ -425,7 +425,7 @@ export const LandingPageContent = ({
             <span>·</span>
             <a href="#" className="hover:text-white transition-colors">Terms</a>
           </div>
-          <p className="mt-6 text-xs">© 2026 ink.</p>
+          <p className="mt-6 text-xs">© 2026 Parallel. Built on ink.</p>
         </div>
       </motion.footer>
     </div>

--- a/app/components/billing/BillingWidget.tsx
+++ b/app/components/billing/BillingWidget.tsx
@@ -1,21 +1,33 @@
 import { useNavigate } from "react-router-dom";
+import { useFetcher } from "react-router";
+import { useEffect } from "react";
+import { Loader2 } from "lucide-react";
 
 interface BillingWidgetProps {
-  enrollments?: number;
-  taps?: number;
-  total?: number;
-  used?: number;
+  // Plan cap is config, not engagement data — still a placeholder until billing is wired.
   cap?: number;
 }
 
-const BillingWidget = ({
-  enrollments = 47,
-  taps = 31,
-  total = 233.22,
-  used = 233.22,
-  cap = 500,
-}: BillingWidgetProps) => {
+const BillingWidget = ({ cap = 500 }: BillingWidgetProps) => {
   const navigate = useNavigate();
+
+  // Real enrollment + tap counts (replaces the old 47/31 mock), shared source
+  // with CurrentPlanCard + EngagementFunnel.
+  const fetcher = useFetcher<{ totalTaps: number; enrollments: number; engaged: number }>();
+  useEffect(() => {
+    if (fetcher.state === "idle" && !fetcher.data) {
+      fetcher.load(`/app/api/dashboard/tap-stats?_t=${Date.now()}`);
+    }
+  }, [fetcher]);
+
+  const isLoading = fetcher.state === "loading" || !fetcher.data;
+  const enrollments = fetcher.data?.enrollments ?? 0;
+  const taps = fetcher.data?.totalTaps ?? 0;
+
+  // Tap + enrollment charges at the published rates ($0.99 / $2.99). Tags
+  // pass-through is billed separately and not included in this quick strip.
+  const total = enrollments * 0.99 + taps * 2.99;
+  const used = total;
   const pct = Math.min(Math.round((used / cap) * 100), 100);
 
   const fmt = (n: number) =>
@@ -24,8 +36,13 @@ const BillingWidget = ({
   return (
     <div
       onClick={() => navigate("/billing")}
-      className="bg-card border border-border rounded-sm p-5 cursor-pointer hover:border-muted-foreground transition-colors"
+      className="relative bg-card border border-border rounded-sm p-5 cursor-pointer hover:border-muted-foreground transition-colors"
     >
+      {isLoading && (
+        <div className="absolute inset-0 bg-background/50 backdrop-blur-[1px] flex items-center justify-center z-10 rounded-sm">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      )}
       <p className="text-sm font-medium text-foreground">This Cycle</p>
       <p className="text-sm text-muted-foreground mt-1">
         {enrollments} enrollments · {taps} taps · {fmt(total)}

--- a/app/components/settings/DeliveryModeSettings.tsx
+++ b/app/components/settings/DeliveryModeSettings.tsx
@@ -123,14 +123,14 @@ const DeliveryModeSettings = () => {
   return (
     <Layout>
       <Layout.AnnotatedSection
-        title="Verified Delivery Mode"
-        description="Choose how INK Verified Delivery shows up to your customers at checkout."
+        title="Delivery mode"
+        description="Choose how ink. shows up to your customers at checkout."
       >
         <Card>
           <BlockStack gap="400">
             <RadioButton
               label="Optional add-on"
-              helpText="Customers see ink. Verified Delivery as a paid checkout option alongside their other shipping methods. They choose whether to opt in."
+              helpText="Customers see an ink. delivery option as a paid checkout choice alongside their other shipping methods. They choose whether to opt in."
               checked={mode === "addon"}
               id="delivery-mode-addon"
               name="delivery-mode"
@@ -139,7 +139,7 @@ const DeliveryModeSettings = () => {
             />
             <RadioButton
               label="Automatic (background)"
-              helpText="Customers see only your standard shipping methods. INK is silently applied to every order. You absorb the per-sticker cost (or price it into your products)."
+              helpText="Customers see only your standard shipping methods. ink. is silently applied to every order. You absorb the per-sticker cost (or price it into your products)."
               checked={mode === "background"}
               id="delivery-mode-background"
               name="delivery-mode"
@@ -150,7 +150,7 @@ const DeliveryModeSettings = () => {
             {mode === "background" && (
               <Banner tone="info">
                 <Text as="p" variant="bodySm">
-                  Background mode hides INK from your checkout the next time
+                  Background mode hides ink. from your checkout the next time
                   Shopify polls our carrier service (usually within a few
                   minutes). Existing in-flight checkouts may still show the
                   option until then.

--- a/app/components/settings/UserManagementSettings.tsx
+++ b/app/components/settings/UserManagementSettings.tsx
@@ -175,7 +175,7 @@ const UserManagementSettings = () => {
       {/* Warehouse App */}
       <Layout.AnnotatedSection
         title="Warehouse App"
-        description="Download the INK enrollment app for your packing stations."
+        description="Download the ink. enrollment app for your packing stations."
       >
         <Card>
           <InlineStack gap="600" wrap={false} blockAlign="start">
@@ -197,7 +197,7 @@ const UserManagementSettings = () => {
             </div>
             <BlockStack gap="400">
               <Text as="p" tone="subdued" variant="bodySm">
-                Scan to download the INK Warehouse app on your packing station devices.
+                Scan to download the ink. Warehouse app on your packing station devices.
               </Text>
               <BlockStack gap="200">
                 <InlineStack gap="200">

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -74,7 +74,7 @@ export default function App() {
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
-          href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600&family=Playfair+Display:wght@300;400;500;600&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=DM+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600&family=Playfair+Display:wght@300;400;500;600&display=swap"
           rel="stylesheet"
         />
         <Meta />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -37,7 +37,7 @@ function GlobalLoadingScreen() {
         boxShadow: "0 4px 20px rgba(0,0,0,0.15)",
       }}>
         <span style={{ color: "#fff", fontSize: 22, fontWeight: 700, fontFamily: "system-ui, sans-serif" }}>
-          INK
+          ink.
         </span>
       </div>
 

--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -253,7 +253,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
             if (uniqueSlugs.length > 0) {
                 const INK_API_BASE = process.env.INK_API_URL || "https://us-central1-inink-c76d3.cloudfunctions.net/api";
-                const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET || "ink_admin_aeb5c9d6e822a4e57d95a6a2224aada64230e48d89acad5782057fcb865548a2";
+                const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET;
+                if (!INK_ADMIN_SECRET) throw new Error("INK_ADMIN_SECRET is not set");
                 const baseUrl = INK_API_BASE.endsWith("/api") ? INK_API_BASE.slice(0, -4) : INK_API_BASE;
 
                 let animsUrl = "";

--- a/app/routes/app._index/route.tsx
+++ b/app/routes/app._index/route.tsx
@@ -1,58 +1,21 @@
-// In-admin landing — the screen a merchant sees the first time they
-// open the app inside Shopify. Stripped to a single door: brand,
-// one-line orientation, big "Open dashboard" CTA. The full public
-// marketing landing lives at the public route (_index); this one
-// just gets them to work.
-
-import { type LoaderFunctionArgs, Link } from "react-router";
+import { type LoaderFunctionArgs } from "react-router";
 import { authenticate } from "../../shopify.server";
+import { LandingPageContent } from "../../components/LandingPageContent";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   await authenticate.admin(request);
   return null;
 };
 
-const FONT_BODY = "'Geist', 'Space Grotesk', ui-sans-serif, system-ui, sans-serif";
-const FONT_DISPLAY = "'Archivo Black', 'Space Grotesk', system-ui, sans-serif";
-const FONT_MONO = "'JetBrains Mono', ui-monospace, monospace";
-
 export default function LandingPage() {
   return (
-    <div
-      className="min-h-[calc(100vh-120px)] bg-white text-black flex items-center justify-center px-5 sm:px-9 py-16"
-      style={{ fontFamily: FONT_BODY }}
-    >
-      <div className="w-full max-w-[720px] text-center">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-neutral-500 pb-6">
-          Parallel
-        </div>
-        <h1
-          className="m-0 uppercase tracking-[-0.028em] leading-[0.92] text-black text-[40px] sm:text-[clamp(48px,6vw,80px)]"
-          style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
-        >
-          Your dashboard is ready.
-        </h1>
-        <p className="pt-6 text-[14px] sm:text-[15px] leading-[1.65] text-neutral-700 max-w-[48ch] mx-auto">
-          The live receipt for every Shopify order. Branded post-purchase,
-          carrier-agnostic returns, built on ink.
-        </p>
-        <div className="pt-10">
-          <Link
-            to="/app/dashboard"
-            className="inline-flex items-center gap-3 bg-black text-white px-6 py-4 text-[12px] font-semibold uppercase tracking-[0.22em] hover:bg-neutral-800 transition-colors"
-            style={{ fontFamily: FONT_BODY }}
-          >
-            Open dashboard
-            <span aria-hidden style={{ fontFamily: FONT_MONO }}>↗</span>
-          </Link>
-        </div>
-        <div
-          className="pt-12 text-[10px] uppercase tracking-[0.22em] text-neutral-400"
-          style={{ fontFamily: FONT_MONO }}
-        >
-          New here? Open the dashboard to set up your brand and order your first stickers.
-        </div>
-      </div>
-    </div>
+    <LandingPageContent
+      ctaLink="/app/dashboard"
+      ctaLabel="Open dashboard"
+      showSignIn={false}
+      headline="Your dashboard is ready."
+      sub="The live receipt for every Shopify order. Branded post-purchase, carrier-agnostic returns, built on ink."
+      footnote="New here? Open the dashboard to set up your brand and order your first stickers."
+    />
   );
 }

--- a/app/routes/app._index/route.tsx
+++ b/app/routes/app._index/route.tsx
@@ -14,7 +14,7 @@ export default function LandingPage() {
       ctaLabel="Open dashboard"
       showSignIn={false}
       headline="Your dashboard is ready."
-      sub="The live receipt for every Shopify order. Branded post-purchase, carrier-agnostic returns, built on ink."
+      sub="A living page for every Shopify order. Branded post-purchase, carrier-agnostic returns — opened on a tap."
       footnote="New here? Open the dashboard to set up your brand and order your first stickers."
     />
   );

--- a/app/routes/app._index/route.tsx
+++ b/app/routes/app._index/route.tsx
@@ -1,4 +1,10 @@
-import { type LoaderFunctionArgs } from "react-router";
+// In-admin landing — the screen a merchant sees the first time they
+// open the app inside Shopify. Stripped to a single door: brand,
+// one-line orientation, big "Open dashboard" CTA. The full public
+// marketing landing lives at the public route (_index); this one
+// just gets them to work.
+
+import { type LoaderFunctionArgs, Link } from "react-router";
 import { authenticate } from "../../shopify.server";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
@@ -6,8 +12,47 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   return null;
 };
 
-import { LandingPageContent } from "../../components/LandingPageContent";
+const FONT_BODY = "'Geist', 'Space Grotesk', ui-sans-serif, system-ui, sans-serif";
+const FONT_DISPLAY = "'Archivo Black', 'Space Grotesk', system-ui, sans-serif";
+const FONT_MONO = "'JetBrains Mono', ui-monospace, monospace";
 
 export default function LandingPage() {
-  return <LandingPageContent ctaLink="/app/dashboard" showSignIn={false} />;
+  return (
+    <div
+      className="min-h-[calc(100vh-120px)] bg-white text-black flex items-center justify-center px-5 sm:px-9 py-16"
+      style={{ fontFamily: FONT_BODY }}
+    >
+      <div className="w-full max-w-[720px] text-center">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-neutral-500 pb-6">
+          Parallel
+        </div>
+        <h1
+          className="m-0 uppercase tracking-[-0.028em] leading-[0.92] text-black text-[40px] sm:text-[clamp(48px,6vw,80px)]"
+          style={{ fontFamily: FONT_DISPLAY, fontWeight: 400 }}
+        >
+          Your dashboard is ready.
+        </h1>
+        <p className="pt-6 text-[14px] sm:text-[15px] leading-[1.65] text-neutral-700 max-w-[48ch] mx-auto">
+          The live receipt for every Shopify order. Branded post-purchase,
+          carrier-agnostic returns, built on ink.
+        </p>
+        <div className="pt-10">
+          <Link
+            to="/app/dashboard"
+            className="inline-flex items-center gap-3 bg-black text-white px-6 py-4 text-[12px] font-semibold uppercase tracking-[0.22em] hover:bg-neutral-800 transition-colors"
+            style={{ fontFamily: FONT_BODY }}
+          >
+            Open dashboard
+            <span aria-hidden style={{ fontFamily: FONT_MONO }}>↗</span>
+          </Link>
+        </div>
+        <div
+          className="pt-12 text-[10px] uppercase tracking-[0.22em] text-neutral-400"
+          style={{ fontFamily: FONT_MONO }}
+        >
+          New here? Open the dashboard to set up your brand and order your first stickers.
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/app/routes/app.api.dashboard.tap-stats.tsx
+++ b/app/routes/app.api.dashboard.tap-stats.tsx
@@ -1,0 +1,25 @@
+import { type LoaderFunctionArgs } from "react-router";
+import { authenticate } from "../shopify.server";
+import { getMerchantTapStats } from "../services/ink-api.server";
+
+const json = (data: any, init?: ResponseInit) =>
+  new Response(JSON.stringify(data), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+// GET /app/api/dashboard/tap-stats — real verified-tap + enrollment totals for the
+// authenticated merchant, summed from their proofs. Consumed by CurrentPlanCard.
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  try {
+    const { session } = await authenticate.admin(request);
+    const stats = await getMerchantTapStats(session.shop);
+    return json(stats);
+  } catch (err: any) {
+    // Re-auth redirects from authenticate.admin are Responses — bubble those so
+    // App Bridge can recover; only swallow real errors to zeros.
+    if (err instanceof Response) throw err;
+    console.error("[tap-stats] error:", err?.message || err);
+    return json({ totalTaps: 0, enrollments: 0 });
+  }
+};

--- a/app/routes/app.api.settings.media.tsx
+++ b/app/routes/app.api.settings.media.tsx
@@ -352,12 +352,24 @@ export const action = async ({ request }: ActionFunctionArgs) => {
        const { id } = body;
        console.log(`[settings/media] DELETE media id=${id}`);
        
-       // Find the item to get the merchantSlug for Alan API call
-       const item = merchantMedia.find((m: any) => m.id === id);
+       // Resolve shop_id so we delete from the SAME merchant_animations doc the
+       // upload writes + the tap reads (via the by-id route). The old slug route
+       // deleted a different doc, leaving the media live at tap (the split-brain).
+       const dData = doc?.data();
+       let alanMerchantId: string | null =
+           dData && typeof dData.shop_id === "string" ? dData.shop_id : null;
+       if (!alanMerchantId && shopDomain) {
+           try {
+               const { getShopIdByDomain } = await import("../services/ink-api.server");
+               alanMerchantId = await getShopIdByDomain(shopDomain);
+           } catch (e: any) {
+               console.warn(`[settings/media] DELETE: couldn't resolve shop_id: ${e?.message || e}`);
+           }
+       }
        
        // Try to delete from Alan's API too (best effort — don't fail if it errors)
-       if (item?.merchantSlug) {
-           const deleteUrl = getAlanUrl(`/admin/merchant-animations/${item.merchantSlug}/${id}`);
+       if (alanMerchantId) {
+           const deleteUrl = getAlanUrl(`/admin/merchant-animations/by-id/${encodeURIComponent(alanMerchantId)}/${encodeURIComponent(id)}`);
            console.log(`[settings/media] Calling Alan DELETE → ${deleteUrl}`);
            try {
                const delResp = await fetch(deleteUrl, {

--- a/app/routes/app.api.settings.media.tsx
+++ b/app/routes/app.api.settings.media.tsx
@@ -4,7 +4,8 @@ import crypto from "crypto";
 import { authenticate } from "../shopify.server";
 
 const INK_API_URL = process.env.INK_API_URL || "https://us-central1-inink-c76d3.cloudfunctions.net/api";
-const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET || "ink_admin_aeb5c9d6e822a4e57d95a6a2224aada64230e48d89acad5782057fcb865548a2";
+const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET;
+if (!INK_ADMIN_SECRET) throw new Error("INK_ADMIN_SECRET is not set");
 
 /** Build an Alan API URL. The INK_API_URL ends in /api; admin routes are /admin/*, api routes are /api/* */
 function getAlanUrl(path: string): string {

--- a/app/routes/app.api.settings.media.tsx
+++ b/app/routes/app.api.settings.media.tsx
@@ -398,11 +398,25 @@ export const action = async ({ request }: ActionFunctionArgs) => {
            // Tell Alan's backend (source of truth) that this is now primary.
            // ConsumerTap fetches branding from Alan, so without this call the
            // dashboard and consumer experience drift.
-           const slugForAlan =
-               item.merchantSlug || (shopDomain ? toMerchantSlug(shopDomain) : "");
-           if (slugForAlan) {
+           // Set-primary MUST target the SAME merchant_animations doc the upload
+           // writes and the consumer tap reads — keyed by shop_id, via the by-id
+           // route. The old slug route (/{toMerchantSlug(domain)}/primary) wrote a
+           // DIFFERENT doc that lacks the uploaded media_items → 502 MEDIA_NOT_FOUND
+           // (the split-brain: upload used shop_id, set-primary used the slug).
+           const dData = doc?.data();
+           let alanMerchantId: string | null =
+               dData && typeof dData.shop_id === "string" ? dData.shop_id : null;
+           if (!alanMerchantId && shopDomain) {
+               try {
+                   const { getShopIdByDomain } = await import("../services/ink-api.server");
+                   alanMerchantId = await getShopIdByDomain(shopDomain);
+               } catch (e: any) {
+                   console.warn(`[settings/media] setPrimary: couldn't resolve shop_id: ${e?.message || e}`);
+               }
+           }
+           if (alanMerchantId) {
                const setPrimaryUrl = getAlanUrl(
-                   `/admin/merchant-animations/${slugForAlan}/primary`
+                   `/admin/merchant-animations/by-id/${encodeURIComponent(alanMerchantId)}/primary`
                );
                console.log(
                    `[settings/media] PATCH primary → ${setPrimaryUrl}, media_id=${id}`
@@ -439,8 +453,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                }
            } else {
                console.warn(
-                   `[settings/media] No merchantSlug on item — skipping Alan API call. ` +
-                   `Local Firestore will be updated but consumer experience may diverge.`
+                   `[settings/media] Could not resolve shop_id — skipping Alan setPrimary. ` +
+                   `Local Firestore will be updated but the consumer tap may diverge.`
                );
            }
 

--- a/app/routes/app.dashboard.tsx
+++ b/app/routes/app.dashboard.tsx
@@ -41,7 +41,7 @@ export const action = async ({
     console.error("[dashboard] mint magic token failed:", err);
     return {
       url: null,
-      error: "Couldn't open your Parallel dashboard. Try again in a moment.",
+      error: "Couldn't open your ink. dashboard. Try again in a moment.",
     };
   }
 };
@@ -118,12 +118,12 @@ const Dashboard = () => {
             <Banner tone="critical">{fetcher.data.error}</Banner>
           )}
 
-          {/* Open the merchant's Parallel dashboard, auto-signed-in. */}
+          {/* Open the merchant's ink. dashboard, auto-signed-in. */}
           <Card>
             <InlineStack align="space-between" blockAlign="center" gap="400" wrap={false}>
               <BlockStack gap="100">
                 <Text as="h2" variant="headingMd">
-                  Your Parallel dashboard
+                  Your ink. dashboard
                 </Text>
                 <Text as="p" tone="subdued">
                   Open the post-purchase surface where your enrolled orders, tap
@@ -132,7 +132,7 @@ const Dashboard = () => {
                 </Text>
               </BlockStack>
               <Button variant="primary" loading={opening} onClick={openParallel}>
-                Open your Parallel dashboard
+                Open your ink. dashboard
               </Button>
             </InlineStack>
           </Card>

--- a/app/routes/app.dashboard.tsx
+++ b/app/routes/app.dashboard.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useFetcher, type ActionFunctionArgs } from "react-router";
 import {
   Page,
   Card,
@@ -10,6 +11,8 @@ import {
   Banner,
   Layout,
 } from "@shopify/polaris";
+import { authenticate } from "../shopify.server";
+import { mintMagicToken } from "../services/ink-api.server";
 import PolarisAppLayout from "~/components/PolarisAppLayout";
 import RecentActivity from "~/components/RecentActivity";
 import EngagementFunnel from "~/components/EngagementFunnel";
@@ -21,9 +24,59 @@ import BillingWidget from "~/components/billing/BillingWidget";
 import CommunicationsUsage from "~/components/CommunicationsUsage";
 import { toast } from "sonner"; // Replaced with Sonner to match previous setup
 
+// Mint a single-use magic-login token for this shop and hand back a
+// parallel.in.ink/welcome URL the merchant can open already signed in.
+export const action = async ({
+  request,
+}: ActionFunctionArgs): Promise<{ url: string | null; error: string | null }> => {
+  const { session } = await authenticate.admin(request);
+  try {
+    const { token } = await mintMagicToken(session.shop);
+    const base = process.env.PARALLEL_APP_URL || "https://parallel.in.ink";
+    return {
+      url: `${base}/welcome?token=${encodeURIComponent(token)}`,
+      error: null,
+    };
+  } catch (err) {
+    console.error("[dashboard] mint magic token failed:", err);
+    return {
+      url: null,
+      error: "Couldn't open your Parallel dashboard. Try again in a moment.",
+    };
+  }
+};
+
 const Dashboard = () => {
   const [hasOrders, setHasOrders] = useState(true);
   const [isTransitioning, setIsTransitioning] = useState(false);
+
+  const fetcher = useFetcher<typeof action>();
+  const pendingWindow = useRef<Window | null>(null);
+  const opening = fetcher.state !== "idle";
+
+  const openParallel = () => {
+    // Open the new tab synchronously inside the click handler (a user gesture)
+    // so the browser doesn't block it as a popup, then point it at the real
+    // signed-in URL once the token comes back from the action.
+    pendingWindow.current = window.open("", "_blank");
+    fetcher.submit({}, { method: "post" });
+  };
+
+  useEffect(() => {
+    const data = fetcher.data;
+    if (!data) return;
+    if (data.url) {
+      if (pendingWindow.current) {
+        pendingWindow.current.location.href = data.url;
+      } else {
+        window.open(data.url, "_blank", "noopener,noreferrer");
+      }
+      pendingWindow.current = null;
+    } else if (data.error && pendingWindow.current) {
+      pendingWindow.current.close();
+      pendingWindow.current = null;
+    }
+  }, [fetcher.data]);
 
   const handleViewDemo = () => {
     setIsTransitioning(true);
@@ -61,6 +114,29 @@ const Dashboard = () => {
     <PolarisAppLayout>
       <Page title="Dashboard">
         <BlockStack gap="400">
+          {fetcher.data?.error && (
+            <Banner tone="critical">{fetcher.data.error}</Banner>
+          )}
+
+          {/* Open the merchant's Parallel dashboard, auto-signed-in. */}
+          <Card>
+            <InlineStack align="space-between" blockAlign="center" gap="400" wrap={false}>
+              <BlockStack gap="100">
+                <Text as="h2" variant="headingMd">
+                  Your Parallel dashboard
+                </Text>
+                <Text as="p" tone="subdued">
+                  Open the post-purchase surface where your enrolled orders, tap
+                  pages, and returns live. You'll be signed in automatically — no
+                  password needed.
+                </Text>
+              </BlockStack>
+              <Button variant="primary" loading={opening} onClick={openParallel}>
+                Open your Parallel dashboard
+              </Button>
+            </InlineStack>
+          </Card>
+
           {/* Operational Analytics (Metabase) */}
           <Card padding="0">
             <div style={{ padding: "0" }}>

--- a/app/routes/app.help.tsx
+++ b/app/routes/app.help.tsx
@@ -128,7 +128,7 @@ const faqSections = [
       {
         question: "When am I charged for a tap?",
         answer:
-          "Only when a customer successfully taps the sticker and the system captures a verified delivery event. You'll be billed monthly.",
+          "Only when a customer successfully taps the sticker and the system captures a verified tap. You'll be billed monthly.",
       },
       {
         question: "How do I order more stickers?",

--- a/app/routes/app.payment.tsx
+++ b/app/routes/app.payment.tsx
@@ -29,7 +29,7 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     }`,
     {
       variables: {
-        name: "INK Verified Delivery",
+        name: "ink — Tap Pages",
         returnUrl: `${process.env.SHOPIFY_APP_URL}/app/payment/callback`,
         lineItems: [
           {
@@ -85,16 +85,16 @@ export default function Payment() {
               <Card>
                 <BlockStack gap="500">
                   <Text as="h2" variant="headingLg">
-                    Activate INK Verified Delivery
+                    Activate ink.
                   </Text>
                   <Text as="p" variant="bodyMd">
-                    To start using INK Verified Delivery and access your dashboard, please activate your subscription.
+                    To start using ink. and access your dashboard, please activate your subscription.
                   </Text>
                   
                   <List type="bullet">
                     <List.Item>Automated Shipping Rates</List.Item>
                     <List.Item>NFC Tag Enrollment</List.Item>
-                    <List.Item>Verified Delivery Proofs</List.Item>
+                    <List.Item>Tap pages for every order</List.Item>
                   </List>
 
                   <div style={{ padding: "20px", background: "#f1f1f1", borderRadius: "8px" }}>

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -6,6 +6,8 @@ import { AppProvider as PolarisAppProvider } from "@shopify/polaris";
 import { authenticate, registerWebhooks } from "../shopify.server";
 import { ShopProvider } from "../contexts/ShopContext";
 import { ensureCarrierServiceRegistered } from "../services/carrier-service.server";
+import { createMerchant } from "../services/ink-api.server";
+import { getMerchant, updateMerchant } from "../services/merchant.server";
 
 import polarisStyles from "@shopify/polaris/build/esm/styles.css?url";
 import translations from "@shopify/polaris/locales/en.json";
@@ -39,6 +41,29 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   registerWebhooks({ session }).catch((err) =>
     console.error("[App] Webhook registration error (non-blocking):", err)
   );
+
+  // Self-provision on app load. Managed-install apps (use_legacy_install_flow =
+  // false) don't fire afterAuth on token exchange — so the install hook never
+  // runs for these stores. This loader does, on every embedded load. Seed the
+  // INK merchant's api_key into merchants/{shop} + default to automatic the
+  // first time only (guarded on ink_api_key so an existing key is never
+  // re-rotated). Non-blocking: never delays or breaks the app render.
+  (async () => {
+    const existing = await getMerchant(session.shop);
+    if (!existing?.ink_api_key) {
+      const inkData = await createMerchant(session.shop, session.shop, `admin@${session.shop}`);
+      if (inkData?.api_key) {
+        await updateMerchant(session.shop, {
+          ink_api_key: inkData.api_key,
+          verified_delivery_mode: "background",
+          payment_status: "active",
+        });
+      }
+    }
+  })().catch((err) =>
+    console.error("[App] INK self-provision error (non-blocking):", err)
+  );
+
   return { apiKey: process.env.SHOPIFY_API_KEY || "" };
 };
 

--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -86,8 +86,8 @@ const ORDER_DETAIL_QUERY = `
     order(id: $id) {
       id
       name
-      customer { email phone }
-      shippingAddress { address1 address2 city province zip country }
+      customer { email phone firstName lastName }
+      shippingAddress { name address1 address2 city province zip country }
       totalPriceSet { shopMoney { amount currencyCode } }
       lineItems(first: 20) {
         edges {
@@ -253,8 +253,19 @@ export const action = async ({ request }: ActionFunctionArgs) => {
             image_url: n.image?.url || null,
           }));
           const addr = order.shippingAddress;
+          // Recipient/customer name — Alan's order mapper reads
+          // shipping_address.name as the customer name fallback, so carry it
+          // through (the order webhook never used to fetch a name → blank
+          // "Customer" + "Ship To" in Parallel).
+          const recipientName =
+            addr?.name ||
+            [order.customer?.firstName, order.customer?.lastName]
+              .filter(Boolean)
+              .join(" ") ||
+            "";
           const shipping_address = addr
             ? {
+                name: recipientName,
                 line1: addr.address1 || "",
                 line2: addr.address2 || "",
                 city: addr.city || "",
@@ -262,7 +273,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                 zip: addr.zip || "",
                 country: addr.country || "",
               }
-            : "Not Provided";
+            : recipientName
+              ? { name: recipientName }
+              : "Not Provided";
 
           let carrier_name: string | null = null;
           let tracking_number: string | null = null;

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -205,7 +205,7 @@ export const EmailService = {
         <div class="email-container">
           <!-- Header -->
           <div class="header">
-            <h1 class="header-title">ink. Verified Delivery</h1>
+            <h1 class="header-title">ink.</h1>
           </div>
 
           <!-- Main Content -->
@@ -282,7 +282,7 @@ export const EmailService = {
 
           <!-- Footer -->
           <div class="footer">
-            <p style="margin: 0 0 10px 0;">Secured by ink. Verified Delivery Protocol</p>
+            <p style="margin: 0 0 10px 0;">Secured by ink.</p>
             <p style="margin: 0;">&copy; ${new Date().getFullYear()} ink. All rights reserved.</p>
           </div>
         </div>

--- a/app/services/ink-api.server.ts
+++ b/app/services/ink-api.server.ts
@@ -130,6 +130,28 @@ export const deleteMerchantUser = async (userId: string) => {
     return true;
 };
 
+// Mint a single-use magic-login token for this shop. Lets the merchant open
+// the Parallel dashboard already authenticated — no password is created or
+// stored. Admin-gated on Alan's side; we pass the shop domain and Alan
+// resolves it to the merchant + mints the token (returned exactly once).
+export const mintMagicToken = async (
+    shopDomain: string,
+): Promise<{ token: string; shop_id: string; expires_at: string }> => {
+    const response = await fetch(getAlanUrl('/auth/magic-tokens'), {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "X-Admin-Secret": INK_ADMIN_SECRET,
+        },
+        body: JSON.stringify({ shop_domain: shopDomain }),
+    });
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Failed to mint magic token: ${response.status} ${errorText}`);
+    }
+    return await response.json();
+};
+
 // V1.3.0 Auth Binding
 export const loginUser = async (email: string, password: string) => {
     const response = await fetch(getAlanUrl('/auth/login'), {
@@ -175,6 +197,13 @@ export const enrollOrder = async (
         nfc_token: nfcToken,
         order_details: {
             order_number: orderNumber,
+            // Parallel renders order_details.customer_name (no fallback to
+            // shipping_address.name), so lift the recipient name up to it —
+            // otherwise "Customer"/"Ship To" stay blank in the dashboard.
+            customer_name:
+                (shippingAddress && typeof shippingAddress === "object"
+                    ? shippingAddress.name
+                    : "") || "",
             customer_email: customerEmail || "unknown@email.com",
             customer_phone: customerPhone || "",
             shipping_address: shippingAddress,

--- a/app/services/ink-api.server.ts
+++ b/app/services/ink-api.server.ts
@@ -93,6 +93,35 @@ export const getShopIdByDomain = async (shopDomain: string): Promise<string> => 
     return merchant.shop_id;
 };
 
+// Real verified-tap + enrollment totals for a merchant, summed from Alan's proof
+// rows (GET /admin/proofs?merchant_id=<shop_id>, which returns tap_count per row).
+// Powers the dashboard's "verified engagements" number — replaces the hardcoded
+// 843/1247 mock. Degrades to zeros on any failure so the card never throws.
+export const getMerchantTapStats = async (
+    shopDomain: string,
+): Promise<{ totalTaps: number; enrollments: number; engaged: number }> => {
+    try {
+        const shopId = await getShopIdByDomain(shopDomain);
+        const res = await fetch(
+            getAlanUrl(`/admin/proofs?merchant_id=${encodeURIComponent(shopId)}`),
+            { headers: { "X-Admin-Secret": INK_ADMIN_SECRET } },
+        );
+        if (!res.ok) {
+            console.warn(`[ink-api] getMerchantTapStats ${res.status} for ${shopDomain}`);
+            return { totalTaps: 0, enrollments: 0, engaged: 0 };
+        }
+        const body = await res.json();
+        const proofs: any[] = Array.isArray(body) ? body : (body.proofs ?? []);
+        const totalTaps = proofs.reduce((sum, p) => sum + (Number(p.tap_count) || 0), 0);
+        // "engaged" = proofs tapped at least once (tap_count > 0) — the Engagement Funnel's "Tapped" bucket.
+        const engaged = proofs.reduce((n, p) => n + ((Number(p.tap_count) || 0) > 0 ? 1 : 0), 0);
+        return { totalTaps, enrollments: proofs.length, engaged };
+    } catch (e: any) {
+        console.error("[ink-api] getMerchantTapStats error:", e?.message || e);
+        return { totalTaps: 0, enrollments: 0, engaged: 0 };
+    }
+};
+
 export const adminCreateUser = async (merchantId: string, name: string, email: string, password?: string) => {
     const payload: any = { merchant_id: merchantId, name, email };
     if (password) payload.password = password;

--- a/app/services/ink-api.server.ts
+++ b/app/services/ink-api.server.ts
@@ -1,7 +1,8 @@
 import { authenticate } from "../shopify.server";
 
 const INK_API_URL = process.env.INK_API_URL || "https://us-central1-inink-c76d3.cloudfunctions.net/api";
-const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET || "ink_admin_aeb5c9d6e822a4e57d95a6a2224aada64230e48d89acad5782057fcb865548a2";
+const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET;
+if (!INK_ADMIN_SECRET) throw new Error("INK_ADMIN_SECRET is not set");
 
 /**
  * Helper to construct the correct URL for Alan's API.

--- a/app/services/notifications.server.ts
+++ b/app/services/notifications.server.ts
@@ -90,22 +90,22 @@ export const NotificationService = {
     
     switch (payload.type) {
       case "outForDelivery":
-        messageBody = `Hi ${payload.customerName}, your order ${payload.orderName} from ${payload.merchantName} is out for delivery today. Get ready to tap your INK sticker!`;
+        messageBody = `Hi ${payload.customerName}, your order ${payload.orderName} from ${payload.merchantName} is out for delivery today. Get ready to tap your ink. sticker!`;
         break;
       case "delivered":
-        messageBody = `Your package ${payload.orderName} has arrived! Tap the INK sticker on the box with your phone to verify delivery and unlock your return window.`;
+        messageBody = `Your package ${payload.orderName} has arrived! Tap the ink. sticker on the box with your phone to verify delivery and unlock your return window.`;
         break;
       case "deliveryConfirmed":
-        messageBody = `Verified! Your INK delivery for ${payload.orderName} is confirmed. ${payload.verifyUrl ? `View your passport: ${payload.verifyUrl}` : ""}`;
+        messageBody = `Verified! Your ink. delivery for ${payload.orderName} is confirmed. ${payload.verifyUrl ? `View your passport: ${payload.verifyUrl}` : ""}`;
         break;
       case "hours4":
-        messageBody = `Hi ${payload.customerName}, we noticed your package ${payload.orderName} arrived earlier today. Please tap the INK sticker to verify it!`;
+        messageBody = `Hi ${payload.customerName}, we noticed your package ${payload.orderName} arrived earlier today. Please tap the ink. sticker to verify it!`;
         break;
       case "hours24":
-        messageBody = `Reminder: Tap the INK sticker on your recent delivery (${payload.orderName}) to verify it and unlock your ${payload.returnWindowDays || 30}-day return window.`;
+        messageBody = `Reminder: Tap the ink. sticker on your recent delivery (${payload.orderName}) to verify it and unlock your ${payload.returnWindowDays || 30}-day return window.`;
         break;
       case "hours48":
-        messageBody = `Final reminder from ${payload.merchantName}: Please tap the INK sticker on your order ${payload.orderName} to properly register your delivery.`;
+        messageBody = `Final reminder from ${payload.merchantName}: Please tap the ink. sticker on your order ${payload.orderName} to properly register your delivery.`;
         break;
       case "return7d":
         messageBody = `Hi ${payload.customerName}, you have 7 days left to return order ${payload.orderName}. Need to start a return? Click here: ${payload.verifyUrl}`;
@@ -153,17 +153,17 @@ export const NotificationService = {
     switch (payload.type) {
       case "outForDelivery":
         subject = subjectPrefix + "Out for Delivery";
-        body = `Hi ${payload.customerName},\n\nYour order is out for delivery today. Get ready to tap your INK sticker!`;
+        body = `Hi ${payload.customerName},\n\nYour order is out for delivery today. Get ready to tap your ink. sticker!`;
         break;
       case "delivered":
         subject = subjectPrefix + "Delivered - Tap Your Sticker!";
-        body = `Your package has arrived!\n\nTap the INK sticker on the box with your phone to verify delivery and unlock your return window.`;
+        body = `Your package has arrived!\n\nTap the ink. sticker on the box with your phone to verify delivery and unlock your return window.`;
         break;
       case "hours4":
       case "hours24":
       case "hours48":
         subject = subjectPrefix + "Friendly Reminder to Tap Your Sticker";
-        body = `Hi ${payload.customerName},\n\nWe noticed your package arrived recently. Please tap the INK sticker to verify it and unlock returns.`;
+        body = `Hi ${payload.customerName},\n\nWe noticed your package arrived recently. Please tap the ink. sticker to verify it and unlock returns.`;
         break;
       case "return7d":
         subject = subjectPrefix + "7 Days Left to Return";

--- a/scripts/init_inventory.js
+++ b/scripts/init_inventory.js
@@ -2,7 +2,8 @@ import dotenv from "dotenv";
 dotenv.config();
 
 const INK_API_URL = process.env.INK_API_URL || "https://us-central1-inink-c76d3.cloudfunctions.net/api";
-const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET || "ink_admin_aeb5c9d6e822a4e57d95a6a2224aada64230e48d89acad5782057fcb865548a2";
+const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET;
+if (!INK_ADMIN_SECRET) { console.error("INK_ADMIN_SECRET is not set"); process.exit(1); }
 
 // Make configurable via ENV as requested
 const INITIAL_TAGS = parseInt(process.env.INITIAL_STICKER_INVENTORY || "100", 10);

--- a/shopify.app.smusic.toml
+++ b/shopify.app.smusic.toml
@@ -1,7 +1,7 @@
 # Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "45cc130ef59cbeaf9133acea201981ed"
-name = "ink. Verified Delivery"
+name = "ink — Tap Pages"
 application_url = "https://shopify-app-250065525755.us-central1.run.app"
 embedded = true
 

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -1,7 +1,7 @@
 # Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "8da1addef3dcd4251db5057cda3c85fa"
-name = "INK Verified Delivery"
+name = "ink — Tap Pages"
 application_url = "https://shopify-app-250065525755.us-central1.run.app"
 embedded = true
 


### PR DESCRIPTION
## Summary
- Reframes the public Shopify landing page from "ink. Verified Delivery" to **Parallel** as the product, with **ink.** as the platform underneath and "live receipt" as the category descriptor in copy.
- Honesty fixes from the real-vs-fake audit (Section 5 of the receipt-reframe brief):
  - "Cryptographically signed and timestamped" softened to "tamper-evident, timestamped record" (the honest characterization of what the proof endpoint does today).
  - "Extended Return Window" card removed (no code support). Replaced with "Refund at scan" (the actual express-tier benefit for tappers).
  - "Any Carrier. Any Location." split into two honest beats: in-store passport (live today) and carrier QR (rolling out with the next ink. update). Avoids overclaiming printerless carrier returns as live in production while carrier_qr_data is null.
- Em dashes removed from user-facing copy.
- Copy-only diff (29 inserts, 29 deletes). No logic, animation, or layout touched.

## Follow-up: App Store rename caveats
The Shopify App Store listing still reads "INK Verified Delivery". That rename is a separate task. Constraints to respect when it happens:

- **Rename the existing 8da1 app, not a new app.** Cloud Run service shopify-app runs as client_id 8da1addef3dcd4251db5057cda3c85fa. A new app regenerates credentials and the pipe goes dark.
- **Do not regenerate the API key or secret.** A plain name change is safe. A credential change is not.
- **Handle change can break external bookmarks.** If the listing handle moves from /apps/ink-verified-delivery/ to /apps/parallel/, hardcoded outside links shift. Buttons inside the app are fine.
- **Name choice is wiring-neutral.** "Parallel" or "Parallel the live receipt" make no difference to Cloud Run.

## Note on branch base
This PR shows 3 commits because main is 2 commits ahead of origin/main (Sam's local work: aa89816 dashboard button + b0c287c order details carry). The landing rewrite is the third commit (4343dc2).

## Test plan
- [ ] Header reads "Parallel". Hero h1 reads "Every order ships with a live receipt."
- [ ] Problem section reads "The Receipt You Already Send" / "Parallel upgrades the receipt. Nothing else has to change."
- [ ] Two-sided value cards: "A receipt that opens." and "Proof on every delivery."
- [ ] How It Works cards: 01 "A receipt that's alive." / 02 "Proof before anything ships." / 03 "One merchant view." Confirm card 02 no longer says "Cryptographically signed."
- [ ] Drop hero (sticky #2) reads "Every receipt, alive." / "Parallel, built on ink."
- [ ] Drop cards: card 2 "Refund at scan." (NOT "Extended Return Window"). Card 3 "Returns from the receipt." with "rolling out" language (NOT "Any Carrier. Any Location.").
- [ ] Footer reads "(c) 2026 Parallel. Built on ink."
