### PR TITLE
feat(delivery): source delivered_at from Shopify's carrier DELIVERED event

### DIFF
--- a/app/routes/webhooks.fulfillments_update.tsx
+++ b/app/routes/webhooks.fulfillments_update.tsx
@@ -1,6 +1,7 @@
 import type { ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import { NotificationService } from "../services/notifications.server";
+import { NFSService } from "../services/nfs.server";
 import firestore from "../firestore.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
@@ -65,20 +66,54 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       return new Response("OK", { status: 200 });
     }
 
-    // 2. Fetch Merchant Notification Settings from Firestore
-    console.log(`📦 Fetching Merchant Settings for ${shop}...`);
-    const settingsSnap = await firestore.collection("merchants").where("shopDomain", "==", shop).limit(1).get();
-    
-    if (settingsSnap.empty) {
+    // 2. Fetch the Merchant doc (ink_api_key + notification settings) from Firestore
+    console.log(`📦 Fetching Merchant for ${shop}...`);
+    const merchantSnap = await firestore.collection("merchants").where("shopDomain", "==", shop).limit(1).get();
+
+    if (merchantSnap.empty) {
       console.log(`⚠️ No merchant document found for ${shop}. Exiting.`);
       return new Response("OK", { status: 200 });
     }
 
-    const settings = settingsSnap.docs[0].data().notification_settings;
-    const merchantName = settingsSnap.docs[0].data().shopName || shop;
+    const merchantDoc = merchantSnap.docs[0].data();
+    const merchantApiKey: string | null = merchantDoc.ink_api_key || null;
+    const settings = merchantDoc.notification_settings;
+    const merchantName = merchantDoc.shopName || shop;
+    const proofReference: string | null = order.proofMetafield?.value || null;
+
+    // 2a. SOURCE OF TRUTH for delivery. When Shopify's carrier tracking reports
+    //     shipment_status === "delivered", stamp delivered_at on the proof. This
+    //     replaces the premature stamp that orders/fulfilled (ship time) used to
+    //     do. The return window starts here, sourced from Shopify (which already
+    //     aggregates every carrier). markProofDelivered is idempotent
+    //     (first-write-wins), so a later Shippo-tracker event is a safe no-op.
+    if (shipmentStatus === "delivered" && proofReference && merchantApiKey) {
+      try {
+        const deliveredAt = fulfillment.updated_at || new Date().toISOString();
+        const carrier = fulfillment.tracking_company || undefined;
+        const trackingNumber =
+          fulfillment.tracking_number || fulfillment.tracking_numbers?.[0] || undefined;
+        const trackingUrl =
+          fulfillment.tracking_url || fulfillment.tracking_urls?.[0] || undefined;
+
+        await NFSService.markDelivered(proofReference, merchantApiKey, {
+          delivered_at: deliveredAt,
+          carrier,
+          tracking_number: trackingNumber,
+          tracking_url: trackingUrl,
+        });
+        console.log(`✅ delivered_at stamped from Shopify DELIVERED for proof ${proofReference}`);
+      } catch (deliveryErr: any) {
+        // Best-effort: a delivery-mark failure must not block notifications or
+        // cause Shopify to retry the whole webhook.
+        console.error(`❌ Failed to stamp delivered_at for ${proofReference}:`, deliveryErr.message);
+      }
+    } else if (shipmentStatus === "delivered" && proofReference && !merchantApiKey) {
+      console.log(`⚠️ DELIVERED for ${shop} but no ink_api_key on merchant — cannot stamp delivered_at.`);
+    }
 
     if (!settings) {
-      console.log(`⚠️ Merchant has no Notification Settings configured. Exiting.`);
+      console.log(`ℹ️ Merchant has no Notification Settings configured. Delivery handled; skipping notification.`);
       return new Response("OK", { status: 200 });
     }
 

--- a/app/routes/webhooks.orders_fulfilled.tsx
+++ b/app/routes/webhooks.orders_fulfilled.tsx
@@ -1,93 +1,27 @@
 import type { ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
-import { NFSService } from "../services/nfs.server";
-import firestore from "../firestore.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-  const { payload, shop, topic, admin } = await authenticate.webhook(request);
+  const { payload, shop, topic } = await authenticate.webhook(request);
 
-  if (!admin) {
-    return new Response("Unauthorized", { status: 401 });
-  }
-
-  // Payload for orders/fulfilled webhook is an Order object.
-  const orderId = payload.id;
-  
-  if (!orderId) {
-    console.error(`[${topic}] No order payload found.`);
-    return new Response("Bad Request", { status: 400 });
-  }
-
-  const orderGid = `gid://shopify/Order/${orderId}`;
-  
-  console.log(`[${topic}] Webhook triggered for shop: ${shop}, orderGid: ${orderGid}`);
-
-  // Fetch the proof_reference metafield to see if this order was enrolled in INK
-  try {
-    // 1. Look up the merchant's ink_api_key from Firestore using the shop domain.
-    //    The API spec requires Bearer <api_key> for PATCH /api/proofs/:proof_id/delivered.
-    let merchantApiKey: string | null = null;
-    const merchantSnap = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shop)
-      .limit(1)
-      .get();
-
-    if (!merchantSnap.empty) {
-      merchantApiKey = merchantSnap.docs[0].data()?.ink_api_key || null;
-    }
-
-    if (!merchantApiKey) {
-      console.error(`[${topic}] No ink_api_key found in Firestore for shop: ${shop}. Cannot mark delivered.`);
-      return new Response("Merchant API key not found", { status: 500 });
-    }
-    console.log(`[${topic}] Found ink_api_key for ${shop} (prefix: ${merchantApiKey.slice(0, 12)}...)`);
-
-    // 2. Fetch the proof_reference metafield from Shopify via GraphQL
-    const response = await admin.graphql(`
-      query GetOrderMetafield($id: ID!) {
-        order(id: $id) {
-          name
-          updatedAt
-          metafield(namespace: "ink", key: "proof_reference") {
-            value
-          }
-        }
-      }
-    `, {
-      variables: {
-        id: orderGid
-      }
-    });
-
-    const body = await response.json();
-    const proofReference = body.data?.order?.metafield?.value;
-    const fulfilledAt = payload.updated_at || body.data?.order?.updatedAt || new Date().toISOString();
-    
-    // Find carrier info from Shopify fulfillment if available
-    let carrier: string | undefined;
-    if (payload.fulfillments && payload.fulfillments.length > 0) {
-      carrier = payload.fulfillments[0].tracking_company || undefined;
-    }
-
-    if (proofReference) {
-      console.log(`[${topic}] Found proof_reference: ${proofReference} for order ${orderGid}. Marking as delivered.`);
-      
-      // 3. Call Alan's API with the merchant's Bearer token (not the admin secret)
-      await NFSService.markDelivered(proofReference, merchantApiKey, {
-        delivered_at: fulfilledAt,
-        carrier,
-      });
-
-      console.log(`[${topic}] ✅ Successfully pushed delivery state to Alan's backend for proof: ${proofReference}`);
-    } else {
-      console.log(`[${topic}] Order ${orderGid} has no INK proof_reference metafield. Skipping (not an INK order).`);
-    }
-
-  } catch (error) {
-    console.error(`[${topic}] Error processing fulfilled webhook:`, error);
-    return new Response("Internal Server Error", { status: 500 });
-  }
+  // orders/fulfilled fires when the merchant SHIPS the order — not when the
+  // carrier delivers it. It used to stamp proof.delivered_at here, which started
+  // the return window at ship time (too early) and, because markProofDelivered is
+  // first-write-wins, prevented the real carrier-delivered signal from ever
+  // setting delivered_at.
+  //
+  // Delivery is now sourced from `fulfillments/update` with
+  // shipment_status === "delivered" (Shopify's carrier-aggregated delivery
+  // event). See webhooks.fulfillments_update.tsx. Shippo tracking remains a
+  // non-Shopify fallback, and PATCH /proofs/:id/delivered is still the manual
+  // trigger for demos / carriers that don't report tracking to Shopify.
+  //
+  // This handler is intentionally inert for the delivery state machine; it only
+  // acknowledges the fulfillment so Shopify stops retrying.
+  console.log(
+    `[${topic}] Order ${payload?.id ?? "?"} fulfilled (shipped) for ${shop}. ` +
+      `delivered_at is NOT set here — awaiting fulfillments/update DELIVERED.`,
+  );
 
   return new Response("OK", { status: 200 });
 };

--- a/app/services/nfs.server.ts
+++ b/app/services/nfs.server.ts
@@ -178,9 +178,14 @@ export const NFSService = {
   /**
    * Marks a proof as delivered via Alan's backend API.
    * Requires the merchant's ink_api_key (Bearer token) per API spec v1.2+.
-   * Called automatically from the orders/fulfilled Shopify webhook.
+   * Called from the fulfillments/update webhook on shipment_status === "delivered".
+   * carrier/tracking are optional and persisted onto the proof when present.
    */
-  async markDelivered(proofId: string, apiKey: string, payload: { delivered_at: string; carrier?: string }): Promise<any> {
+  async markDelivered(
+    proofId: string,
+    apiKey: string,
+    payload: { delivered_at: string; carrier?: string; tracking_number?: string; tracking_url?: string },
+  ): Promise<any> {
     console.log(`📦 Marking delivery for proof ${proofId}:`, payload);
 
     const response = await fetch(`${NFS_API_URL}/api/proofs/${proofId}/delivered`, {

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -27,6 +27,17 @@ api_version = "2025-10"
   topics = [ "orders/fulfilled" ]
   uri = "/webhooks/orders_fulfilled"
 
+  # Carrier delivery signal. fulfillments/update carries shipment_status, which
+  # flips to "delivered" when Shopify's carrier tracking reports delivery. This —
+  # NOT orders/fulfilled (which fires at ship time) — is the source of delivered_at.
+  [[webhooks.subscriptions]]
+  topics = [ "fulfillments/create" ]
+  uri = "/webhooks/fulfillments_create"
+
+  [[webhooks.subscriptions]]
+  topics = [ "fulfillments/update" ]
+  uri = "/webhooks/fulfillments_update"
+
 
 
 [access_scopes]


### PR DESCRIPTION
**Phase 1 of the Shopify-deep returns flip** — make Shopify the source of truth for delivery so the return window starts at *actual delivery*, not ship time.

> ⚠️ Merging auto-deploys to Cloud Run (CI `749b2b7`). Prod deploy = gated on Sam.

## The bug this fixes
`orders/fulfilled` fires at **ship time** and was stamping `proof.delivered_at` there. Because `markProofDelivered` is first-write-wins, that (a) started the return window too early and (b) blocked the real carrier-delivered signal from ever setting `delivered_at`.

## Changes
- **Subscribe** `fulfillments/create` + `fulfillments/update` (the carrier delivery signal).
- **`orders/fulfilled`** no longer stamps `delivered_at` — it's now inert for the delivery state machine and just acknowledges the fulfillment (ship event).
- **`fulfillments/update`** is the source of truth: on `shipment_status === "delivered"` it calls `PATCH /proofs/:id/delivered` with `delivered_at` (`fulfillment.updated_at`) + `carrier` + `tracking_number` + `tracking_url`. Delivery marking is independent of notification settings.
- **`nfs.server` `markDelivered`** forwards `tracking_number` + `tracking_url`.

## Spine untouched
Same `delivered_at` → ENROLLED→ACTIVE/NEUTERED window; `carrier` stays a plain string. Shippo tracking remains a non-Shopify fallback; `PATCH /proofs/:id/delivered` is still the manual demo trigger.

## Notes
- Edits **only** the production app toml (`8da1`). `shopify.app.smusic.toml` is a separate dev app (`45cc`) — left as-is; sync separately if used.
- **Demo change:** "fulfill order in admin" no longer flips delivered. Use the manual `PATCH /proofs/:id/delivered` trigger, or a real/simulated carrier DELIVERED event.

## Pairs with
`ink-backend#11` (persists carrier + tracking on the proof + signed custody event; deploy locally).

## Test
`npm run typecheck` clean. Live smoke (gated): order → fulfill → real delivery → `proof.delivered_at` flips from Shopify DELIVERED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)