### PR TITLE
chore(approval): unify Admin API version on 2025-10

### DIFF
--- a/app/routes/api.enroll.tsx
+++ b/app/routes/api.enroll.tsx
@@ -60,7 +60,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     // Create admin client helper for Shopify API calls
     const admin = {
       graphql: async (query: string, options?: any) => {
-        const response = await fetch(`https://${session.shop}/admin/api/2024-10/graphql.json`, {
+        const response = await fetch(`https://${session.shop}/admin/api/2025-10/graphql.json`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/app/routes/api.jobs.notifications.tsx
+++ b/app/routes/api.jobs.notifications.tsx
@@ -83,7 +83,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     `;
 
     try {
-      const response = await fetch(`https://${session.shop}/admin/api/2024-10/graphql.json`, {
+      const response = await fetch(`https://${session.shop}/admin/api/2025-10/graphql.json`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -168,7 +168,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
                   metafieldsSet(metafields: $metafields) { userErrors { message } }
                 }
               `;
-              await fetch(`https://${session.shop}/admin/api/2024-10/graphql.json`, {
+              await fetch(`https://${session.shop}/admin/api/2025-10/graphql.json`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json", "X-Shopify-Access-Token": session.accessToken },
                 body: JSON.stringify({

--- a/app/routes/api.orders.fetch.tsx
+++ b/app/routes/api.orders.fetch.tsx
@@ -84,7 +84,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     // Create admin client helper for Shopify API calls
     const admin = {
       graphql: async (query: string, options?: any) => {
-        const response = await fetch(`https://${session.shop}/admin/api/2024-10/graphql.json`, {
+        const response = await fetch(`https://${session.shop}/admin/api/2025-10/graphql.json`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/app/routes/api.photos.upload.tsx
+++ b/app/routes/api.photos.upload.tsx
@@ -189,7 +189,7 @@ async function createAdminClient(session: any): Promise<any> {
   // Using 'any' type to bypass strict type checking for the custom implementation
   return {
     graphql: async (query: string, options?: any) => {
-      const response = await fetch(`https://${session.shop}/admin/api/2024-10/graphql.json`, {
+      const response = await fetch(`https://${session.shop}/admin/api/2025-10/graphql.json`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/app/routes/api.return-status.tsx
+++ b/app/routes/api.return-status.tsx
@@ -114,7 +114,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   const adminGraphql = async (query: string, variables: unknown) => {
     const resp = await fetch(
-      `https://${session.shop}/admin/api/2024-10/graphql.json`,
+      `https://${session.shop}/admin/api/2025-10/graphql.json`,
       {
         method: "POST",
         headers: {

--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -370,7 +370,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                     if (!sess.accessToken) continue;
 
                     const adminGraphql = async (query: string, variables?: any) => {
-                        const response = await fetch(`https://${sess.shop}/admin/api/2024-10/graphql.json`, {
+                        const response = await fetch(`https://${sess.shop}/admin/api/2025-10/graphql.json`, {
                             method: "POST",
                             headers: {
                                 "Content-Type": "application/json",
@@ -410,7 +410,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                 const orderGid = foundOrderGid;
 
                 const adminGraphql = async (query: string, variables?: any) => {
-                    const response = await fetch(`https://${session.shop}/admin/api/2024-10/graphql.json`, {
+                    const response = await fetch(`https://${session.shop}/admin/api/2025-10/graphql.json`, {
                         method: "POST",
                         headers: {
                             "Content-Type": "application/json",
@@ -537,7 +537,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                 
                 // Create admin GraphQL helper
                 const adminGraphql = async (query: string, variables?: any) => {
-                    const response = await fetch(`https://${session.shop}/admin/api/2024-10/graphql.json`, {
+                    const response = await fetch(`https://${session.shop}/admin/api/2025-10/graphql.json`, {
                         method: "POST",
                         headers: {
                             "Content-Type": "application/json",

--- a/app/routes/app.api.dashboard.metrics.tsx
+++ b/app/routes/app.api.dashboard.metrics.tsx
@@ -93,7 +93,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
       graphqlClient = {
         graphql: async (query: string, options?: any) => {
-          const response = await fetch(`https://${session.shop}/admin/api/2024-10/graphql.json`, {
+          const response = await fetch(`https://${session.shop}/admin/api/2025-10/graphql.json`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",

--- a/app/routes/app.api.orders.tsx
+++ b/app/routes/app.api.orders.tsx
@@ -127,7 +127,7 @@ async function queryShopifyOrders(shopDomain: string, accessToken: string, searc
     }
   `;
 
-  const response = await fetch(`https://${shopDomain}/admin/api/2024-10/graphql.json`, {
+  const response = await fetch(`https://${shopDomain}/admin/api/2025-10/graphql.json`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/app/routes/app.api.warehouse.enroll.tsx
+++ b/app/routes/app.api.warehouse.enroll.tsx
@@ -256,7 +256,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       const session = await getOfflineSession(effectiveShopDomain);
       if (session) {
         const adminGraphql = async (query: string, variables?: any) => {
-          const response = await fetch(`https://${session.shop}/admin/api/2024-10/graphql.json`, {
+          const response = await fetch(`https://${session.shop}/admin/api/2025-10/graphql.json`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
@@ -412,7 +412,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     
     if (session) {
         const adminGraphql = async (query: string, variables?: any) => {
-            const response = await fetch(`https://${session.shop}/admin/api/2024-10/graphql.json`, {
+            const response = await fetch(`https://${session.shop}/admin/api/2025-10/graphql.json`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/app/routes/ink.update.tsx
+++ b/app/routes/ink.update.tsx
@@ -133,7 +133,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     console.log(`🔍 Attempting to locate order (Raw ID: ${rawOrderId}, Proof ID: ${proof_ref || 'None'})`);
 
     const adminGraphqlForSession = async (session: any, query: string, variables?: any) => {
-      const response = await fetch(`https://${session.shop}/admin/api/2024-10/graphql.json`, {
+      const response = await fetch(`https://${session.shop}/admin/api/2025-10/graphql.json`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -225,7 +225,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
       // Re-create the adminGraphql wrapper for the correct target session so the rest of the code works
       const adminGraphql = async (query: string, variables?: any) => {
-        const response = await fetch(`https://${targetSession.shop}/admin/api/2024-10/graphql.json`, {
+        const response = await fetch(`https://${targetSession.shop}/admin/api/2025-10/graphql.json`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/app/routes/webhooks.nfs.verify.tsx
+++ b/app/routes/webhooks.nfs.verify.tsx
@@ -60,7 +60,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     // Create admin client with graphql method
     const client = {
       request: async (query: string, options?: any) => {
-        const response = await fetch(`https://${session.shop}/admin/api/2024-10/graphql.json`, {
+        const response = await fetch(`https://${session.shop}/admin/api/2025-10/graphql.json`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -9,7 +9,7 @@ embedded = true
 automatically_update_urls_on_dev = true
 
 [webhooks]
-api_version = "2024-10"
+api_version = "2025-10"
 
   [[webhooks.subscriptions]]
   topics = [ "app/uninstalled" ]


### PR DESCRIPTION
## What
Brings the **whole app onto one current Admin API version (2025-10)** ahead of Shopify app review. Today it's split:
- official client (`shopify.server.ts`) → **2025-10** (`ApiVersion.October25`) ✓
- `shopify.app.smusic.toml` → **2025-10** ✓
- `shopify.app.toml` webhook `api_version` → **2024-10** ✗
- **16 raw `/admin/api/2024-10/graphql.json` fetch URLs** across 11 route files → **2024-10** ✗

This bumps the toml + all 16 URLs to **2025-10**, matching the client.

## Why
Shopify app review flags aging / soon-deprecated API versions, and a single source of truth avoids exactly this drift. 2025-10 is the version the official client already runs in prod, so this aligns the lagging raw calls to it.

## Changes
- `shopify.app.toml`: webhooks `api_version` 2024-10 → 2025-10
- 16 hardcoded Admin GraphQL URLs → 2025-10 across: `api.verify` (×3), `api.jobs.notifications` (×2), `app.api.warehouse.enroll` (×2), `ink.update` (×2), `api.enroll`, `api.orders.fetch`, `api.photos.upload`, `api.return-status`, `app.api.dashboard.metrics`, `app.api.orders`, `webhooks.nfs.verify`

## Verification
- No query text changed — these are standard order / fulfillment / metafield ops the official 2025-10 client already runs successfully.
- `tsc --noEmit` clean (string-literal-only edits).
- ⚠️ **Worth a quick smoke test on a real store before merge** — these are live Admin GraphQL calls now on 2025-10. Low risk (standard queries), but I can't exercise them against a live shop from here.

## Not deployed
The Shopify app deploys manually (`shopify app deploy`), so this waits on your go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)