### PR TITLE
fix(returns): mark delivered on real carrier delivery, not ship time (#5)

### DIFF
--- a/app/routes/webhooks.fulfillments_update.tsx
+++ b/app/routes/webhooks.fulfillments_update.tsx
@@ -1,6 +1,7 @@
 import type { ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import { NotificationService } from "../services/notifications.server";
+import { NFSService } from "../services/nfs.server";
 import firestore from "../firestore.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
@@ -74,8 +75,32 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       return new Response("OK", { status: 200 });
     }
 
-    const settings = settingsSnap.docs[0].data().notification_settings;
-    const merchantName = settingsSnap.docs[0].data().shopName || shop;
+    const merchantData = settingsSnap.docs[0].data();
+    const settings = merchantData.notification_settings;
+    const merchantName = merchantData.shopName || shop;
+
+    // ── Mark the proof DELIVERED at the REAL carrier-delivered moment. This is
+    // now the authoritative delivered_at (orders/fulfilled no longer marks at
+    // ship time). Runs BEFORE the notification-settings gate so delivery is
+    // recorded even for merchants with no notifications configured. Best-effort:
+    // a failure must never block the notification or the 200. ──
+    if (shipmentStatus === "delivered" && order.proofMetafield?.value) {
+      const merchantApiKey = merchantData.ink_api_key;
+      if (merchantApiKey) {
+        try {
+          const deliveredAt = fulfillment.updated_at || new Date().toISOString();
+          await NFSService.markDelivered(order.proofMetafield.value, merchantApiKey, {
+            delivered_at: deliveredAt,
+            carrier: fulfillment.tracking_company || undefined,
+          });
+          console.log(`✅ Marked proof ${order.proofMetafield.value} delivered at REAL carrier delivery (${deliveredAt}).`);
+        } catch (e: any) {
+          console.error(`❌ mark-delivered failed (non-fatal):`, e?.message);
+        }
+      } else {
+        console.log(`⚠️ No ink_api_key for ${shop}; cannot mark proof delivered.`);
+      }
+    }
 
     if (!settings) {
       console.log(`⚠️ Merchant has no Notification Settings configured. Exiting.`);

--- a/app/routes/webhooks.orders_fulfilled.tsx
+++ b/app/routes/webhooks.orders_fulfilled.tsx
@@ -71,15 +71,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     }
 
     if (proofReference) {
-      console.log(`[${topic}] Found proof_reference: ${proofReference} for order ${orderGid}. Marking as delivered.`);
-      
-      // 3. Call Alan's API with the merchant's Bearer token (not the admin secret)
-      await NFSService.markDelivered(proofReference, merchantApiKey, {
-        delivered_at: fulfilledAt,
-        carrier,
-      });
-
-      console.log(`[${topic}] ✅ Successfully pushed delivery state to Alan's backend for proof: ${proofReference}`);
+      // Deliberately DO NOT mark delivered here. orders/fulfilled fires at SHIP
+      // time; marking delivered now would pre-empt the REAL carrier "delivered"
+      // event (webhooks.fulfillments_update.tsx), which is the authoritative
+      // delivered_at. This fixes the "return window opened at ship time" bug.
+      // (merchantApiKey / fulfilledAt / carrier stay computed above for a future
+      // shipped_at record; markProofDelivered is idempotent first-write-wins, so
+      // whoever sets delivered_at first wins — that must be REAL delivery.)
+      console.log(`[${topic}] Order ${orderGid} shipped (proof ${proofReference}); delivery is marked on the REAL carrier-delivered event, not at ship time.`);
     } else {
       console.log(`[${topic}] Order ${orderGid} has no INK proof_reference metafield. Skipping (not an INK order).`);
     }


### PR DESCRIPTION
Fixes the return window opening at ship time. `orders/fulfilled` no longer marks delivered (it fires at ship); `fulfillments/update` now marks the proof delivered at the real carrier-delivery moment. Embed-only, no scope change, no re-consent, build passes. Follow-up flagged: an untracked-shipment fallback. 🤖 Generated with [Claude Code](https://claude.com/claude-code)