### PR TITLE
fix(embed): show order ship-to, not customer default address (stale-address leak)

### DIFF
--- a/app/routes/app.tagged-shipments._index.tsx
+++ b/app/routes/app.tagged-shipments._index.tsx
@@ -44,8 +44,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
             totalPriceSet { shopMoney { amount currencyCode } }
             customer {
               firstName lastName email
-              defaultAddress { address1 city provinceCode zip }
             }
+            shippingAddress { address1 city provinceCode zip }
             tags
             metafields(namespace: "ink", first: 10) {
               edges { node { key value } }
@@ -151,7 +151,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         ? `${order.customer.firstName} ${order.customer.lastName}`
         : "Guest",
       customerEmail: order.customer?.email || "",
-      customerAddress: order.customer?.defaultAddress,
+      // THIS order's ship-to — never the customer's saved default address
+      // (which leaks a stale/previous address onto a new order).
+      customerAddress: order.shippingAddress,
       date: new Date(order.createdAt).toLocaleDateString("en-US", {
         month: "short",
         day: "numeric",


### PR DESCRIPTION
## Bug
The **Shipments** list showed `customer.defaultAddress` as the order's address (`app.tagged-shipments._index.tsx` query line ~47 + loader line ~154). That's the customer's *saved profile default*, not where **this order** shipped — so a stale/previous address (a test "123 Test St") surfaced on a new order that actually shipped elsewhere. Confirmed against a live order: embed showed 123 Test St; real ship-to was a different address.

## Fix
Query `order.shippingAddress` and display that. The render already guards `customerAddress &&`, so when the address is absent/redacted the block simply hides — consistent with the honest "no address" shown in the in.ink app and ink admin.

## Notes
- No scope change → no merchant re-consent.
- Reliably surfacing the real ship-to end-to-end (and into the backend, which currently only receives a name) depends on **Shopify Protected Customer Data** approval — part of the App Store submission. This fix removes the *wrong* address regardless.
- Production build passes (`react-router build`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)