### PR TITLE
refactor(embed): keep crypto/forensics OUT of the embed order views

### DIFF
--- a/app/components/OrderDetailView.tsx
+++ b/app/components/OrderDetailView.tsx
@@ -1,5 +1,3 @@
-import { useState, useEffect } from "react";
-import { Copy } from "lucide-react";
 import { useRouteLoaderData } from "react-router";
 import {
   Page,
@@ -10,9 +8,6 @@ import {
   InlineStack,
   Badge,
   Divider,
-  Thumbnail,
-  Button,
-  Modal,
 } from "@shopify/polaris";
 import type { BadgeProps } from "@shopify/polaris";
 
@@ -69,12 +64,12 @@ const statusBadgeTone = (s: string): BadgeProps["tone"] => {
   return undefined;
 };
 
+// The Shopify embed stays lean: order essentials + a handoff. The full delivery
+// proof — tap history, location, signed cryptographic record — lives in the
+// standalone ink. dashboard (its Advanced drawer), never here. Keeping the crypto
+// out of the embed is deliberate (engagement-led surface, not a forensics console).
 export default function OrderDetailView({ order, onBack }: OrderDetailViewProps) {
-  const [activeTab, setActiveTab] = useState<"write" | "tap">("write");
-  const [copiedField, setCopiedField] = useState<string | null>(null);
-  const [lightboxImage, setLightboxImage] = useState<string | null>(null);
-
-  // Get shop slug for "View in Shopify" link
+  // Shop slug for the "View in Shopify" link.
   const settingsData = useRouteLoaderData("routes/app.settings") as any;
   const shopUrlSlug = (() => {
     if (settingsData?.shopDomain) {
@@ -89,517 +84,136 @@ export default function OrderDetailView({ order, onBack }: OrderDetailViewProps)
     }
   })();
 
-  const copyToClipboard = (text: string, field: string) => {
-    navigator.clipboard.writeText(text).catch(() => {});
-    setCopiedField(field);
-    setTimeout(() => setCopiedField(null), 1500);
-  };
-
-  const hasTapData = order.status === "verified" || order.status === "expired";
-  const nfcUid = order.metafields.nfc_uid || "—";
-  const proofId = order.metafields.proof_reference || "—";
-
-  // Parse warehouse GPS
-  let warehouseCoords = "—";
-  if (order.metafields.warehouse_gps) {
-    try {
-      const gps = JSON.parse(order.metafields.warehouse_gps);
-      warehouseCoords = `${gps.lat}, ${gps.lng}`;
-    } catch {
-      warehouseCoords = order.metafields.warehouse_gps;
-    }
-  }
-
-  // Parse delivery GPS
-  let deliveryCoords = "";
-  let deliveryDistance = "";
-  if (order.metafields.delivery_gps) {
-    try {
-      const gps = JSON.parse(order.metafields.delivery_gps);
-      deliveryCoords = `${gps.lat}, ${gps.lng}`;
-      deliveryDistance = gps.distance || "";
-    } catch {
-      deliveryCoords = order.metafields.delivery_gps;
-    }
-  }
-
-  const deliveryVerifiedAt = order.metafields.delivery_verified_at || "";
-  const deviceInfo = order.metafields.device_info || "";
-  const verifyUrl = order.metafields.verify_url || "";
-  const gpsVerdict = order.metafields.gps_verdict || "";
-  // Only show a meaningful verdict badge — hide when genuinely unknown
-  const showGpsVerdictBadge = gpsVerdict && gpsVerdict.toLowerCase() !== "unknown";
-
   const statusRaw = order.status?.toLowerCase() || "pending";
   const statusLabel = statusRaw.charAt(0).toUpperCase() + statusRaw.slice(1);
-
-  const addressLabel = order.customerAddress
-    ? `${order.customerAddress.city}, ${order.customerAddress.provinceCode} ${order.customerAddress.zip}`
-    : "";
-  // Keep for customer card only — do NOT show in Tap Location map
-  const _ = addressLabel; // suppress unused warning
-
-
-  const tabItems = [
-    { id: "write" as const, content: "Write" },
-    { id: "tap" as const, content: "Tap" },
-  ];
+  const deliveredAt = order.metafields.delivery_verified_at || "";
 
   return (
-    <>
-      <Page
-        title={order.orderNumber}
-        titleMetadata={
-          <Badge tone={statusBadgeTone(statusRaw)}>{statusLabel}</Badge>
-        }
-        subtitle={order.date}
-        backAction={{ content: "Shipments", onAction: onBack }}
-        secondaryActions={[
-          {
-            content: "View in Shopify",
-            external: true,
-            url: `https://admin.shopify.com/store/${shopUrlSlug}/orders/${order.id}`,
-          },
-        ]}
-      >
-        <Layout>
-          {/* Left column: Customer + Products */}
-          <Layout.Section variant="oneThird">
-            <BlockStack gap="400">
-              {/* Customer */}
-              <Card>
-                <BlockStack gap="300">
-                  <Text as="h3" variant="headingSm">Customer</Text>
-                  <Text as="p" variant="bodyMd" fontWeight="medium">
-                    {order.customerName}
-                  </Text>
-                  <Text as="p" variant="bodySm" tone="subdued">
-                    {order.customerEmail || "No email"}
-                  </Text>
-                  {order.customerAddress && (
-                    <>
-                      <Divider />
-                      <Text as="p" variant="bodySm" tone="subdued">
-                        {order.customerAddress.address1}<br />
-                        {order.customerAddress.city},{" "}
-                        {order.customerAddress.provinceCode}{" "}
-                        {order.customerAddress.zip}
-                      </Text>
-                    </>
-                  )}
-                </BlockStack>
-              </Card>
+    <Page
+      title={order.orderNumber}
+      titleMetadata={<Badge tone={statusBadgeTone(statusRaw)}>{statusLabel}</Badge>}
+      subtitle={order.date}
+      backAction={{ content: "Shipments", onAction: onBack }}
+      secondaryActions={[
+        {
+          content: "View in Shopify",
+          external: true,
+          url: `https://admin.shopify.com/store/${shopUrlSlug}/orders/${order.id}`,
+        },
+      ]}
+    >
+      <Layout>
+        {/* Left column: Customer + Products */}
+        <Layout.Section variant="oneThird">
+          <BlockStack gap="400">
+            <Card>
+              <BlockStack gap="300">
+                <Text as="h3" variant="headingSm">
+                  Customer
+                </Text>
+                <Text as="p" variant="bodyMd" fontWeight="medium">
+                  {order.customerName}
+                </Text>
+                <Text as="p" variant="bodySm" tone="subdued">
+                  {order.customerEmail || "No email"}
+                </Text>
+                {order.customerAddress && (
+                  <>
+                    <Divider />
+                    <Text as="p" variant="bodySm" tone="subdued">
+                      {order.customerAddress.address1}
+                      <br />
+                      {order.customerAddress.city}, {order.customerAddress.provinceCode}{" "}
+                      {order.customerAddress.zip}
+                    </Text>
+                  </>
+                )}
+              </BlockStack>
+            </Card>
 
-              {/* Products */}
-              <Card>
-                <BlockStack gap="300">
-                  <Text as="h3" variant="headingSm">Products</Text>
-                  {order.items.map((item, idx) => (
-                    <InlineStack key={idx} align="space-between" blockAlign="start">
-                      <BlockStack gap="0">
-                        <Text as="p" variant="bodySm" fontWeight="medium">
-                          {item.title}
-                        </Text>
-                        <Text as="p" variant="bodySm" tone="subdued">
-                          {item.sku ? `${item.sku} × ` : ""}
-                          {item.quantity}
-                        </Text>
-                      </BlockStack>
+            <Card>
+              <BlockStack gap="300">
+                <Text as="h3" variant="headingSm">
+                  Products
+                </Text>
+                {order.items.map((item, idx) => (
+                  <InlineStack key={idx} align="space-between" blockAlign="start">
+                    <BlockStack gap="0">
                       <Text as="p" variant="bodySm" fontWeight="medium">
-                        {fmt(parseFloat(item.price) * item.quantity, order.currency)}
+                        {item.title}
                       </Text>
-                    </InlineStack>
-                  ))}
-                  <Divider />
-                  <InlineStack align="space-between">
-                    <Text as="span" tone="subdued" variant="bodySm">Subtotal</Text>
-                    <Text as="span" variant="bodySm">{fmt(order.subtotal, order.currency)}</Text>
-                  </InlineStack>
-                  <InlineStack align="space-between">
-                    <Text as="span" tone="subdued" variant="bodySm">Shipping</Text>
-                    <Text as="span" variant="bodySm">Free</Text>
-                  </InlineStack>
-                  <Divider />
-                  <InlineStack align="space-between">
-                    <Text as="span" variant="bodySm" fontWeight="semibold">Total</Text>
-                    <Text as="span" variant="bodySm" fontWeight="semibold">
-                      {fmt(order.total, order.currency)}
+                      <Text as="p" variant="bodySm" tone="subdued">
+                        {item.sku ? `${item.sku} × ` : ""}
+                        {item.quantity}
+                      </Text>
+                    </BlockStack>
+                    <Text as="p" variant="bodySm" fontWeight="medium">
+                      {fmt(parseFloat(item.price) * item.quantity, order.currency)}
                     </Text>
                   </InlineStack>
-                </BlockStack>
-              </Card>
+                ))}
+                <Divider />
+                <InlineStack align="space-between">
+                  <Text as="span" tone="subdued" variant="bodySm">
+                    Subtotal
+                  </Text>
+                  <Text as="span" variant="bodySm">
+                    {fmt(order.subtotal, order.currency)}
+                  </Text>
+                </InlineStack>
+                <InlineStack align="space-between">
+                  <Text as="span" tone="subdued" variant="bodySm">
+                    Shipping
+                  </Text>
+                  <Text as="span" variant="bodySm">
+                    Free
+                  </Text>
+                </InlineStack>
+                <Divider />
+                <InlineStack align="space-between">
+                  <Text as="span" variant="bodySm" fontWeight="semibold">
+                    Total
+                  </Text>
+                  <Text as="span" variant="bodySm" fontWeight="semibold">
+                    {fmt(order.total, order.currency)}
+                  </Text>
+                </InlineStack>
+              </BlockStack>
+            </Card>
+          </BlockStack>
+        </Layout.Section>
+
+        {/* Right column: delivery status + handoff (no forensics in the embed) */}
+        <Layout.Section>
+          <Card>
+            <BlockStack gap="300">
+              <Text as="h3" variant="headingSm">
+                Delivery
+              </Text>
+              {deliveredAt ? (
+                <InlineStack align="space-between">
+                  <Text as="span" tone="subdued" variant="bodySm">
+                    Delivered
+                  </Text>
+                  <Text as="span" variant="bodySm">
+                    {deliveredAt}
+                  </Text>
+                </InlineStack>
+              ) : (
+                <Text as="p" variant="bodySm" tone="subdued">
+                  No delivery recorded yet.
+                </Text>
+              )}
+              <Divider />
+              <Text as="p" variant="bodySm" tone="subdued">
+                The full delivery record — tap history, location, and the signed
+                cryptographic proof — lives in your ink. dashboard. Open it from the
+                Dashboard.
+              </Text>
             </BlockStack>
-          </Layout.Section>
-
-          {/* Right column: Events (Write / Tap) */}
-          <Layout.Section>
-            <div style={{ border: "1px solid var(--p-color-border)" }}>
-              {/* Folder-style tab bar */}
-              <div style={{
-                display: "flex",
-                alignItems: "flex-end",
-                background: "var(--p-color-bg-surface-secondary)",
-                padding: "0 16px",
-              }}>
-                <div style={{ display: "flex", alignItems: "flex-end", paddingTop: "8px" }}>
-                  {tabItems.map((tab) => (
-                    <button
-                      key={tab.id}
-                      onClick={() => setActiveTab(tab.id)}
-                      style={{
-                        padding: "8px 16px",
-                        fontSize: "13px",
-                        fontWeight: 500,
-                        cursor: "pointer",
-                        border: "1px solid var(--p-color-border)",
-                        borderBottom:
-                          activeTab === tab.id
-                            ? "1px solid var(--p-color-bg-surface)"
-                            : "1px solid var(--p-color-border)",
-                        background:
-                          activeTab === tab.id
-                            ? "var(--p-color-bg-surface)"
-                            : "transparent",
-                        color:
-                          activeTab === tab.id
-                            ? "var(--p-color-text)"
-                            : "var(--p-color-text-secondary)",
-                        marginBottom: "-1px",
-                        borderRadius: "0",
-                        position: "relative",
-                        zIndex: activeTab === tab.id ? 2 : 1,
-                      }}
-                    >
-                      {tab.content}
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div style={{ borderTop: "1px solid var(--p-color-border)" }} />
-
-              {/* Tab content */}
-              <div style={{ padding: "16px", background: "var(--p-color-bg-surface)" }}>
-
-                {/* ── WRITE TAB ── */}
-                {activeTab === "write" && (
-                  <BlockStack gap="400">
-                    {/* NFC UID + Proof ID */}
-                    <InlineStack gap="400" wrap={false}>
-                      <div style={{ flex: 1, background: "var(--p-color-bg-surface-secondary)", padding: "12px", borderRadius: "8px" }}>
-                        <Text as="p" tone="subdued" variant="bodySm">NFC Tag UID</Text>
-                        <Text as="p" variant="bodySm" fontWeight="medium">
-                          <code style={{ fontFamily: "monospace" }}>{nfcUid}</code>
-                        </Text>
-                      </div>
-                      <div style={{ flex: 1, background: "var(--p-color-bg-surface-secondary)", padding: "12px", borderRadius: "8px" }}>
-                        <Text as="p" tone="subdued" variant="bodySm">Proof ID</Text>
-                        <InlineStack gap="200" blockAlign="center">
-                          <Text as="p" variant="bodySm" fontWeight="medium">
-                            <code style={{ fontFamily: "monospace" }}>{proofId}</code>
-                          </Text>
-                          {proofId !== "—" && (
-                            <button
-                              onClick={() => copyToClipboard(proofId, "proofId")}
-                              style={{ background: "none", border: "none", cursor: "pointer", padding: "2px" }}
-                              aria-label="Copy Proof ID"
-                            >
-                              <Copy size={14} />
-                            </button>
-                          )}
-                          {copiedField === "proofId" && (
-                            <Text as="span" variant="bodySm" tone="success">Copied!</Text>
-                          )}
-                        </InlineStack>
-                      </div>
-                    </InlineStack>
-
-                    {/* Warehouse GPS */}
-                    {warehouseCoords !== "—" && (
-                      <div style={{ background: "var(--p-color-bg-surface-secondary)", padding: "16px", borderRadius: "8px" }}>
-                        <Text as="p" tone="subdued" variant="bodySm">Warehouse Location</Text>
-                        <Text as="p" variant="bodySm" fontWeight="medium">
-                          Distribution Center
-                        </Text>
-                        <InlineStack gap="200" blockAlign="center">
-                          <Text as="p" variant="bodySm" tone="subdued">
-                            <code style={{ fontFamily: "monospace", fontSize: "12px" }}>{warehouseCoords}</code>
-                          </Text>
-                          <a
-                            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(warehouseCoords)}`}
-                            target="_blank"
-                            rel="noreferrer"
-                            style={{ fontSize: "12px", color: "var(--p-color-text-interactive)" }}
-                          >
-                            View Map
-                          </a>
-                        </InlineStack>
-                      </div>
-                    )}
-
-                    {/* Package Photos */}
-                    <PackagePhotos
-                      proofId={proofId}
-                      nfcTagUid={nfcUid}
-                      onLightbox={setLightboxImage}
-                    />
-                  </BlockStack>
-                )}
-
-                {/* ── TAP TAB ── */}
-                {activeTab === "tap" && (
-                  hasTapData ? (
-                    <InlineStack gap="800" wrap={false} blockAlign="start">
-                      {/* Timeline */}
-                      <div style={{ flex: 1 }}>
-                        <BlockStack gap="400">
-                          <Text as="p" tone="subdued" variant="bodySm" fontWeight="medium">Timeline</Text>
-                          <BlockStack gap="300">
-                            {/* Tapped */}
-                            {deliveryVerifiedAt && (
-                              <InlineStack gap="300" blockAlign="start">
-                                <div style={{ width: 10, height: 10, borderRadius: "50%", background: "var(--p-color-text)", marginTop: 4, flexShrink: 0 }} />
-                                <BlockStack gap="100">
-                                  <Text as="p" variant="bodySm" fontWeight="medium">Tapped</Text>
-                                  <Text as="p" tone="subdued" variant="bodySm">{deliveryVerifiedAt}</Text>
-                                  {deviceInfo && (
-                                    <span style={{ fontSize: "10px", padding: "2px 6px", border: "1px solid var(--p-color-border)", borderRadius: "4px" }}>
-                                      {deviceInfo}
-                                    </span>
-                                  )}
-                                </BlockStack>
-                              </InlineStack>
-                            )}
-                            {/* Location */}
-                            {deliveryCoords && (
-                              <InlineStack gap="300" blockAlign="start">
-                                <div style={{ width: 10, height: 10, borderRadius: "50%", background: "var(--p-color-text)", marginTop: 4, flexShrink: 0 }} />
-                                <BlockStack gap="100">
-                                  <InlineStack gap="200" blockAlign="center">
-                                    <Text as="p" variant="bodySm" fontWeight="medium">Location verified</Text>
-                                    {showGpsVerdictBadge && (
-                                      <span style={{
-                                        fontSize: "10px",
-                                        fontWeight: 700,
-                                        padding: "2px 6px",
-                                        borderRadius: "4px",
-                                        background: gpsVerdict.toLowerCase() === "match" ? "#dcfce7" : "#fee2e2",
-                                        color: gpsVerdict.toLowerCase() === "match" ? "#166534" : "#991b1b",
-                                      }}>
-                                        {gpsVerdict.toUpperCase()}
-                                      </span>
-                                    )}
-                                  </InlineStack>
-                                  {deliveryDistance && (
-                                    <Text as="p" tone="subdued" variant="bodySm">{deliveryDistance} from shipping address</Text>
-                                  )}
-                                  <Text as="p" tone="subdued" variant="bodySm">
-                                    <code style={{ fontFamily: "monospace", fontSize: "12px" }}>{deliveryCoords}</code>
-                                  </Text>
-                                </BlockStack>
-                              </InlineStack>
-                            )}
-                            {/* Confirmation */}
-                            <InlineStack gap="300" blockAlign="start">
-                              <div style={{ width: 10, height: 10, borderRadius: "50%", background: "var(--p-color-border)", marginTop: 4, flexShrink: 0 }} />
-                              <BlockStack gap="100">
-                                <Text as="p" variant="bodySm" fontWeight="medium">Confirmation sent</Text>
-                                <Text as="p" tone="subdued" variant="bodySm">
-                                  Delivery record sent to {order.customerEmail || "customer"}
-                                </Text>
-                                {verifyUrl && (
-                                  <a
-                                    href={verifyUrl}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    style={{
-                                      display: "inline-flex",
-                                      alignItems: "center",
-                                      gap: "4px",
-                                      fontSize: "12px",
-                                      padding: "4px 10px",
-                                      border: "1px solid var(--p-color-border)",
-                                      borderRadius: "4px",
-                                      color: "var(--p-color-text)",
-                                      textDecoration: "none",
-                                    }}
-                                  >
-                                    View Public Proof
-                                  </a>
-                                )}
-                              </BlockStack>
-                            </InlineStack>
-                          </BlockStack>
-                        </BlockStack>
-                      </div>
-
-                      {deliveryCoords && (
-                        <div style={{ flex: 1 }}>
-                          <BlockStack gap="200">
-                            <Text as="p" tone="subdued" variant="bodySm" fontWeight="medium">Tap Location</Text>
-                            <div style={{ background: "var(--p-color-bg-surface-secondary)", padding: "16px", borderRadius: "8px" }}>
-                              <TapLocationCity coords={deliveryCoords} />
-                              <Text as="p" variant="bodySm" tone="subdued">
-                                <code style={{ fontFamily: "monospace", fontSize: "12px" }}>{deliveryCoords}</code>
-                              </Text>
-                              {/* Embedded map */}
-                              <div style={{ marginTop: "8px", height: "128px", borderRadius: "4px", overflow: "hidden" }}>
-                                <iframe
-                                  width="100%"
-                                  height="100%"
-                                  style={{ border: 0 }}
-                                  src={`https://maps.google.com/maps?q=${encodeURIComponent(deliveryCoords)}&t=&z=15&ie=UTF8&iwloc=&output=embed`}
-                                  title="Delivery location"
-                                />
-                              </div>
-                              {deliveryDistance && (
-                                <Text as="p" variant="bodySm" tone="success">✓ {deliveryDistance} from address</Text>
-                              )}
-                              <a
-                                href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(deliveryCoords)}`}
-                                target="_blank"
-                                rel="noreferrer"
-                                style={{ fontSize: "12px", color: "var(--p-color-text-interactive)" }}
-                              >
-                                Open in Google Maps
-                              </a>
-                            </div>
-                          </BlockStack>
-                        </div>
-                      )}
-
-                    </InlineStack>
-                  ) : (
-                    <BlockStack gap="200" inlineAlign="center">
-                      <Text as="p" variant="bodySm" fontWeight="medium" tone="subdued">No tap has been recorded</Text>
-                      <Text as="p" variant="bodySm" tone="subdued">Waiting for customer to tap the NFC tag</Text>
-                    </BlockStack>
-                  )
-                )}
-              </div>
-            </div>
-          </Layout.Section>
-        </Layout>
-      </Page>
-
-      {/* Lightbox */}
-      <Modal open={!!lightboxImage} onClose={() => setLightboxImage(null)} title="Package Photo">
-        <Modal.Section>
-          {lightboxImage && (
-            <img
-              src={lightboxImage}
-              alt="Package photo"
-              style={{ width: "100%", maxHeight: "80vh", objectFit: "contain" }}
-            />
-          )}
-        </Modal.Section>
-      </Modal>
-    </>
-  );
-}
-
-// ─────────────────────────────────────────────
-// Package Photos sub-component
-// fetches from /api/retrieve/:id (same logic as before)
-// ─────────────────────────────────────────────
-function PackagePhotos({
-  proofId,
-  nfcTagUid,
-  onLightbox,
-}: {
-  proofId: string;
-  nfcTagUid?: string;
-  onLightbox: (url: string) => void;
-}) {
-  const [photos, setPhotos] = useState<string[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    // Prefer proofId (proof_...) over nfcTagUid for retrieval. Alan's
-    // /api/proofs/nfc/{uid} subpath is not implemented; the resolver in
-    // /api/retrieve handles proof_id-style lookups via chain_of_custody.
-    const lookupId =
-      proofId && proofId !== "—" ? proofId : nfcTagUid;
-
-    if (!lookupId || lookupId === "—") {
-      setLoading(false);
-      return;
-    }
-
-    fetch(`/api/retrieve/${lookupId}`)
-      .then((res) => res.json())
-      .then((data) => {
-        if (data?.media_items?.length > 0) {
-          setPhotos(data.media_items.map((m: any) => m.url));
-        }
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
-  }, [proofId]);
-
-  return (
-    <BlockStack gap="300">
-      <Text as="p" tone="subdued" variant="bodySm">Package Photos</Text>
-
-      {loading ? (
-        <div style={{ padding: "32px", textAlign: "center" }}>
-          <Text as="p" tone="subdued" variant="bodySm">Loading photos…</Text>
-        </div>
-      ) : photos.length > 0 ? (
-        <InlineStack gap="300">
-          {photos.map((url, i) => (
-            <button
-              key={i}
-              onClick={() => onLightbox(url)}
-              style={{ border: "1px solid var(--p-color-border)", borderRadius: "4px", overflow: "hidden", cursor: "pointer", background: "none", padding: 0 }}
-            >
-              <Thumbnail source={url} alt={`Package Proof ${i + 1}`} size="large" />
-            </button>
-          ))}
-        </InlineStack>
-      ) : (
-        <div style={{ background: "var(--p-color-bg-surface-secondary)", borderRadius: "8px", padding: "32px", textAlign: "center", border: "2px dashed var(--p-color-border)" }}>
-          <Text as="p" tone="subdued" variant="bodySm">No photos uploaded yet</Text>
-        </div>
-      )}
-    </BlockStack>
-  );
-}
-
-// ─────────────────────────────────────────────
-// TapLocationCity - reverse geocodes GPS coords
-// using OpenStreetMap Nominatim (free, no key needed)
-// ─────────────────────────────────────────────
-function TapLocationCity({ coords }: { coords: string }) {
-  const [city, setCity] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!coords) return;
-    const [lat, lng] = coords.split(",").map((s) => s.trim());
-    if (!lat || !lng) return;
-
-    fetch(
-      `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`,
-      { headers: { "Accept-Language": "en" } }
-    )
-      .then((r) => r.json())
-      .then((data) => {
-        const addr = data?.address;
-        if (!addr) return;
-        // Build a compact city label: "City, Country"
-        const cityName = addr.city || addr.town || addr.village || addr.county || addr.state_district || "";
-        const state = addr.state || "";
-        const country = addr.country_code?.toUpperCase() || addr.country || "";
-        const parts = [cityName, state, country].filter(Boolean);
-        setCity(parts.join(", "));
-      })
-      .catch(() => { /* silently ignore */ });
-  }, [coords]);
-
-  if (!city) return null;
-
-  return (
-    <Text as="p" variant="bodySm" fontWeight="medium">
-      {city}
-    </Text>
+          </Card>
+        </Layout.Section>
+      </Layout>
+    </Page>
   );
 }

--- a/app/components/OrderExpandedRow.tsx
+++ b/app/components/OrderExpandedRow.tsx
@@ -1,15 +1,5 @@
-import { useState, useEffect } from "react";
-import {
-  Badge,
-  BlockStack,
-  Box,
-  Button,
-  InlineStack,
-  Text,
-  Thumbnail,
-} from "@shopify/polaris";
+import { BlockStack, Box, Button, InlineStack, Text } from "@shopify/polaris";
 import { ExternalIcon } from "@shopify/polaris-icons";
-import TapLocationCard from "./TapLocationCard";
 
 interface OrderItem {
   title: string;
@@ -76,248 +66,84 @@ const formatTimestamp = (raw: string): string => {
   }
 };
 
-// ─────────────────────────────────────────────
-// PackagePhotosRow — fetches photos from /api/retrieve/:id
-// Same logic as PackagePhotos in OrderDetailView, compact display
-// ─────────────────────────────────────────────
-function PackagePhotosRow({ proofId }: { proofId: string }) {
-  const [photos, setPhotos] = useState<string[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [lightbox, setLightbox] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!proofId || proofId === "—") {
-      setLoading(false);
-      return;
-    }
-    fetch(`/api/retrieve/${proofId}`)
-      .then((r) => r.json())
-      .then((data) => {
-        if (data?.media_items?.length > 0) {
-          setPhotos(data.media_items.map((m: any) => m.url || m.media_url).filter(Boolean));
-        }
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
-  }, [proofId]);
-
-  return (
-    <BlockStack gap="200">
-      <Text as="p" tone="subdued" variant="bodySm">Package Photos</Text>
-      {loading ? (
-        <Text as="p" tone="subdued" variant="bodySm">Loading photos…</Text>
-      ) : photos.length > 0 ? (
-        <>
-          <InlineStack gap="200" wrap>
-            {photos.map((url, i) => (
-              <button
-                key={i}
-                onClick={() => setLightbox(url)}
-                style={{
-                  border: "1px solid var(--p-color-border)",
-                  borderRadius: "4px",
-                  overflow: "hidden",
-                  cursor: "pointer",
-                  background: "none",
-                  padding: 0,
-                }}
-              >
-                <Thumbnail source={url} alt={`Photo ${i + 1}`} size="large" />
-              </button>
-            ))}
-          </InlineStack>
-
-          {/* Inline lightbox */}
-          {lightbox && (
-            <div
-              onClick={() => setLightbox(null)}
-              style={{
-                position: "fixed",
-                inset: 0,
-                background: "rgba(0,0,0,0.8)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                zIndex: 9999,
-                cursor: "zoom-out",
-              }}
-            >
-              <img
-                src={lightbox}
-                alt="Package photo"
-                style={{ maxWidth: "90vw", maxHeight: "90vh", objectFit: "contain" }}
-                onClick={(e) => e.stopPropagation()}
-              />
-            </div>
-          )}
-        </>
-      ) : (
-        <div
-          style={{
-            background: "var(--p-color-bg-surface-secondary)",
-            borderRadius: "8px",
-            padding: "16px",
-            textAlign: "center",
-            border: "2px dashed var(--p-color-border)",
-          }}
-        >
-          <Text as="p" tone="subdued" variant="bodySm">No photos uploaded yet</Text>
-        </div>
-      )}
-    </BlockStack>
-  );
-}
-
-// ─────────────────────────────────────────────
-// Main component
-// ─────────────────────────────────────────────
+// The orders-table row expansion stays lean: customer + products + delivery, and a
+// handoff. The full delivery proof — tap history, location, signed cryptographic
+// record — lives in the standalone ink. dashboard, never in the embed. Keeping the
+// crypto/forensics out of the embed is deliberate.
 const OrderExpandedRow = ({ order, onCollapse, onViewFull }: OrderExpandedRowProps) => {
-  const [selectedTab, setSelectedTab] = useState(0);
-
-  const eventTabs = [
-    { id: "write", content: "Write" },
-    { id: "tap", content: "Tap" },
-  ];
-
-  // Parse delivery GPS — stored as JSON {"lat":..,"lng":..} or as "lat, lng" string
-  let deliveryCoords: { lat: number; lng: number } | undefined;
-  if (order.metafields?.delivery_gps) {
-    try {
-      const parsed = JSON.parse(order.metafields.delivery_gps);
-      if (parsed.lat !== undefined && parsed.lng !== undefined) {
-        deliveryCoords = { lat: Number(parsed.lat), lng: Number(parsed.lng) };
-      }
-    } catch {
-      const parts = order.metafields.delivery_gps.split(",").map((s: string) => parseFloat(s.trim()));
-      if (parts.length === 2 && !isNaN(parts[0]) && !isNaN(parts[1])) {
-        deliveryCoords = { lat: parts[0], lng: parts[1] };
-      }
-    }
-  }
-
-  // Parse warehouse GPS — stored as JSON {"lat":..,"lng":..}
-  let warehouseLabel = "—";
-  let warehouseCoordStr = "";
-  if (order.metafields?.warehouse_gps) {
-    try {
-      const wgps = JSON.parse(order.metafields.warehouse_gps);
-      warehouseCoordStr = `${Number(wgps.lat).toFixed(4)}, ${Number(wgps.lng).toFixed(4)}`;
-      warehouseLabel = "Warehouse";
-    } catch {
-      warehouseCoordStr = order.metafields.warehouse_gps;
-      warehouseLabel = "Warehouse";
-    }
-  }
-
-  const fullAddress = order.customerAddress
-    ? `${order.customerAddress.address1}, ${order.customerAddress.city}, ${order.customerAddress.provinceCode} ${order.customerAddress.zip}`
-    : "";
-
-  const addressLabel = order.customerAddress
-    ? `${order.customerAddress.city}, ${order.customerAddress.provinceCode} ${order.customerAddress.zip}`
-    : "";
-
-  const proofId = order.metafields?.proof_reference || "";
-  const nfcUid = order.metafields?.nfc_uid || "—";
-  const deviceInfo = order.metafields?.device_info || "";
-  const verifiedAt = order.metafields?.delivery_verified_at || order.metafields?.delivery_timestamp || "";
-  const verifyUrl = order.metafields?.verify_url || "";
-  const gpsVerdict = order.metafields?.gps_verdict || "";
-  const distanceFromAddress = order.metafields?.distance_from_address || "";
-
-  // GPS verdict badge — only show for genuine results, hide when "unknown"
-  const showVerdictBadge = gpsVerdict && gpsVerdict.toLowerCase() !== "unknown";
-  const verdictIsMatch = gpsVerdict.toLowerCase() === "match";
-
-  const hasTapData = order.status === "verified" || order.status === "enrolled" || !!verifiedAt;
+  const deliveredAt =
+    order.metafields?.delivery_verified_at || order.metafields?.delivery_timestamp || "";
 
   return (
     <div style={{ borderTop: "1px solid var(--p-color-border)", maxHeight: "520px", overflowY: "auto" }}>
-      {/* Sticky header with tab bar */}
+      {/* Header — actions only (no forensic tabs) */}
       <div
         style={{
           display: "flex",
-          alignItems: "flex-end",
+          alignItems: "center",
           justifyContent: "space-between",
-          padding: "0 16px",
+          padding: "8px 16px",
           background: "var(--p-color-bg-surface-secondary)",
           position: "sticky",
           top: 0,
           zIndex: 1,
         }}
       >
-        <div style={{ display: "flex", gap: "0", alignItems: "flex-end", paddingTop: "8px" }}>
-          {eventTabs.map((tab, i) => (
-            <button
-              key={tab.id}
-              onClick={() => setSelectedTab(i)}
-              style={{
-                padding: "8px 16px",
-                fontSize: "13px",
-                fontWeight: 500,
-                cursor: "pointer",
-                border: "1px solid var(--p-color-border)",
-                borderBottom:
-                  selectedTab === i
-                    ? "1px solid var(--p-color-bg-surface)"
-                    : "1px solid var(--p-color-border)",
-                background:
-                  selectedTab === i ? "var(--p-color-bg-surface)" : "transparent",
-                color:
-                  selectedTab === i
-                    ? "var(--p-color-text)"
-                    : "var(--p-color-text-secondary)",
-                marginBottom: "-1px",
-                borderRadius: "0",
-                position: "relative",
-                zIndex: selectedTab === i ? 2 : 1,
-              }}
-            >
-              {tab.content}
-            </button>
-          ))}
-        </div>
-        <div style={{ paddingBottom: "6px" }}>
-          <InlineStack gap="200">
-            <Button icon={ExternalIcon} size="slim" onClick={onViewFull}>
-              View Full Record
-            </Button>
-            <Button size="slim" onClick={onCollapse} accessibilityLabel="Collapse order details">
-              ▲
-            </Button>
-          </InlineStack>
-        </div>
+        <Text as="p" variant="bodySm" fontWeight="semibold" tone="subdued">
+          Order details
+        </Text>
+        <InlineStack gap="200">
+          <Button icon={ExternalIcon} size="slim" onClick={onViewFull}>
+            View Full Record
+          </Button>
+          <Button size="slim" onClick={onCollapse} accessibilityLabel="Collapse order details">
+            ▲
+          </Button>
+        </InlineStack>
       </div>
       <div style={{ borderTop: "1px solid var(--p-color-border)" }} />
 
-      {/* Content grid: customer+products | tab content */}
+      {/* Content grid: customer + products | delivery + handoff */}
       <div
-        className="grid grid-cols-1 md:grid-cols-[1fr_2fr]"
+        className="grid grid-cols-1 md:grid-cols-[1fr_1fr]"
         style={{ background: "var(--p-color-bg-surface)" }}
       >
         {/* ── Left: Customer + Products ── */}
         <Box padding="400" borderInlineEndWidth="025" borderColor="border">
           <BlockStack gap="400">
             <BlockStack gap="100">
-              <Text as="p" variant="bodySm" fontWeight="semibold" tone="subdued">CUSTOMER</Text>
-              <Text as="p" variant="bodySm" fontWeight="medium">{order.customerName}</Text>
-              <Text as="p" variant="bodySm" tone="subdued">{order.customerEmail}</Text>
+              <Text as="p" variant="bodySm" fontWeight="semibold" tone="subdued">
+                CUSTOMER
+              </Text>
+              <Text as="p" variant="bodySm" fontWeight="medium">
+                {order.customerName}
+              </Text>
+              <Text as="p" variant="bodySm" tone="subdued">
+                {order.customerEmail}
+              </Text>
               {order.customerAddress && (
                 <Text as="p" variant="bodySm" tone="subdued">
-                  {order.customerAddress.address1}<br />
-                  {order.customerAddress.city}, {order.customerAddress.provinceCode} {order.customerAddress.zip}
+                  {order.customerAddress.address1}
+                  <br />
+                  {order.customerAddress.city}, {order.customerAddress.provinceCode}{" "}
+                  {order.customerAddress.zip}
                 </Text>
               )}
             </BlockStack>
 
             <BlockStack gap="100">
-              <Text as="p" variant="bodySm" fontWeight="semibold" tone="subdued">PRODUCTS</Text>
+              <Text as="p" variant="bodySm" fontWeight="semibold" tone="subdued">
+                PRODUCTS
+              </Text>
               {order.items.map((item, idx) => (
                 <InlineStack key={idx} align="space-between">
                   <BlockStack gap="0">
-                    <Text as="p" variant="bodySm">{item.title}</Text>
+                    <Text as="p" variant="bodySm">
+                      {item.title}
+                    </Text>
                     <Text as="p" variant="bodySm" tone="subdued">
-                      {item.sku ? `${item.sku} × ` : ""}{item.quantity}
+                      {item.sku ? `${item.sku} × ` : ""}
+                      {item.quantity}
                     </Text>
                   </BlockStack>
                   <Text as="p" variant="bodySm" fontWeight="medium">
@@ -327,15 +153,25 @@ const OrderExpandedRow = ({ order, onCollapse, onViewFull }: OrderExpandedRowPro
               ))}
               <div style={{ borderTop: "1px solid var(--p-color-border)", paddingTop: "8px" }}>
                 <InlineStack align="space-between">
-                  <Text as="span" variant="bodySm" tone="subdued">Subtotal</Text>
-                  <Text as="span" variant="bodySm">{fmt(order.subtotal, order.currency)}</Text>
+                  <Text as="span" variant="bodySm" tone="subdued">
+                    Subtotal
+                  </Text>
+                  <Text as="span" variant="bodySm">
+                    {fmt(order.subtotal, order.currency)}
+                  </Text>
                 </InlineStack>
                 <InlineStack align="space-between">
-                  <Text as="span" variant="bodySm" tone="subdued">Shipping</Text>
-                  <Text as="span" variant="bodySm">Free</Text>
+                  <Text as="span" variant="bodySm" tone="subdued">
+                    Shipping
+                  </Text>
+                  <Text as="span" variant="bodySm">
+                    Free
+                  </Text>
                 </InlineStack>
                 <InlineStack align="space-between">
-                  <Text as="span" variant="bodySm" fontWeight="semibold">Total</Text>
+                  <Text as="span" variant="bodySm" fontWeight="semibold">
+                    Total
+                  </Text>
                   <Text as="span" variant="bodySm" fontWeight="semibold">
                     {fmt(order.total, order.currency)}
                   </Text>
@@ -345,170 +181,33 @@ const OrderExpandedRow = ({ order, onCollapse, onViewFull }: OrderExpandedRowPro
           </BlockStack>
         </Box>
 
-        {/* ── Right: Write / Tap tab content ── */}
+        {/* ── Right: Delivery + handoff (no forensics in the embed) ── */}
         <Box padding="400">
-          <div style={{ position: "relative" }}>
-
-            {/* ── WRITE TAB ── */}
-            <div
-              style={
-                selectedTab === 0
-                  ? {}
-                  : { visibility: "hidden", height: 0, overflow: "hidden", position: "absolute", width: "100%" }
-              }
-            >
-              <BlockStack gap="400">
-                {/* NFC UID + Proof ID */}
-                <InlineStack gap="400" wrap={false}>
-                  <div style={{ flex: 1, background: "var(--p-color-bg-surface-secondary)", padding: "12px", borderRadius: "8px" }}>
-                    <Text as="p" tone="subdued" variant="bodySm">NFC Tag UID</Text>
-                    <Text as="p" variant="bodySm" fontWeight="medium">
-                      <code style={{ fontFamily: "monospace" }}>{nfcUid}</code>
-                    </Text>
-                  </div>
-                  <div style={{ flex: 1, background: "var(--p-color-bg-surface-secondary)", padding: "12px", borderRadius: "8px" }}>
-                    <Text as="p" tone="subdued" variant="bodySm">Proof ID</Text>
-                    <Text as="p" variant="bodySm" fontWeight="medium">
-                      <code style={{ fontFamily: "monospace", wordBreak: "break-all" }}>
-                        {proofId || "—"}
-                      </code>
-                    </Text>
-                  </div>
-                </InlineStack>
-
-                {/* Warehouse GPS */}
-                {warehouseCoordStr && (
-                  <div style={{ background: "var(--p-color-bg-surface-secondary)", padding: "12px", borderRadius: "8px" }}>
-                    <Text as="p" tone="subdued" variant="bodySm">Warehouse</Text>
-                    <Text as="p" variant="bodySm" fontWeight="medium">{warehouseLabel}</Text>
-                    <Text as="p" tone="subdued" variant="bodySm">
-                      <code style={{ fontFamily: "monospace", fontSize: "12px" }}>{warehouseCoordStr}</code>
-                    </Text>
-                  </div>
-                )}
-
-                {/* Package Photos — fetched from INK API */}
-                {proofId && <PackagePhotosRow proofId={proofId} />}
-              </BlockStack>
+          <BlockStack gap="300">
+            <Text as="p" variant="bodySm" fontWeight="semibold" tone="subdued">
+              DELIVERY
+            </Text>
+            {deliveredAt ? (
+              <InlineStack align="space-between">
+                <Text as="span" variant="bodySm" tone="subdued">
+                  Delivered
+                </Text>
+                <Text as="span" variant="bodySm">
+                  {formatTimestamp(deliveredAt)}
+                </Text>
+              </InlineStack>
+            ) : (
+              <Text as="p" variant="bodySm" tone="subdued">
+                No delivery recorded yet.
+              </Text>
+            )}
+            <div style={{ borderTop: "1px solid var(--p-color-border)", paddingTop: "8px" }}>
+              <Text as="p" variant="bodySm" tone="subdued">
+                Tap history, location, and the signed cryptographic proof live in your
+                ink. dashboard.
+              </Text>
             </div>
-
-            {/* ── TAP TAB ── */}
-            <div
-              style={
-                selectedTab === 1
-                  ? {}
-                  : { visibility: "hidden", height: 0, overflow: "hidden", position: "absolute", width: "100%" }
-              }
-            >
-              {hasTapData ? (
-                <BlockStack gap="500">
-                  {/* Timeline */}
-                  <BlockStack gap="300">
-                    <Text as="p" tone="subdued" variant="bodySm" fontWeight="medium">Timeline</Text>
-
-                    {/* Tapped event */}
-                    {verifiedAt ? (
-                      <InlineStack gap="300" blockAlign="start">
-                        <div style={{ width: 10, height: 10, borderRadius: "50%", background: "var(--p-color-text)", marginTop: 4, flexShrink: 0 }} />
-                        <BlockStack gap="100">
-                          <Text as="p" variant="bodySm" fontWeight="medium">Tapped</Text>
-                          <Text as="p" tone="subdued" variant="bodySm">{formatTimestamp(verifiedAt)}</Text>
-                          {deviceInfo && <Badge>{deviceInfo}</Badge>}
-                        </BlockStack>
-                      </InlineStack>
-                    ) : (
-                      <InlineStack gap="300" blockAlign="start">
-                        <div style={{ width: 10, height: 10, borderRadius: "50%", background: "var(--p-color-border)", marginTop: 4, flexShrink: 0 }} />
-                        <Text as="p" tone="subdued" variant="bodySm">Waiting for customer tap…</Text>
-                      </InlineStack>
-                    )}
-
-                    {/* Location verified */}
-                    {deliveryCoords && (
-                      <InlineStack gap="300" blockAlign="start">
-                        <div style={{ width: 10, height: 10, borderRadius: "50%", background: "var(--p-color-text)", marginTop: 4, flexShrink: 0 }} />
-                        <BlockStack gap="100">
-                          <InlineStack gap="200" blockAlign="center">
-                            <Text as="p" variant="bodySm" fontWeight="medium">Location verified</Text>
-                            {showVerdictBadge && (
-                              <span style={{
-                                fontSize: "10px",
-                                fontWeight: 700,
-                                padding: "2px 6px",
-                                borderRadius: "4px",
-                                background: verdictIsMatch ? "#dcfce7" : "#fee2e2",
-                                color: verdictIsMatch ? "#166534" : "#991b1b",
-                              }}>
-                                {gpsVerdict.toUpperCase()}
-                              </span>
-                            )}
-                          </InlineStack>
-                          {distanceFromAddress && (
-                            <Text as="p" tone="subdued" variant="bodySm">{distanceFromAddress} from shipping address</Text>
-                          )}
-                          <Text as="p" tone="subdued" variant="bodySm">
-                            <code style={{ fontFamily: "monospace", fontSize: "11px" }}>
-                              {deliveryCoords.lat.toFixed(6)}, {deliveryCoords.lng.toFixed(6)}
-                            </code>
-                          </Text>
-                        </BlockStack>
-                      </InlineStack>
-                    )}
-
-                    {/* Confirmation sent */}
-                    <InlineStack gap="300" blockAlign="start">
-                      <div style={{ width: 10, height: 10, borderRadius: "50%", background: "var(--p-color-border)", marginTop: 4, flexShrink: 0 }} />
-                      <BlockStack gap="100">
-                        <Text as="p" variant="bodySm" fontWeight="medium">Confirmation sent</Text>
-                        <Text as="p" tone="subdued" variant="bodySm">
-                          Delivery record sent to {order.customerEmail || "customer"}
-                        </Text>
-                        {verifyUrl && (
-                          <a
-                            href={verifyUrl}
-                            target="_blank"
-                            rel="noreferrer"
-                            style={{
-                              display: "inline-flex",
-                              alignItems: "center",
-                              gap: "4px",
-                              fontSize: "12px",
-                              padding: "4px 10px",
-                              border: "1px solid var(--p-color-border)",
-                              borderRadius: "4px",
-                              color: "var(--p-color-text)",
-                              textDecoration: "none",
-                            }}
-                          >
-                            View Public Proof
-                          </a>
-                        )}
-                      </BlockStack>
-                    </InlineStack>
-                  </BlockStack>
-
-                  {/* Tap Location map */}
-                  {deliveryCoords && (
-                    <BlockStack gap="200">
-                      <Text as="p" tone="subdued" variant="bodySm" fontWeight="medium">Tap Location</Text>
-                      <TapLocationCard
-                        lat={deliveryCoords.lat}
-                        lng={deliveryCoords.lng}
-                        address={addressLabel}
-                        fullAddress={fullAddress}
-                        distanceFromAddress={distanceFromAddress}
-                      />
-                    </BlockStack>
-                  )}
-                </BlockStack>
-              ) : (
-                <BlockStack gap="200" inlineAlign="center">
-                  <Text as="p" variant="bodySm" fontWeight="medium" tone="subdued">No tap has been recorded</Text>
-                  <Text as="p" variant="bodySm" tone="subdued">Waiting for customer to tap the NFC tag</Text>
-                </BlockStack>
-              )}
-            </div>
-          </div>
+          </BlockStack>
         </Box>
       </div>
     </div>


### PR DESCRIPTION
Your call — the cryptographic delivery proof stays in the **in.ink** dashboard (its Advanced drawer), not the Shopify embed. Both embed order surfaces now drop the forensic UI.

**Removed** (from `OrderDetailView` + `OrderExpandedRow`):
- NFC UID, Proof ID, warehouse/delivery GPS, **"Location verified"**, the **GPS-verdict MATCH/MISMATCH badge** (fraud-detection UI on a merchant surface), tap timeline, embedded maps, package-photo fetchers (`PackagePhotosRow` / `TapLocationCard` / `TapLocationCity`).

**Kept:** order essentials (customer, products, totals, delivered date) + a one-line handoff — *the full delivery proof lives in your ink. dashboard.*

**Not touched:** the `verified` state + metafields (types still list them; nothing renders them). The forensic record is unchanged in the in.ink Advanced drawer — confirmed it already holds the full set (ed25519 sig + signed hash + proof ID, Integrity·OK, tap log w/ location, interaction window).

**Verified:** `tsc --noEmit` clean · `react-router build` succeeds. Embedded routes need a Shopify admin session → not browser-previewable standalone.

Pairs with the lean-dashboard + native Advanced KPIs work (#19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)