### PR TITLE
security: remove hardcoded INK admin secret from source (env-required)

### DIFF
--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -253,7 +253,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
             if (uniqueSlugs.length > 0) {
                 const INK_API_BASE = process.env.INK_API_URL || "https://us-central1-inink-c76d3.cloudfunctions.net/api";
-                const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET || "ink_admin_aeb5c9d6e822a4e57d95a6a2224aada64230e48d89acad5782057fcb865548a2";
+                const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET;
+                if (!INK_ADMIN_SECRET) throw new Error("INK_ADMIN_SECRET is not set");
                 const baseUrl = INK_API_BASE.endsWith("/api") ? INK_API_BASE.slice(0, -4) : INK_API_BASE;
 
                 let animsUrl = "";

--- a/app/routes/app.api.settings.media.tsx
+++ b/app/routes/app.api.settings.media.tsx
@@ -4,7 +4,8 @@ import crypto from "crypto";
 import { authenticate } from "../shopify.server";
 
 const INK_API_URL = process.env.INK_API_URL || "https://us-central1-inink-c76d3.cloudfunctions.net/api";
-const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET || "ink_admin_aeb5c9d6e822a4e57d95a6a2224aada64230e48d89acad5782057fcb865548a2";
+const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET;
+if (!INK_ADMIN_SECRET) throw new Error("INK_ADMIN_SECRET is not set");
 
 /** Build an Alan API URL. The INK_API_URL ends in /api; admin routes are /admin/*, api routes are /api/* */
 function getAlanUrl(path: string): string {

--- a/app/services/ink-api.server.ts
+++ b/app/services/ink-api.server.ts
@@ -1,7 +1,8 @@
 import { authenticate } from "../shopify.server";
 
 const INK_API_URL = process.env.INK_API_URL || "https://us-central1-inink-c76d3.cloudfunctions.net/api";
-const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET || "ink_admin_aeb5c9d6e822a4e57d95a6a2224aada64230e48d89acad5782057fcb865548a2";
+const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET;
+if (!INK_ADMIN_SECRET) throw new Error("INK_ADMIN_SECRET is not set");
 
 /**
  * Helper to construct the correct URL for Alan's API.

--- a/scripts/init_inventory.js
+++ b/scripts/init_inventory.js
@@ -2,7 +2,8 @@ import dotenv from "dotenv";
 dotenv.config();
 
 const INK_API_URL = process.env.INK_API_URL || "https://us-central1-inink-c76d3.cloudfunctions.net/api";
-const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET || "ink_admin_aeb5c9d6e822a4e57d95a6a2224aada64230e48d89acad5782057fcb865548a2";
+const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET;
+if (!INK_ADMIN_SECRET) { console.error("INK_ADMIN_SECRET is not set"); process.exit(1); }
 
 // Make configurable via ENV as requested
 const INITIAL_TAGS = parseInt(process.env.INITIAL_STICKER_INVENTORY || "100", 10);


### PR DESCRIPTION
## What

The INK admin secret (`X-Admin-Secret` for the INK `/admin/*` API) was hardcoded as a `|| "ink_admin_aeb5c9…"` fallback in 4 source files. This removes the literal and replaces each fallback with an env-required guard.

| File | Change |
| --- | --- |
| `app/services/ink-api.server.ts` | module-scope: `process.env.INK_ADMIN_SECRET` + `if (!INK_ADMIN_SECRET) throw` |
| `app/routes/app.api.settings.media.tsx` | module-scope: same guard |
| `app/routes/api.verify.tsx` | in-function (handler): same guard |
| `scripts/init_inventory.js` | Node: `process.env.INK_ADMIN_SECRET` + `if (!…) { console.error(…); process.exit(1); }` |

The `if (!INK_ADMIN_SECRET) throw` guard narrows the type back to `string`, so downstream `string` usage still typechecks with no changes needed.

## Safety / verification

- Removing the fallback is safe: `INK_ADMIN_SECRET` is already set as an env var on the live Cloud Run service.
- `git grep -n ink_admin_aeb5c9` returns nothing in tracked source after the change.
- `npx tsc --noEmit`: the only 2 reported errors (`app.api.settings.media.tsx` Object-possibly-undefined and `app.tsx` `verified_delivery_mode`) are **pre-existing on the base branch** — confirmed by running tsc on `rewrite/parallel-live-receipt-landing`. My 4 edited files introduce no new type errors.
- `api.return-status.tsx` was intentionally left untouched — it reads `process.env.INK_RETURN_WEBHOOK_SECRET || process.env.INK_ADMIN_SECRET` (env vars only, no hardcoded literal).

## Out of scope (separate operator steps)

- **Rotation** of the secret and a **git-history scrub** are NOT done here. This PR only removes the literal from current source. The secret value still exists in this repo's git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)