### PR TITLE
fix(verify): scope email session to the PROOF's shop (kill silent-fail)

### DIFF
--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -512,9 +512,59 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                 console.log("📧 =================================================");
                 
                 const { getOfflineSession } = await import("../session-utils.server");
-                
-                const session = await getOfflineSession();
-                
+
+                // CRITICAL: scope the Shopify session lookup to the PROOF's shop.
+                // Using getOfflineSession() unfiltered returns the FIRST offline
+                // session in Firestore (e.g. dmg4mi-8i.myshopify.com), so a proof
+                // for a different merchant would search the wrong shop's orders,
+                // silently miss the order, and never fire the email. Worse — on
+                // an order-number collision it could email the wrong merchant's
+                // customer. Resolve shop_id → shopDomain via the merchants
+                // collection first, then load that shop's offline session.
+                const proofShopDomain: string = alanData.shop_domain || "";
+                const proofShopId: string = alanData.shop_id || "";
+
+                let targetShopDomain = proofShopDomain;
+                if (!targetShopDomain && proofShopId) {
+                    try {
+                        const allMerchants = await firestore
+                            .collection("merchants")
+                            .get();
+                        for (const doc of allMerchants.docs) {
+                            const data = doc.data();
+                            if (
+                                data.shop_id === proofShopId ||
+                                data.ink_shop_id === proofShopId
+                            ) {
+                                targetShopDomain = data.shopDomain || "";
+                                if (targetShopDomain) break;
+                            }
+                        }
+                    } catch (e) {
+                        console.warn(
+                            "⚠️ Failed to resolve shop_id → shopDomain for email session:",
+                            e,
+                        );
+                    }
+                }
+
+                let session = targetShopDomain
+                    ? await getOfflineSession(targetShopDomain)
+                    : null;
+
+                if (session) {
+                    console.log(
+                        `✅ Loaded shop-scoped session for ${session.shop} (proof shop_id="${proofShopId}")`,
+                    );
+                } else {
+                    console.warn(
+                        `⚠️⚠️⚠️ FALLBACK: no offline session for proof shop ` +
+                        `(shop_id="${proofShopId}", shop_domain="${targetShopDomain || proofShopDomain}"). ` +
+                        `Falling back to first available offline session — this may email the WRONG customer.`,
+                    );
+                    session = await getOfflineSession();
+                }
+
                 if (!session) {
                     console.warn("⚠️ No session found for email");
                     return;


### PR DESCRIPTION
## Summary

- `/api/verify`'s Return-Passport email path called `getOfflineSession()` with no filter → always searched the **first** offline session in Firestore (e.g. `dmg4mi-8i.myshopify.com`), regardless of which merchant the proof belonged to.
- Every non-first-shop proof failed the Shopify order search silently and never fired `EmailService.sendReturnPassportEmail`. Worse — on any order-number collision it would email the **wrong** merchant's customer.
- Fix: resolve `alanData.shop_id` → `shopDomain` via the `merchants` collection, then load `getOfflineSession(shopDomain)`. Fall back to the unfiltered lookup only if no session exists for the proof's shop, with a **loud** `⚠️⚠️⚠️ FALLBACK` warning so a wrong-customer email cannot happen silently.

## Repro (live 2026-07-01, before fix)

`POST https://shopify-app-3ijhzmtboa-uc.a.run.app/api/verify` with `{ "serial_number": "nfc_mr19i66h_23l957zs", "delivery_gps": {"lat":40.7128,"lng":-74.006} }`

Cloud Run logs showed:
- Proof resolved with `shop_id="shop_bb508e5ca47a1036"` (Steve Madden — `sm-test-hhawzn52.myshopify.com`)
- Session used for Admin GraphQL search: **`dmg4mi-8i.myshopify.com`** (first offline session, WRONG shop)
- `⚠️ Could not find order #7510464594158`
- `📧 Return Passport email process completed` — no send

## After fix (expected)

- Log: `✅ Loaded shop-scoped session for sm-test-hhawzn52.myshopify.com (proof shop_id="shop_bb508e5ca47a1036")`
- Order search hits Steve Madden's shop, finds `#7510464594158`
- `EmailService.sendReturnPassportEmail` is reached; SendGrid returns 202 (when `SEND_VERIFY_EMAIL=true`)

## Test plan

- [ ] Post the repro request above to `/api/verify` after Cloud Run auto-deploys.
- [ ] `gcloud run services logs read shopify-app --project inink-c76d3 --region us-central1 --limit 200` — confirm the search hits `sm-test-hhawzn52.myshopify.com`, not `dmg4mi-8i.myshopify.com`.
- [ ] If `SEND_VERIFY_EMAIL=true`, confirm SendGrid 202 in logs.
- [ ] Post a proof for the first-session shop too — confirm the shop-scoped path is used (no fallback warning).
- [ ] Watch for any `⚠️⚠️⚠️ FALLBACK` warnings in prod (they point at a merchant with no offline session and should be investigated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)