### PR TITLE
feat(outreach): read merchant.outreach templates on Delivered email + test-mode gate

### DIFF
--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -703,6 +703,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                         let emailEnabled = true;
                         let deliveredOn = true;
                         let isTestMerchant = false;
+                        // FAIL-CLOSED guard: only send once we've POSITIVELY loaded
+                        // the proof's merchant doc. If the lookup misses or throws,
+                        // we can't confirm the merchant isn't a test store or hasn't
+                        // disabled email — so we skip rather than blast a customer on
+                        // an unresolved merchant. Flips true only inside `if (mDoc)`.
+                        let merchantDocLoaded = false;
                         try {
                             let mDoc: Record<string, any> | null = null;
                             const proofShopIdForOutreach = alanData.shop_id || "";
@@ -727,6 +733,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                                 if (!bySnap2.empty) mDoc = bySnap2.docs[0].data();
                             }
                             if (mDoc) {
+                                merchantDocLoaded = true;
                                 const outreach = (mDoc.outreach as Record<string, any> | undefined) || {};
                                 const messages = (outreach.messages as Record<string, any> | undefined) || {};
                                 const notifications = (outreach.notifications as Record<string, any> | undefined) || {};
@@ -753,7 +760,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                             console.warn("Could not fetch outreach settings:", e);
                         }
 
-                        if (isTestMerchant) {
+                        if (!merchantDocLoaded) {
+                            console.warn(
+                                `📧 SKIP (no merchant doc): could not resolve a merchant for proof shop_id="${alanData.shop_id || ""}" / shop="${session.shop}". Failing closed — refusing to send to ${order.customer.email}.`,
+                            );
+                        } else if (isTestMerchant) {
                             console.log(
                                 `📧 SKIP (test-mode): merchant returns_test_mode=true or is_test=true — refusing to send real customer email for ${order.customer.email}`,
                             );

--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -607,6 +607,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                           lineItems(first: 1) {
                               edges {
                                   node {
+                                      title
                                       image {
                                           url
                                       }
@@ -644,7 +645,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                           name
                           customer { email firstName }
                           lineItems(first: 1) {
-                            edges { node { image { url } } }
+                            edges { node { title image { url } } }
                           }
                         }
                       }
@@ -687,35 +688,97 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                     // for manual testing.
                     if (order.customer?.email && process.env.SEND_VERIFY_EMAIL === "true") {
                         const { EmailService } = await import("../services/email.server");
-                        
-                        // Fetch settings
                         const { default: firestore } = await import("../firestore.server");
+
+                        // Load the merchant's Outreach config + settings from
+                        // the same doc. Reads snake_case first (ink-backend's
+                        // `shop_domain` — the only field Steve Madden's doc has;
+                        // the merged shop-scope fix in #30 reads camelCase only,
+                        // which is why the fallback path fires on Steve). This
+                        // ALSO lets us gate on merchant.returns_test_mode so a
+                        // testing merchant never blasts real customers.
                         let rWindow = 30;
+                        let outreachSubject: string | undefined;
+                        let outreachBody: string | undefined;
+                        let emailEnabled = true;
+                        let deliveredOn = true;
+                        let isTestMerchant = false;
                         try {
-                            const settingsSnap = await firestore.collection("merchants").where("shopDomain", "==", session.shop).limit(1).get();
-                            if (!settingsSnap.empty) {
-                                const settings = settingsSnap.docs[0].data().notification_settings;
-                                if (settings?.returnWindow) {
-                                    rWindow = parseInt(settings.returnWindow) || 30;
+                            let mDoc: Record<string, any> | null = null;
+                            const proofShopIdForOutreach = alanData.shop_id || "";
+                            if (proofShopIdForOutreach) {
+                                const d = await firestore.collection("merchants").doc(proofShopIdForOutreach).get();
+                                if (d.exists) mDoc = d.data() || null;
+                            }
+                            if (!mDoc) {
+                                const bySnap = await firestore
+                                    .collection("merchants")
+                                    .where("shop_domain", "==", session.shop)
+                                    .limit(1)
+                                    .get();
+                                if (!bySnap.empty) mDoc = bySnap.docs[0].data();
+                            }
+                            if (!mDoc) {
+                                const bySnap2 = await firestore
+                                    .collection("merchants")
+                                    .where("shopDomain", "==", session.shop)
+                                    .limit(1)
+                                    .get();
+                                if (!bySnap2.empty) mDoc = bySnap2.docs[0].data();
+                            }
+                            if (mDoc) {
+                                const outreach = (mDoc.outreach as Record<string, any> | undefined) || {};
+                                const messages = (outreach.messages as Record<string, any> | undefined) || {};
+                                const notifications = (outreach.notifications as Record<string, any> | undefined) || {};
+                                outreachSubject = messages.return_unlocked_subject as string | undefined;
+                                outreachBody = messages.return_unlocked_email as string | undefined;
+                                if (typeof notifications.email_enabled === "boolean") emailEnabled = notifications.email_enabled;
+                                if (typeof notifications.delivered_on === "boolean") deliveredOn = notifications.delivered_on;
+                                // Legacy notification_settings.returnWindow, then modern
+                                // outreach.notifications.return_window_days, then merchant.return_window_days.
+                                const nwd = notifications.return_window_days ?? mDoc.return_window_days;
+                                if (nwd) rWindow = parseInt(String(nwd)) || 30;
+                                if (!nwd && mDoc.notification_settings?.returnWindow) {
+                                    rWindow = parseInt(mDoc.notification_settings.returnWindow) || 30;
                                 }
+                                // Test merchants (Steve Madden dev store, seed merchants) must NEVER
+                                // fire real customer emails. Gates on:
+                                //   merchant.returns_test_mode (existing test-gate for return labels)
+                                //   merchant.is_test         (dev-only marker)
+                                // Either → no real send. Kept independent of the SEND_VERIFY_EMAIL env
+                                // gate: env=true + merchant=test still → NO send, loudly logged.
+                                isTestMerchant = Boolean(mDoc.returns_test_mode || mDoc.is_test);
                             }
                         } catch (e) {
-                            console.warn("Could not fetch return window settings:", e);
+                            console.warn("Could not fetch outreach settings:", e);
                         }
-                        
-                        // Send Return Passport email with photos
-                        await EmailService.sendReturnPassportEmail({
-                            to: order.customer.email,
-                            customerName: order.customer.firstName || "Customer",
-                            orderName: order.name,
-                            proofUrl: alanData.verify_url || `https://in.ink/verify/${alanData.proof_id}`,
-                            photoUrls: photoUrls,
-                            returnWindowDays: rWindow,
-                            merchantName: session.shop.replace('.myshopify.com', ''),
-                            productImageUrl: productImageUrl,
-                        });
-                        
-                        console.log(`✅ Return Passport email sent to ${order.customer.email}`);
+
+                        if (isTestMerchant) {
+                            console.log(
+                                `📧 SKIP (test-mode): merchant returns_test_mode=true or is_test=true — refusing to send real customer email for ${order.customer.email}`,
+                            );
+                        } else if (!emailEnabled || !deliveredOn) {
+                            console.log(
+                                `📧 SKIP (merchant outreach off): email_enabled=${emailEnabled}, delivered_on=${deliveredOn}`,
+                            );
+                        } else {
+                            const productName = order.lineItems?.edges?.[0]?.node?.title || undefined;
+                            await EmailService.sendReturnPassportEmail({
+                                to: order.customer.email,
+                                customerName: order.customer.firstName || "Customer",
+                                orderName: order.name,
+                                proofUrl: alanData.verify_url || `https://in.ink/verify/${alanData.proof_id}`,
+                                photoUrls: photoUrls,
+                                returnWindowDays: rWindow,
+                                merchantName: session.shop.replace('.myshopify.com', ''),
+                                productImageUrl: productImageUrl,
+                                subjectOverride: outreachSubject,
+                                bodyOverride: outreachBody,
+                                productName: productName,
+                            });
+                        }
+                        // (send-success log is emitted inside EmailService.sendReturnPassportEmail;
+                        // this outer log used to fire even on skip which was misleading.)
                     } else {
                         console.warn("⚠️ Order found but no customer email");
                     }

--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -2,6 +2,7 @@ import { type ActionFunctionArgs } from "react-router";
 import { serialNumberToToken } from "../utils/nfc-conversion.server";
 import { INK_NAMESPACE } from "../utils/metafields.server";
 import { getProof } from "../services/ink-api.server";
+import { brandSlugFromDomain } from "../services/email.server";
 import firestore from "../firestore.server";
 
 const CORS_HEADERS = {
@@ -703,6 +704,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                         let emailEnabled = true;
                         let deliveredOn = true;
                         let isTestMerchant = false;
+                        // Branded sender: {brand}@in.ink + shop_name + support reply-to,
+                        // resolved from the merchant doc below.
+                        let senderFromEmail: string | undefined;
+                        let senderFromName: string | undefined;
+                        let senderReplyTo: string | undefined;
                         // FAIL-CLOSED guard: only send once we've POSITIVELY loaded
                         // the proof's merchant doc. If the lookup misses or throws,
                         // we can't confirm the merchant isn't a test store or hasn't
@@ -755,6 +761,29 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                                 // Either → no real send. Kept independent of the SEND_VERIFY_EMAIL env
                                 // gate: env=true + merchant=test still → NO send, loudly logged.
                                 isTestMerchant = Boolean(mDoc.returns_test_mode || mDoc.is_test);
+
+                                // Branded sender — {brand}@in.ink via the same slug
+                                // resolver that mints {brand}.in.ink. Prefer the
+                                // merchant's own shop_domain (snake first), then the
+                                // Shopify session host. Name = shop_name; reply-to =
+                                // support/owner email. Unresolvable slug → undefined,
+                                // so email.server falls back to notifications@in.ink.
+                                const brandDomain =
+                                    (mDoc.shop_domain as string | undefined) ||
+                                    (mDoc.shopDomain as string | undefined) ||
+                                    session.shop;
+                                const brandSlug = brandSlugFromDomain(brandDomain);
+                                if (brandSlug && brandSlug.length >= 2) {
+                                    senderFromEmail = `${brandSlug}@in.ink`;
+                                }
+                                senderFromName =
+                                    (mDoc.shop_name as string | undefined) ||
+                                    (mDoc.name as string | undefined) ||
+                                    undefined;
+                                senderReplyTo =
+                                    (mDoc.support_email as string | undefined) ||
+                                    (mDoc.owner_email as string | undefined) ||
+                                    undefined;
                             }
                         } catch (e) {
                             console.warn("Could not fetch outreach settings:", e);
@@ -786,6 +815,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                                 subjectOverride: outreachSubject,
                                 bodyOverride: outreachBody,
                                 productName: productName,
+                                fromEmail: senderFromEmail,
+                                fromName: senderFromName,
+                                replyTo: senderReplyTo,
                             });
                         }
                         // (send-success log is emitted inside EmailService.sendReturnPassportEmail;

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -1,14 +1,36 @@
 
 import sendgrid from "@sendgrid/mail";
 
-// SendGrid credentials from environment variables
+// SendGrid credentials from environment variables. FROM defaults to a NEUTRAL
+// notifications@in.ink — the merchant-branded {brand}@in.ink From is passed in
+// per-send (payload.fromEmail); this env value is only the no-merchant-context
+// fallback. in.ink is SendGrid domain-authenticated, so any {x}@in.ink sends.
 const apiKey = process.env.SENDGRID_API_KEY;
-const fromEmail = process.env.SENDGRID_FROM_EMAIL;
+const fromEmail = process.env.SENDGRID_FROM_EMAIL || "notifications@in.ink";
 
 if (apiKey) {
   sendgrid.setApiKey(apiKey);
 } else {
   console.warn("⚠️ SendGrid API Key missing. Email service will be disabled.");
+}
+
+// Derive the {brand} slug for a {brand}@in.ink sender — mirrors the ink-backend
+// brandSlugFromDomain() (utils/resolveMerchantForAnimation.js) which mints
+// {brand}.in.ink: strip protocol/www, take the first DNS label, slugify.
+// e.g. "stevemadden.myshopify.com" → "stevemadden" → stevemadden@in.ink.
+export function brandSlugFromDomain(domain?: string | null): string {
+  const host = String(domain || "")
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .split("/")[0];
+  return (host.split(".")[0] || "")
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/g, "");
 }
 
 interface ReturnPassportEmailPayload {
@@ -29,6 +51,12 @@ interface ReturnPassportEmailPayload {
   subjectOverride?: string;
   bodyOverride?: string;
   productName?: string; // template variable for {product}
+  // Dynamic branded sender. When set, the email comes FROM the merchant's brand
+  // ({brand}@in.ink) with their name + support reply-to, instead of the neutral
+  // notifications@in.ink default. Computed by the caller from the merchant doc.
+  fromEmail?: string;
+  fromName?: string;
+  replyTo?: string;
 }
 
 // One-pass template substitution. The TEMPLATE is trusted (merchant-authored),
@@ -96,7 +124,16 @@ export const EmailService = {
       subjectOverride,
       bodyOverride,
       productName,
+      fromEmail: fromEmailOverride,
+      fromName,
+      replyTo,
     } = payload;
+
+    // Branded sender: {brand}@in.ink + shop_name when provided, else the neutral
+    // notifications@in.ink env default. Reply-to = merchant support (omitted if
+    // unset). Display name defaults to the merchant name we already show.
+    const senderEmail = fromEmailOverride || fromEmail;
+    const senderName = fromName || merchantName;
 
     // Determine return button URL
     const returnButtonUrl = returnUrl || proofUrl;
@@ -378,13 +415,14 @@ export const EmailService = {
     try {
       await sendgrid.send({
         to,
-        from: fromEmail,
+        from: { email: senderEmail, name: senderName },
+        ...(replyTo ? { replyTo } : {}),
         subject: finalSubject,
         text: finalText,
         html: finalHtml,
       });
 
-      console.log(`✅ Return Passport email sent to ${to}`);
+      console.log(`✅ Return Passport email sent to ${to} (from ${senderEmail})`);
       return true;
     } catch (error: any) {
       console.error("❌ Failed to send email:", error.response?.body || error.message);

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -21,6 +21,28 @@ interface ReturnPassportEmailPayload {
   returnWindowDays?: number;  // Return window (e.g., 30 days)
   returnUrl?: string;  // URL to start return
   productImageUrl?: string; // Main product image
+  // Merchant-authored overrides from the Outreach panel (parallelreturns
+  // Settings.tsx → ink-backend merchant.outreach.messages.return_unlocked_*).
+  // Templated with {order_no}, {product}, {return_url}, {merchant_name},
+  // {customer_name}, {return_window} before send. Unset ⇒ hardcoded defaults
+  // (today's shape, no drift for merchants who haven't touched Outreach).
+  subjectOverride?: string;
+  bodyOverride?: string;
+  productName?: string; // template variable for {product}
+}
+
+// One-pass template substitution. Deliberately dumb — no conditionals, no
+// escaping (merchant text is trusted authored copy, not user-generated).
+// Missing keys collapse to empty string so a merchant's stray `{typo}` doesn't
+// leak into the sent email.
+function fillTemplate(
+  tpl: string,
+  vars: Record<string, string | undefined | null>,
+): string {
+  return tpl.replace(/\{(\w+)\}/g, (_m, key) => {
+    const v = vars[key];
+    return v == null ? "" : String(v);
+  });
 }
 
 // Legacy interface for backward compatibility
@@ -43,20 +65,33 @@ export const EmailService = {
       return false;
     }
 
-    const { 
-      to, 
-      customerName, 
-      orderName, 
-      proofUrl, 
+    const {
+      to,
+      customerName,
+      orderName,
+      proofUrl,
       merchantName = "InInk Verified Merchant",
       photoUrls = [],
       returnWindowDays = 30,
       returnUrl,
-      productImageUrl
+      productImageUrl,
+      subjectOverride,
+      bodyOverride,
+      productName,
     } = payload;
 
     // Determine return button URL
     const returnButtonUrl = returnUrl || proofUrl;
+
+    // Template variables shared by merchant-authored subject + body.
+    const tplVars: Record<string, string> = {
+      order_no: orderName,
+      product: productName || "your order",
+      return_url: returnButtonUrl,
+      merchant_name: merchantName,
+      customer_name: customerName,
+      return_window: String(returnWindowDays),
+    };
 
     // Premium HTML Template
     const htmlContent = `
@@ -290,13 +325,39 @@ export const EmailService = {
       </html>
     `;
 
+    // Merchant-authored overrides. Subject-only, body-only, and both-set all
+    // work. When only body is set, we wrap it in a minimal branded frame so a
+    // plain-text merchant template still ships as a readable email — no need to
+    // author full HTML in the Outreach panel.
+    const finalSubject = subjectOverride && subjectOverride.trim()
+      ? fillTemplate(subjectOverride, tplVars)
+      : `Your Order ${orderName} from ${merchantName} is Verified`;
+
+    const filledBody = bodyOverride && bodyOverride.trim()
+      ? fillTemplate(bodyOverride, tplVars)
+      : "";
+    const finalHtml = filledBody
+      ? `<div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;color:#0a0a0a;background:#f5f4ef;padding:32px;line-height:1.55;">
+           <div style="max-width:560px;margin:0 auto;background:#fff;border:1px solid #e6e4dd;padding:32px;">
+             <div style="font-family:'Courier New',monospace;font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#6b6864;margin-bottom:16px;">ink. &middot; ${merchantName}</div>
+             ${filledBody.replace(/\n/g, "<br>")}
+             <div style="margin-top:24px;padding-top:16px;border-top:1px solid #eeece5;">
+               <a href="${returnButtonUrl}" style="display:inline-block;background:#0a0a0a;color:#fff;text-decoration:none;padding:14px 24px;font-weight:700;letter-spacing:0.02em;">Open your order &rarr;</a>
+             </div>
+           </div>
+         </div>`
+      : htmlContent;
+    const finalText = filledBody
+      ? filledBody + `\n\nOpen your order: ${returnButtonUrl}`
+      : `Your delivery for order ${orderName} from ${merchantName} has been verified! Use this link to manage returns: ${returnButtonUrl}`;
+
     try {
       await sendgrid.send({
         to,
         from: fromEmail,
-        subject: `Your Order ${orderName} from ${merchantName} is Verified`,
-        text: `Your delivery for order ${orderName} from ${merchantName} has been verified! Use this link to manage returns: ${returnButtonUrl}`, // Fallback plain text
-        html: htmlContent,
+        subject: finalSubject,
+        text: finalText,
+        html: finalHtml,
       });
 
       console.log(`✅ Return Passport email sent to ${to}`);

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -31,10 +31,14 @@ interface ReturnPassportEmailPayload {
   productName?: string; // template variable for {product}
 }
 
-// One-pass template substitution. Deliberately dumb — no conditionals, no
-// escaping (merchant text is trusted authored copy, not user-generated).
-// Missing keys collapse to empty string so a merchant's stray `{typo}` doesn't
-// leak into the sent email.
+// One-pass template substitution. The TEMPLATE is trusted (merchant-authored),
+// but the VALUES are NOT — {customer_name} and {product} come straight from the
+// Shopify order (buyer-controlled firstName / line-item title), so they can
+// carry markup. This fn stays raw and is safe ONLY where the output lands in a
+// plain-text context (the SendGrid subject line + the text/plain part). For the
+// HTML body, escape the assembled string with escapeHtml() before it goes in a
+// tag. Missing keys collapse to empty string so a merchant's stray `{typo}`
+// doesn't leak into the sent email.
 function fillTemplate(
   tpl: string,
   vars: Record<string, string | undefined | null>,
@@ -43,6 +47,20 @@ function fillTemplate(
     const v = vars[key];
     return v == null ? "" : String(v);
   });
+}
+
+// Escape a plain-text string for safe interpolation into HTML. The merchant
+// Outreach body is authored as plain text (a textarea, not an HTML editor), so
+// escaping the WHOLE assembled string — template + injected values — is correct
+// AND kills the XSS from buyer-controlled {customer_name}/{product}. Newlines
+// are converted to <br> by the caller AFTER escaping, so those tags survive.
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 // Legacy interface for backward compatibility
@@ -336,11 +354,17 @@ export const EmailService = {
     const filledBody = bodyOverride && bodyOverride.trim()
       ? fillTemplate(bodyOverride, tplVars)
       : "";
+    // HTML-safe versions: the body + merchant name may carry buyer-controlled
+    // markup (via {customer_name}/{product} or the shop domain), so escape
+    // before they land in a tag. Newlines → <br> AFTER escaping so the breaks
+    // survive. The plain-text part (finalText) stays raw — no HTML context.
+    const htmlSafeBody = escapeHtml(filledBody).replace(/\n/g, "<br>");
+    const htmlSafeMerchant = escapeHtml(merchantName);
     const finalHtml = filledBody
       ? `<div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;color:#0a0a0a;background:#f5f4ef;padding:32px;line-height:1.55;">
            <div style="max-width:560px;margin:0 auto;background:#fff;border:1px solid #e6e4dd;padding:32px;">
-             <div style="font-family:'Courier New',monospace;font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#6b6864;margin-bottom:16px;">ink. &middot; ${merchantName}</div>
-             ${filledBody.replace(/\n/g, "<br>")}
+             <div style="font-family:'Courier New',monospace;font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#6b6864;margin-bottom:16px;">ink. &middot; ${htmlSafeMerchant}</div>
+             ${htmlSafeBody}
              <div style="margin-top:24px;padding-top:16px;border-top:1px solid #eeece5;">
                <a href="${returnButtonUrl}" style="display:inline-block;background:#0a0a0a;color:#fff;text-decoration:none;padding:14px 24px;font-weight:700;letter-spacing:0.02em;">Open your order &rarr;</a>
              </div>


### PR DESCRIPTION
## Summary
Additive on top of the merged shop-scope fix ([#30](https://github.com/ssmusic/Ink-Shopify-Dashboard/pull/30)). The Return Passport email now respects the merchant's Outreach panel (subject/body templates + toggles) AND refuses to fire when the merchant is flagged test-mode — three independent guards must all pass.

## Guardrails followed
- **G1 RECOVER, don't rebuild:** collides with nothing in-flight; the shop-scope work stays in #30 as merged. Follow-up work — cherry-picking the 6-branch `feat/buyer-profile` stack (branded receipt-email + first-party QR + hardened SMS from `cad233c`+`ce36b10`+`32e272a`) — remains a **separate task** and is called out in the branch-ledger.
- **G2 GATE THE SENDS:** three-stage gate — `SEND_VERIFY_EMAIL=true` env AND merchant is NOT `returns_test_mode`/`is_test` AND `outreach.notifications.email_enabled && delivered_on`. Any failure logs a `📧 SKIP` line + returns.
- **G3 shop-scope untouched:** `api.verify.tsx`'s session-lookup block from #30 is intact — this PR only reads AFTER it.

## Changes
- `email.server.ts`: `subjectOverride` / `bodyOverride` / `productName` with `{order_no|product|return_url|merchant_name|customer_name|return_window}` substitution. Missing keys collapse to empty.
- `api.verify.tsx`: read `merchant.outreach` (snake_case `shop_domain` first — Steve's ink-backend-provisioned doc has only that; camelCase fallback for legacy).
- `api.verify.tsx`: add `title` to the lineItems GraphQL so `{product}` fills. Remove misleading outer send log.

## Pairs with
- ink-backend [#20](https://github.com/ssmusic/ink-backend/pull/20) — the `merchant.outreach.*` source of truth
- parallelreturns [#306](https://github.com/ssmusic/parallelreturns/pull/306) — Settings.tsx save+hydrate

## Test plan
- [ ] Merchant sets `returns_test_mode: true` (Steve, today) → `SEND_VERIFY_EMAIL=true`, hit `/api/verify` → log shows `📧 SKIP (test-mode)`, NO SendGrid call.
- [ ] Merchant flips `returns_test_mode: false`, sets `outreach.messages.return_unlocked_subject: "Ready when you are — {order_no}"` → `/api/verify` → SendGrid 202 with the templated subject.
- [ ] Merchant flips `outreach.notifications.delivered_on: false` → SKIP with `📧 SKIP (merchant outreach off)`.
- [ ] Untouched merchant (no `outreach` field) → hardcoded default subject/body, same as before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)