### PR TITLE
fix(verify): stop emailing customer on every scan (#3)

### DIFF
--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -630,7 +630,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                     
                     const productImageUrl = order.lineItems?.edges?.[0]?.node?.image?.url;
 
-                    if (order.customer?.email) {
+                    // Gated OFF by default: this fired a Return Passport email on
+                    // EVERY verify/scan (a customer scanning twice got two emails).
+                    // Production customer notifications are the fulfillments/update
+                    // webhook → NotificationService. Set SEND_VERIFY_EMAIL=true only
+                    // for manual testing.
+                    if (order.customer?.email && process.env.SEND_VERIFY_EMAIL === "true") {
                         const { EmailService } = await import("../services/email.server");
                         
                         // Fetch settings


### PR DESCRIPTION
`api.verify` fired a Return Passport email on every scan (leftover testing mode). Gated behind `SEND_VERIFY_EMAIL=true` (off by default); prod notifications are the fulfillments/update webhook. Build passes. 🤖 Generated with [Claude Code](https://claude.com/claude-code)