### PR TITLE
fix(embed): billing-address fallback when order has no ship-to

### DIFF
--- a/app/routes/app.tagged-shipments._index.tsx
+++ b/app/routes/app.tagged-shipments._index.tsx
@@ -46,6 +46,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
               firstName lastName email
             }
             shippingAddress { address1 city provinceCode zip }
+            billingAddress { address1 city provinceCode zip }
             tags
             metafields(namespace: "ink", first: 10) {
               edges { node { key value } }
@@ -151,9 +152,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         ? `${order.customer.firstName} ${order.customer.lastName}`
         : "Guest",
       customerEmail: order.customer?.email || "",
-      // THIS order's ship-to — never the customer's saved default address
-      // (which leaks a stale/previous address onto a new order).
-      customerAddress: order.shippingAddress,
+      // THIS order's ship-to, falling back to the billing address when there's
+      // no shipping address (pickup / billing-only orders). NEVER the customer's
+      // saved default — that leaks a stale/previous address onto a new order.
+      customerAddress: order.shippingAddress ?? order.billingAddress,
       date: new Date(order.createdAt).toLocaleDateString("en-US", {
         month: "short",
         day: "numeric",


### PR DESCRIPTION
Follow-up to the ship-to fix. Verified against live order #1008: `shippingAddress` is **null** (the test order only has a **billing** address — 1830 Redesdale). So the prior fix correctly killed the stale-default leak but left the field blank. Now displays `order.shippingAddress ?? order.billingAddress` — ship-to when present (real orders), billing as fallback (pickup/billing-only), never the customer's stale default. Build passes. No scope change → no re-consent. 🤖 Generated with [Claude Code](https://claude.com/claude-code)