### PR TITLE
fix(webhooks): align orders/create path to the handler (#9)

### DIFF
--- a/app/routes/app.register-webhook.tsx
+++ b/app/routes/app.register-webhook.tsx
@@ -33,7 +33,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const { admin } = await authenticate.admin(request);
 
   const webhooks = [
-    { topic: "ORDERS_CREATE",    path: "/webhooks/orders/create" },
+    { topic: "ORDERS_CREATE",    path: "/webhooks/orders_create" }, // must match webhooks.orders_create.ts (underscore)
     { topic: "ORDERS_FULFILLED", path: "/webhooks/orders_fulfilled" },
   ];
 

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -21,7 +21,11 @@ api_version = "2025-10"
 
   [[webhooks.subscriptions]]
   topics = [ "orders/create" ]
-  uri = "/webhooks/orders/create"
+  # Must match the flat-route handler file webhooks.orders_create.ts → the path
+  # is /webhooks/orders_create (underscore). The old "/webhooks/orders/create"
+  # (slash) routed to a non-existent handler → a re-register would 404 and break
+  # enroll. The live subscription already uses the underscore.
+  uri = "/webhooks/orders_create"
 
   [[webhooks.subscriptions]]
   topics = [ "orders/fulfilled" ]


### PR DESCRIPTION
The toml + register-webhook said `/webhooks/orders/create` (slash); the handler is `/webhooks/orders_create` (underscore). A re-register would 404 and break auto-enroll. Aligned both to the underscore (which the live subscription already uses). Config-only, build passes. 🤖 Generated with [Claude Code](https://claude.com/claude-code)