### PR TITLE
chore(shopify): rename app to "Récit in.ink" + npx deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "shopify app dev",
     "config:link": "shopify app config link",
     "generate": "shopify app generate",
-    "deploy": "shopify app deploy",
+    "deploy": "npx -y @shopify/cli app deploy",
     "config:use": "shopify app config use",
     "env": "shopify app env",
     "start": "react-router-serve ./build/server/index.js",

--- a/shopify.app.smusic.toml
+++ b/shopify.app.smusic.toml
@@ -1,7 +1,7 @@
 # Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "45cc130ef59cbeaf9133acea201981ed"
-name = "ink — Tap Pages"
+name = "Récit in.ink"
 application_url = "https://shopify-app-250065525755.us-central1.run.app"
 embedded = true
 

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -1,7 +1,7 @@
 # Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "8da1addef3dcd4251db5057cda3c85fa"
-name = "ink — Tap Pages"
+name = "Récit in.ink"
 application_url = "https://shopify-app-250065525755.us-central1.run.app"
 embedded = true
 


### PR DESCRIPTION
Renames the Shopify app **ink — Tap Pages → Récit in.ink** (both `.toml` configs; `client_id`s untouched). The rename is **already live** — released via `shopify app deploy` as version `recit-in-ink-6` — so this PR just records it in git.

Also fixes the `deploy` script to run the Shopify CLI via `npx -y @shopify/cli` (the bare `shopify` bin was never installed → the earlier `shopify: command not found`).

⚠️ Merging to `main` triggers the Cloud Run server redeploy (these paths are not in the CI ignore list). No functional change — same server code. The app rename does NOT depend on this merge.