### PR TITLE
recover(comms): branded receipt email + QR + hardened SMS, behind the §19 send-gate

### DIFF
--- a/app/routes/ink.update.tsx
+++ b/app/routes/ink.update.tsx
@@ -359,6 +359,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                   phone
                   firstName
                 }
+                shippingAddress {
+                  phone
+                }
               }
             }
           `;
@@ -373,7 +376,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
           
           if (orderData?.data?.order?.customer) {
             const customerEmail = orderData.data.order.customer.email;
-            const customerPhone = orderData.data.order.customer.phone;
+            // Shopify often nulls customer.phone but keeps shippingAddress.phone.
+            const customerPhone = orderData.data.order.customer.phone ?? orderData.data.order.shippingAddress?.phone;
             const customerName = orderData.data.order.customer.firstName || "Customer";
             const orderName = orderData.data.order.name;
             

--- a/app/routes/ink.update.tsx
+++ b/app/routes/ink.update.tsx
@@ -1,6 +1,7 @@
 import { type ActionFunctionArgs } from "react-router";
 import crypto from "crypto";
 import { INK_NAMESPACE } from "../utils/metafields.server";
+import { brandSlugFromDomain } from "../services/email.server";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -387,6 +388,50 @@ export const action = async ({ request }: ActionFunctionArgs) => {
             console.log("   - Phone:", customerPhone);
             console.log("   - Email:", customerEmail);
 
+            // ── SEND-GATE (test-merchant + arm switch + branded From) ──
+            // Load the proof's merchant doc ONCE and derive the gates that every
+            // customer send below must pass (Bible §19). Snake_case `shop_domain`
+            // first (ink-backend-provisioned docs), camelCase fallback.
+            const { default: firestore } = await import("../firestore.server");
+            let merchantDoc: Record<string, any> | null = null;
+            try {
+              if (shop_id) {
+                const byId = await firestore.collection("merchants").doc(String(shop_id)).get();
+                if (byId.exists) merchantDoc = byId.data() || null;
+              }
+              if (!merchantDoc) {
+                const s = await firestore.collection("merchants").where("shop_domain", "==", targetSession.shop).limit(1).get();
+                if (!s.empty) merchantDoc = s.docs[0].data();
+              }
+              if (!merchantDoc) {
+                const s = await firestore.collection("merchants").where("shopDomain", "==", targetSession.shop).limit(1).get();
+                if (!s.empty) merchantDoc = s.docs[0].data();
+              }
+            } catch (e) {
+              console.warn("⚠️ Could not load merchant doc for send-gate:", e);
+            }
+            // A test/dev merchant NEVER fires a real customer email/SMS (Steve/
+            // sm-test is returns_test_mode:true). Fail-closed if we can't resolve
+            // the merchant at all — don't send on an unknown store.
+            const isTestMerchant = Boolean(merchantDoc?.returns_test_mode || merchantDoc?.is_test);
+            const merchantResolved = !!merchantDoc;
+            // The branded delivered receipt is off by default; when unarmed it
+            // falls through to the existing generic dispatch (unchanged live
+            // behavior). Arm with SEND_DELIVERED_EMAIL=true on Cloud Run.
+            const deliveredEmailArmed = process.env.SEND_DELIVERED_EMAIL === "true";
+            // Dynamic branded From — {brand}@in.ink via the same resolver that
+            // mints {brand}.in.ink (Bible §19). Falls back to the neutral env From.
+            const brandSlug = brandSlugFromDomain(
+              (merchantDoc?.shop_domain as string) ||
+              (merchantDoc?.shopDomain as string) ||
+              targetSession.shop
+            );
+            if (isTestMerchant || !merchantResolved) {
+              console.log(
+                `📧 Delivered customer sends SKIPPED (${isTestMerchant ? "test-merchant" : "merchant unresolved — fail-closed"}) for ${targetSession.shop}`
+              );
+            }
+
             // ── BRANDED RECEIPT EMAIL (delivered case) ──
             // Paint the SAME branded receipt the tap page is built from
             // (brand book's published page + the proof) and send it via
@@ -404,13 +449,18 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                 const sendgrid = sgModule.default;
 
                 const sgApiKey = process.env.SENDGRID_API_KEY;
-                const sgFromEmail = process.env.SENDGRID_FROM_EMAIL || "noreply@in.ink";
+                const sgFromEmail = process.env.SENDGRID_FROM_EMAIL || "notifications@in.ink";
+                // {brand}@in.ink when the slug resolves, else the neutral default.
+                const brandedFromEmail = brandSlug && brandSlug.length >= 2 ? `${brandSlug}@in.ink` : sgFromEmail;
 
                 // shop_id comes from Alan's webhook payload when present;
                 // fetchBrandBook returns null on anything missing/erroring.
                 const book = shop_id ? await fetchBrandBook(String(shop_id)) : null;
 
-                if (book && customerEmail && sgApiKey && verify_url) {
+                // Gated: armed + not a test merchant + merchant resolved, THEN the
+                // content preconditions (book/email/key/url). Unarmed or test →
+                // skip branded; fall through to the (test-gated) generic dispatch.
+                if (deliveredEmailArmed && !isTestMerchant && merchantResolved && book && customerEmail && sgApiKey && verify_url) {
                   // Map Alan's order_details TOLERANTLY into the shape the
                   // painter reads: order_details.line_items[*] with
                   // { title, description, image_url, unit_price, qty }.
@@ -457,16 +507,19 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                   sendgrid.setApiKey(sgApiKey);
                   await sendgrid.send({
                     to: customerEmail,
-                    from: sgFromEmail,
+                    from: { email: brandedFromEmail, name: data.brandName },
+                    ...(merchantDoc?.support_email || merchantDoc?.owner_email
+                      ? { replyTo: (merchantDoc.support_email || merchantDoc.owner_email) as string }
+                      : {}),
                     subject: `${data.brandName} — your receipt`,
                     html,
                   });
 
                   brandedReceiptSent = true;
-                  console.log(`✅ Branded receipt email sent to ${customerEmail} (${data.brandName})`);
+                  console.log(`✅ Branded receipt email sent to ${customerEmail} (${data.brandName}, from ${brandedFromEmail})`);
                 } else {
                   console.log(
-                    `ℹ️ Branded receipt skipped (book: ${!!book}, email: ${!!customerEmail}, sgKey: ${!!sgApiKey}, verify_url: ${!!verify_url}) — falling back to generic path.`
+                    `ℹ️ Branded receipt skipped (armed: ${deliveredEmailArmed}, test: ${isTestMerchant}, book: ${!!book}, email: ${!!customerEmail}, sgKey: ${!!sgApiKey}, verify_url: ${!!verify_url}) — falling back to generic path.`
                   );
                 }
               } catch (receiptErr: any) {
@@ -474,13 +527,18 @@ export const action = async ({ request }: ActionFunctionArgs) => {
               }
             }
 
-            // Fetch Merchant Settings from Firestore
-            const { default: firestore } = await import("../firestore.server");
-            const settingsSnap = await firestore.collection("merchants").where("shopDomain", "==", targetSession.shop).limit(1).get();
-            const merchantName = settingsSnap.empty ? targetSession.shop : (settingsSnap.docs[0].data().shopName || targetSession.shop);
-            const settings = settingsSnap.empty ? null : settingsSnap.docs[0].data().notification_settings;
+            // Merchant name + notification settings from the already-loaded doc
+            // (no second Firestore read; reuses `merchantDoc` from the send-gate).
+            const merchantName =
+              (merchantDoc?.shopName as string) ||
+              (merchantDoc?.shop_name as string) ||
+              targetSession.shop;
+            const settings = merchantDoc?.notification_settings || null;
 
-            if (!settings) {
+            if (!merchantResolved || isTestMerchant) {
+               // Test merchant or unresolved store — never fire a real customer
+               // notification (already logged by the send-gate above).
+            } else if (!settings) {
                console.warn(`⚠️ No Notification Settings found for merchant ${targetSession.shop}. Skipping notifications.`);
             } else {
                const { NotificationService } = await import("../services/notifications.server");

--- a/app/routes/ink.update.tsx
+++ b/app/routes/ink.update.tsx
@@ -437,9 +437,16 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                   };
 
                   const data = buildReceiptEmailData(book, proof);
+                  // First-party QR image: the ink-backend /api/qr endpoint renders
+                  // an SVG QR encoding the receipt URL. INK_API_URL already ends in
+                  // "/api" (same constant used across this app for ink calls), so
+                  // `${INK_API_URL}/qr` resolves to /api/qr.
+                  const INK_API_BASE =
+                    process.env.INK_API_URL ||
+                    "https://us-central1-inink-c76d3.cloudfunctions.net/api";
                   const html = renderReceiptEmail(data, {
                     receiptUrl: verify_url,
-                    qrImageUrl: null,
+                    qrImageUrl: `${INK_API_BASE}/qr?u=${encodeURIComponent(verify_url)}`,
                     poweredByInk: true,
                   });
 

--- a/app/routes/ink.update.tsx
+++ b/app/routes/ink.update.tsx
@@ -8,6 +8,20 @@ const CORS_HEADERS = {
   "Access-Control-Allow-Headers": "Content-Type, X-INK-Signature, Authorization, Accept",
 };
 
+/**
+ * Fallback merchant name for the branded receipt's `proof.merchant`. The
+ * painter only uses this when the brand book has no runtime/site/IG name, so a
+ * best-effort name is fine: prefer order_details.merchant, else the shop
+ * domain's stem (e.g. "buckmason" → "Buckmason").
+ */
+function merchantNameForReceipt(targetSession: any, orderDetails: any): string {
+  const fromOrder = (orderDetails?.merchant || orderDetails?.merchant_name || "").toString().trim();
+  if (fromOrder) return fromOrder;
+  const shop: string = targetSession?.shop || "";
+  const stem = shop.replace(/\.myshopify\.com$/i, "").split(".")[0] || "";
+  return stem ? stem.charAt(0).toUpperCase() + stem.slice(1) : "";
+}
+
 // Handle OPTIONS preflight
 export const loader = async () => {
   return new Response(null, {
@@ -87,6 +101,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       timestamp,
       verify_url,
       device_info,
+      // Best-effort: Alan's webhook may also carry the proof's shop_id +
+      // order_details. Used (when present) to paint the branded receipt email.
+      shop_id,
+      order_details,
     } = payload;
 
     console.log("📦 Webhook data:", {
@@ -365,6 +383,86 @@ export const action = async ({ request }: ActionFunctionArgs) => {
             console.log("   - Phone:", customerPhone);
             console.log("   - Email:", customerEmail);
 
+            // ── BRANDED RECEIPT EMAIL (delivered case) ──
+            // Paint the SAME branded receipt the tap page is built from
+            // (brand book's published page + the proof) and send it via
+            // SendGrid. This REPLACES the old generic delivered email when it
+            // succeeds. Best-effort + fully guarded: if the book or customer
+            // email is missing — or anything throws — we fall straight through
+            // to the existing NotificationService.dispatch path below, so we
+            // never regress or send nothing. The webhook must never break.
+            let brandedReceiptSent = false;
+            if (status === "delivered") {
+              try {
+                const { fetchBrandBook, buildReceiptEmailData, renderReceiptEmail } =
+                  await import("../services/receipt-email");
+                const sgModule = await import("@sendgrid/mail");
+                const sendgrid = sgModule.default;
+
+                const sgApiKey = process.env.SENDGRID_API_KEY;
+                const sgFromEmail = process.env.SENDGRID_FROM_EMAIL || "noreply@in.ink";
+
+                // shop_id comes from Alan's webhook payload when present;
+                // fetchBrandBook returns null on anything missing/erroring.
+                const book = shop_id ? await fetchBrandBook(String(shop_id)) : null;
+
+                if (book && customerEmail && sgApiKey && verify_url) {
+                  // Map Alan's order_details TOLERANTLY into the shape the
+                  // painter reads: order_details.line_items[*] with
+                  // { title, description, image_url, unit_price, qty }.
+                  // Alan/enroll use `product_details` with { name, image_url,
+                  // price, quantity }, so mirror both.
+                  const od: any = order_details || {};
+                  const rawItems: any[] = od.line_items || od.product_details || [];
+                  const lineItems = (Array.isArray(rawItems) ? rawItems : []).map((it: any) => ({
+                    title: it?.title || it?.name || "",
+                    description: it?.description || "",
+                    image_url: it?.image_url || it?.imageUrl || null,
+                    unit_price: it?.unit_price || it?.price || "",
+                    qty: it?.qty ?? it?.quantity ?? 1,
+                  }));
+
+                  const proof: any = {
+                    merchant: merchantNameForReceipt(targetSession, order_details),
+                    order_id: order_id,
+                    order_details: {
+                      customer_name:
+                        od.customer_name ||
+                        orderData.data.order.customer.firstName ||
+                        customerName ||
+                        "",
+                      order_number: od.order_number || orderName || order_id || "",
+                      line_items: lineItems,
+                    },
+                  };
+
+                  const data = buildReceiptEmailData(book, proof);
+                  const html = renderReceiptEmail(data, {
+                    receiptUrl: verify_url,
+                    qrImageUrl: null,
+                    poweredByInk: true,
+                  });
+
+                  sendgrid.setApiKey(sgApiKey);
+                  await sendgrid.send({
+                    to: customerEmail,
+                    from: sgFromEmail,
+                    subject: `${data.brandName} — your receipt`,
+                    html,
+                  });
+
+                  brandedReceiptSent = true;
+                  console.log(`✅ Branded receipt email sent to ${customerEmail} (${data.brandName})`);
+                } else {
+                  console.log(
+                    `ℹ️ Branded receipt skipped (book: ${!!book}, email: ${!!customerEmail}, sgKey: ${!!sgApiKey}, verify_url: ${!!verify_url}) — falling back to generic path.`
+                  );
+                }
+              } catch (receiptErr: any) {
+                console.error("❌ Branded receipt email failed — falling back to generic path:", receiptErr?.message || receiptErr);
+              }
+            }
+
             // Fetch Merchant Settings from Firestore
             const { default: firestore } = await import("../firestore.server");
             const settingsSnap = await firestore.collection("merchants").where("shopDomain", "==", targetSession.shop).limit(1).get();
@@ -380,6 +478,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                let notificationType: any = null;
                if (status === "delivered") notificationType = "delivered";
                if (status === "verified") notificationType = "deliveryConfirmed";
+
+               // If we already sent the new branded receipt for the delivered
+               // case, don't ALSO fire the old generic delivered notification.
+               if (brandedReceiptSent && notificationType === "delivered") {
+                 console.log("ℹ️ Branded receipt already sent — skipping generic 'delivered' notification.");
+                 notificationType = null;
+               }
 
                if (notificationType) {
                  console.log(`📨 Dispatching immediate [${notificationType}] notification via NotificationService...`);

--- a/app/routes/webhooks.fulfillments_update.tsx
+++ b/app/routes/webhooks.fulfillments_update.tsx
@@ -45,6 +45,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
             phone
             firstName
           }
+          shippingAddress {
+            phone
+          }
           proofMetafield: metafield(namespace: "ink", key: "proof_reference") { value }
           verifyUrlMetafield: metafield(namespace: "ink", key: "verify_url") { value }
         }
@@ -115,7 +118,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
     if (notificationType) {
       const customerEmail = order.customer?.email;
-      const customerPhone = order.customer?.phone;
+      // Shopify often nulls customer.phone but keeps shippingAddress.phone.
+      const customerPhone = order.customer?.phone ?? order.shippingAddress?.phone;
       const customerName = order.customer?.firstName || "Customer";
       // Use the REAL verify_url that Alan's /ink/update webhook stored on the
       // order (canonical {brand}.in.ink/r/{token}). The old code built

--- a/app/routes/webhooks.fulfillments_update.tsx
+++ b/app/routes/webhooks.fulfillments_update.tsx
@@ -46,6 +46,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
             firstName
           }
           proofMetafield: metafield(namespace: "ink", key: "proof_reference") { value }
+          verifyUrlMetafield: metafield(namespace: "ink", key: "verify_url") { value }
         }
       }
     `;
@@ -116,7 +117,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       const customerEmail = order.customer?.email;
       const customerPhone = order.customer?.phone;
       const customerName = order.customer?.firstName || "Customer";
-      const verifyUrl = order.proofMetafield?.value ? `https://shop.in.ink/t/${order.proofMetafield.value}` : undefined;
+      // Use the REAL verify_url that Alan's /ink/update webhook stored on the
+      // order (canonical {brand}.in.ink/r/{token}). The old code built
+      // `https://shop.in.ink/t/${proof_reference}` which is a known-bad link
+      // (wrong host + proof_reference is not the token). If no real verify_url
+      // is on the order yet, omit the URL rather than send a broken one.
+      const verifyUrl = order.verifyUrlMetafield?.value || undefined;
 
       console.log(`\n📨 Dispatching immediate [${notificationType}] notification via NotificationService...`);
       console.log(`   - To: ${customerName}`);

--- a/app/routes/webhooks.fulfillments_update.tsx
+++ b/app/routes/webhooks.fulfillments_update.tsx
@@ -80,19 +80,17 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     }
 
     const merchantData = settingsSnap.docs[0].data();
-    // Never fire a real customer notification from a test/dev merchant (Bible §19).
-    if (merchantData.returns_test_mode || merchantData.is_test) {
-      console.log(`📧 Notifications SKIPPED (test-merchant: returns_test_mode/is_test) for ${shop}.`);
-      return new Response("OK", { status: 200 });
-    }
     const settings = merchantData.notification_settings;
     const merchantName = merchantData.shopName || shop;
 
     // ── Mark the proof DELIVERED at the REAL carrier-delivered moment. This is
     // now the authoritative delivered_at (orders/fulfilled no longer marks at
-    // ship time). Runs BEFORE the notification-settings gate so delivery is
-    // recorded even for merchants with no notifications configured. Best-effort:
-    // a failure must never block the notification or the 200. ──
+    // ship time). Runs BEFORE the test-merchant and notification-settings gates:
+    // delivery is a FACT and must be recorded for every merchant — test-flagged
+    // ones included (as of 2026-07-01 ALL merchants are test-flagged, so gating
+    // this would kill delivery detection platform-wide). The gates below only
+    // suppress customer NOTIFICATIONS. Best-effort: a failure must never block
+    // the notification or the 200. ──
     if (shipmentStatus === "delivered" && order.proofMetafield?.value) {
       const merchantApiKey = merchantData.ink_api_key;
       if (merchantApiKey) {
@@ -109,6 +107,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       } else {
         console.log(`⚠️ No ink_api_key for ${shop}; cannot mark proof delivered.`);
       }
+    }
+
+    // Never fire a real customer notification from a test/dev merchant (Bible
+    // §19/§20). Sits AFTER mark-delivered on purpose: it gates only the
+    // notification dispatch below, never the delivered_at record.
+    if (merchantData.returns_test_mode || merchantData.is_test) {
+      console.log(`📧 Notifications SKIPPED (test-merchant: returns_test_mode/is_test) for ${shop}.`);
+      return new Response("OK", { status: 200 });
     }
 
     if (!settings) {

--- a/app/routes/webhooks.fulfillments_update.tsx
+++ b/app/routes/webhooks.fulfillments_update.tsx
@@ -80,6 +80,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     }
 
     const merchantData = settingsSnap.docs[0].data();
+    // Never fire a real customer notification from a test/dev merchant (Bible §19).
+    if (merchantData.returns_test_mode || merchantData.is_test) {
+      console.log(`📧 Notifications SKIPPED (test-merchant: returns_test_mode/is_test) for ${shop}.`);
+      return new Response("OK", { status: 200 });
+    }
     const settings = merchantData.notification_settings;
     const merchantName = merchantData.shopName || shop;
 

--- a/app/services/notifications.server.ts
+++ b/app/services/notifications.server.ts
@@ -6,9 +6,26 @@ const TWILIO_SID = process.env.TWILIO_ACCOUNT_SID;
 const TWILIO_TOKEN = process.env.TWILIO_AUTH_TOKEN;
 const TWILIO_PHONE = process.env.TWILIO_PHONE_NUMBER;
 
+const TWILIO_MESSAGING_SERVICE_SID = process.env.TWILIO_MESSAGING_SERVICE_SID;
+
 const twilioClient = TWILIO_SID && TWILIO_TOKEN ? twilio(TWILIO_SID, TWILIO_TOKEN) : null;
 
-export type NotificationType = 
+/**
+ * Normalize a phone number to E.164 (Twilio rejects anything else).
+ * Returns null for anything we can't confidently coerce — callers must bail
+ * rather than send to a malformed number.
+ */
+function normalizeE164(p?: string | null): string | null {
+  if (!p) return null;
+  const d = p.replace(/[^\d+]/g, "");
+  if (d.startsWith("+")) return d;
+  const only = d.replace(/\D/g, "");
+  if (only.length === 10) return `+1${only}`;
+  if (only.length === 11 && only.startsWith("1")) return `+${only}`;
+  return null;
+}
+
+export type NotificationType =
   | "outForDelivery" 
   | "delivered" 
   | "deliveryConfirmed" 
@@ -83,7 +100,20 @@ export const NotificationService = {
       return false;
     }
 
-    if (!payload.toPhone) return false;
+    // Normalize the recipient to E.164. Bail on anything we can't coerce —
+    // Twilio would reject it anyway. Never log the phone number.
+    const toNumber = normalizeE164(payload.toPhone);
+    if (!toNumber) {
+      console.warn("⚠️ SMS skipped: recipient phone is missing or not a valid number.");
+      return false;
+    }
+
+    // Strip a known-bad legacy link before sending. The old `in.ink/verify/...`
+    // URL is broken (wrong host + not the real token); if we see it, drop the
+    // URL so the body falls back to the no-link copy rather than SMS a dead link.
+    if (payload.verifyUrl && /in\.ink\/verify\//.test(payload.verifyUrl)) {
+      payload = { ...payload, verifyUrl: undefined };
+    }
 
     // Format message based on type
     let messageBody = "";
@@ -93,7 +123,9 @@ export const NotificationService = {
         messageBody = `Hi ${payload.customerName}, your order ${payload.orderName} from ${payload.merchantName} is out for delivery today. Get ready to tap your ink. sticker!`;
         break;
       case "delivered":
-        messageBody = `Your package ${payload.orderName} has arrived! Tap the ink. sticker on the box with your phone to verify delivery and unlock your return window.`;
+        messageBody = payload.verifyUrl
+          ? `Your ${payload.merchantName} order ${payload.orderName} was delivered. Your receipt + returns: ${payload.verifyUrl}`
+          : `Your package ${payload.orderName} has arrived! Tap the ink. sticker on the box to verify delivery and unlock your return window.`;
         break;
       case "deliveryConfirmed":
         messageBody = `Verified! Your ink. delivery for ${payload.orderName} is confirmed. ${payload.verifyUrl ? `View your passport: ${payload.verifyUrl}` : ""}`;
@@ -115,16 +147,34 @@ export const NotificationService = {
         break;
     }
 
+    // Production A2P / toll-free pools send via a Messaging Service; otherwise
+    // fall back to a single normalized from-number. Guard the from-number too —
+    // if neither a Messaging Service nor a valid from-number is configured, we
+    // can't send.
+    const fromNumber = normalizeE164(TWILIO_PHONE);
+    if (!TWILIO_MESSAGING_SERVICE_SID && !fromNumber) {
+      console.warn("⚠️ SMS skipped: no TWILIO_MESSAGING_SERVICE_SID and no valid TWILIO_PHONE_NUMBER configured.");
+      return false;
+    }
+
+    const createParams: any = {
+      body: messageBody,
+      to: toNumber,
+    };
+    if (TWILIO_MESSAGING_SERVICE_SID) {
+      createParams.messagingServiceSid = TWILIO_MESSAGING_SERVICE_SID;
+    } else {
+      createParams.from = fromNumber;
+    }
+
     try {
-      await twilioClient.messages.create({
-        body: messageBody,
-        from: TWILIO_PHONE,
-        to: payload.toPhone,
-      });
-      console.log(`✅ SMS (${payload.type}) sent via Twilio to ${payload.toPhone}`);
+      await twilioClient.messages.create(createParams);
+      console.log(`✅ SMS (${payload.type}) sent via Twilio.`);
       return true;
     } catch (error: any) {
-      console.error(`❌ Twilio SMS failed:`, error.message);
+      // Surface Twilio's code + message (e.g. 21608 trial-unverified recipient,
+      // 21211 bad to-number, 21610 unsubscribed). Never log phone/creds.
+      console.error(`❌ Twilio SMS failed [code ${error?.code ?? "?"}]: ${error?.message ?? error}`);
       return false;
     }
   },

--- a/app/services/receipt-email.ts
+++ b/app/services/receipt-email.ts
@@ -1,0 +1,217 @@
+// The EMAIL painter + a SERVER-SAFE assembler.
+//
+// COPIED VERBATIM from parallelreturns src/lib/email/receipt-email.ts so the
+// SendGrid send rail in the Shopify app can paint the SAME branded receipt the
+// tap page is built from. The ONLY change vs. the source is the two type-only
+// imports (BrandBook / Proof) → local `any` so this compiles standalone, plus
+// the added `fetchBrandBook` helper at the bottom. Do NOT change painter logic.
+//
+// The receipt email is EMITTED from the SAME source the tap page is built from —
+// the brand book's published page (`book.tap_page`: its hero media + headline +
+// deck, in the merchant's tokens) + the proof (the order). Change the page →
+// the email changes, with nothing to hand-sync.
+//
+// The live tap-page engine (`buildTapPageContext`/`generateTapPage`) is CLIENT-side
+// (Supabase + localStorage), so it can't run in the send rail. `buildReceiptEmailData`
+// is a PURE, server-safe reader of the same `book.tap_page` + proof. Both functions
+// are pure (no React / DOM / Supabase) so they run in the SendGrid rail.
+//
+// DATA-SHAPE NOTES for the rail:
+//   - The brand book lives at `response.brand_book.book` (NOT `response.brand_book`).
+//   - The book JSON can carry raw control chars → parse with a tolerant strip:
+//     `JSON.parse(text.replace(/[\x00-\x1f]/g, " "))`.
+//   - The hero is often a VIDEO (`tap_page.hero_video_url`); email uses the poster
+//     image (`tap_page.hero_url`), and the full video plays on the live page.
+
+// Local minimal types so this file compiles standalone (the real BrandBook /
+// Proof types live in the parallelreturns repo, not the Shopify app).
+type BrandBook = any;
+type Proof = any;
+
+export interface ReceiptEmailData {
+  brandName: string;
+  /** The page's hero headline (e.g. "Start the timer"). */
+  headline: string;
+  /** The page's hero deck / subline. */
+  deck: string;
+  /** Hero image — the page's hero (IG photo or video POSTER). */
+  heroUrl: string | null;
+  ink: string;
+  accent: string;
+  surface: string;
+  displayFont: string;
+  bodyFont: string;
+  product: string;
+  /** The bought product's photo — STAMPED in the hero corner, mirroring the
+   *  tap page. null when there's no product image, or it IS the hero. */
+  productImageUrl: string | null;
+  orderNo: string;
+}
+
+export interface ReceiptEmailInput {
+  receiptUrl: string;
+  qrImageUrl?: string | null;
+  poweredByInk?: boolean;
+}
+
+function esc(s: unknown): string {
+  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function safeFont(family: string | undefined | null, fallback: string): string {
+  return family ? `'${family}', ${fallback}` : fallback;
+}
+
+function brandNameFromUrl(url: string | undefined | null): string {
+  if (!url) return "";
+  const host = url.replace(/^https?:\/\//i, "").replace(/^www\./i, "").split("/")[0] ?? "";
+  const stem = host.split(".")[0] ?? "";
+  return stem ? stem.charAt(0).toUpperCase() + stem.slice(1) : "";
+}
+
+/** SERVER-SAFE: assemble the painter's data from the brand book's published page +
+ *  proof — the same source the tap page renders from. Pure. */
+export function buildReceiptEmailData(book: BrandBook, proof: Proof): ReceiptEmailData {
+  const runtime = book.runtime?.parallel_brand_runtime;
+  const colors = book.tokens?.colors;
+  const rtColors = runtime?.design_tokens?.colors;
+  const ink = rtColors?.text ?? colors?.ink ?? "#111111";
+  const accent = rtColors?.accent ?? colors?.accent ?? ink;
+
+  const type = book.tokens?.typography;
+  // Email can't load the brand's Adobe/Typekit face (e.g. acumin-pro-extra-
+  // condensed), so the FALLBACK must carry the brand's CHARACTER, not collapse
+  // to a serif. Condensed-sans stack: Oswald (webfont-loaded in the head for
+  // Apple/iOS Mail) → Arial Narrow / Helvetica → sans. Never serif.
+  const displayFont = safeFont(type?.display?.family, "'Oswald', 'Arial Narrow', 'Helvetica Neue', Arial, sans-serif");
+  const bodyFont = safeFont(type?.body?.family, "Inter, system-ui, sans-serif");
+
+  const brandName =
+    runtime?.brand?.name?.trim() ||
+    book.dembrandt?.siteName?.trim() ||
+    book.instagram?.owner_full_name?.trim() ||
+    brandNameFromUrl(book.source_url) ||
+    proof.merchant ||
+    "";
+
+  const od = proof.order_details;
+  const item0 = od?.line_items?.[0];
+  const product = item0?.title || item0?.description || "";
+  const orderNo = od?.order_number || proof.order_id || "";
+
+  // The published page's hero — its headline / deck / media win; the product is
+  // only the fallback when the merchant hasn't published a page.
+  const tap = book.tap_page;
+  const heroSection = tap?.custom_sections?.find((s: any) => s.kind === "hero");
+  const headline = (heroSection && "headline" in heroSection ? heroSection.headline : "") || product || "Your order";
+  // Always STATE what was bought. The page's deck wins; otherwise a neutral
+  // product line that mirrors the live tap page ("{first name}, your {product}
+  // is here.") so the email never leaves the order unnamed.
+  const firstName = (od?.customer_name || "").trim().split(/\s+/)[0] || "";
+  const pageDeck = (heroSection && "deck" in heroSection ? heroSection.deck : "") || "";
+  const deck = pageDeck || (product ? `${firstName ? `${firstName}, your` : "Your"} ${product} is here.` : "");
+  // Email shows the poster image (hero_url); the video (hero_video_url) plays on
+  // the live page. Falls back to product image only when the page has no hero.
+  const heroUrl = tap?.hero_url || (tap?.hero_images && tap.hero_images[0]) || item0?.image_url || null;
+  // The bought product's photo, STAMPED in the hero corner — but only when it's
+  // DISTINCT from the hero (else a product-only hero would stamp itself), exactly
+  // like the tap page's ProductStamp guard.
+  const productImageUrl = item0?.image_url && item0.image_url !== heroUrl ? item0.image_url : null;
+
+  return { brandName, headline, deck, heroUrl, ink, accent, surface: "#ffffff", displayFont, bodyFont, product, productImageUrl, orderNo };
+}
+
+/** Paint the email — hero-forward, mirroring the tap page: brand mark → big hero →
+ *  headline → deck → CTA into the live page. Inbox-safe (tables, inline styles). */
+export function renderReceiptEmail(data: ReceiptEmailData, input: ReceiptEmailInput): string {
+  const { ink, surface, displayFont: display, bodyFont: body, brandName: brand, headline, deck, heroUrl: hero, product, productImageUrl: stamp, orderNo } = data;
+
+  const heroImg = `<img src="${esc(hero)}" width="600" alt="${esc(headline)}" style="width:100%;max-width:600px;height:auto;display:block;border:0;outline:none;" />`;
+  // The bought product is STAMPED in the hero's bottom-right corner, mirroring the
+  // tap page. position:absolute renders the corner in Apple/iOS Mail (the bulk of
+  // opens); Gmail/Outlook strip positioning so the product flows just under the
+  // hero — degraded but never broken, and the hero ALWAYS shows (it's a real
+  // <img>, no background-image dependency).
+  // The whole hero (image + product stamp) is a LINK into the live receipt —
+  // tap the picture, open the door.
+  const heroBlock = hero
+    ? `<tr><td style="padding:0;">
+         <a href="${esc(input.receiptUrl)}" target="_blank" style="display:block;text-decoration:none;">
+           <div style="position:relative;line-height:0;font-size:0;">
+             ${heroImg}${stamp ? `
+             <div style="position:absolute;right:14px;bottom:14px;width:22%;max-width:132px;line-height:0;">
+               <img src="${esc(stamp)}" width="132" alt="${esc(product)}" style="width:100%;height:auto;display:block;border-radius:12px;border:3px solid #ffffff;box-shadow:0 6px 18px rgba(0,0,0,0.28);" />
+             </div>` : ""}
+           </div>
+         </a>
+       </td></tr>`
+    : "";
+
+  const deckBlock = deck
+    ? `<tr><td style="padding:10px 34px 0;font:16px/1.5 ${body};color:${esc(ink)};opacity:.7;">${esc(deck)}</td></tr>`
+    : "";
+
+  const metaBits = [esc(product), orderNo ? `Order ${esc(orderNo)}` : ""].filter((s) => s && s.length).join(" &nbsp;&middot;&nbsp; ");
+  const metaBlock = metaBits
+    ? `<tr><td style="padding:18px 34px 0;font:12px/1.5 ${body};color:${esc(ink)};opacity:.5;letter-spacing:.02em;">${metaBits}</td></tr>`
+    : "";
+
+  const qrBlock = input.qrImageUrl
+    ? `<tr><td style="padding:18px 34px 0;">
+         <table role="presentation" cellpadding="0" cellspacing="0"><tr>
+           <td style="padding-right:14px;"><img src="${esc(input.qrImageUrl)}" width="74" height="74" alt="Scan to open your receipt" style="display:block;border-radius:8px;background:#fff;border:0;" /></td>
+           <td style="font:13px/1.45 ${body};color:${esc(ink)};opacity:.7;">On a laptop?<br/>Scan to open it on your phone.</td>
+         </tr></table>
+       </td></tr>`
+    : "";
+
+  const footer = input.poweredByInk
+    ? `<tr><td style="padding:24px 34px 28px;font:11px/1 ${body};color:${esc(ink)};opacity:.4;letter-spacing:.04em;">Powered by ink.</td></tr>`
+    : `<tr><td style="padding:18px 34px 26px;"></td></tr>`;
+
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="color-scheme" content="light"/><title>${esc(brand)} &mdash; ${esc(headline)}</title><style>@import url('https://fonts.googleapis.com/css2?family=Oswald:wght@500;700&display=swap');</style></head>
+<body style="margin:0;padding:0;background:#ededeb;">
+<span style="display:none!important;opacity:0;color:transparent;height:0;width:0;overflow:hidden;">${esc(headline)} &mdash; open your receipt.</span>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#ededeb;">
+  <tr><td align="center" style="padding:22px 10px;">
+    <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="width:600px;max-width:600px;background:${esc(surface)};border-radius:16px;overflow:hidden;">
+      <tr><td style="padding:24px 34px 18px;font:700 15px/1 ${display};letter-spacing:.2em;color:${esc(ink)};text-transform:uppercase;">${esc(brand)}</td></tr>
+      ${heroBlock}
+      <tr><td style="padding:26px 34px 0;font:700 44px/1.0 ${display};letter-spacing:-.015em;color:${esc(ink)};">${esc(headline)}</td></tr>
+      ${deckBlock}
+      ${metaBlock}
+      <tr><td style="padding:26px 34px 0;">
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"><tr>
+          <td align="center" bgcolor="${esc(ink)}" style="border-radius:40px;background:${esc(ink)};">
+            <a href="${esc(input.receiptUrl)}" target="_blank" style="display:block;padding:17px 24px;font:700 16px/1 ${display};letter-spacing:.04em;color:#ffffff;text-decoration:none;">OPEN YOUR RECEIPT&nbsp;&nbsp;&rarr;</a>
+          </td>
+        </tr></table>
+      </td></tr>
+      ${qrBlock}
+      ${footer}
+    </table>
+  </td></tr>
+</table>
+</body></html>`;
+}
+
+/**
+ * SERVER-SAFE brand-book fetch for the send rail. Pulls the published brand book
+ * from the public worker proxy and returns `response.brand_book.book` (the shape
+ * `buildReceiptEmailData` expects), or null on any error. Tolerant of raw
+ * control chars in the book JSON (strips them before parse). Never throws.
+ */
+export async function fetchBrandBook(shopId: string): Promise<any | null> {
+  try {
+    const r = await fetch(
+      `https://ink-easypost-proxy.inink.workers.dev/api/public/brand-book?shop_id=${encodeURIComponent(shopId)}`
+    );
+    const txt = await r.text();
+    // Tolerant control-char strip (the book JSON can carry raw control chars).
+    const json = JSON.parse(txt.replace(/[\x00-\x1f]/g, " "));
+    return json?.brand_book?.book ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What this is
**RECOVER, don't rebuild** — the branded post-delivery receipt email + first-party QR-in-email + hardened delivered-SMS were already built on the stranded `feat/buyer-profile` 6-branch stack. This cherry-picks the three real commits onto current `main` (all clean, typecheck 0 errors) and wires them behind the **layered send-gate** (Bible §19).

Recovered commits: `cad233c` (branded receipt + `receipt-email.ts` painter) · `ce36b10` (`/api/qr` image in email) · `32e272a` (delivered SMS carries the real `verify_url` + E164 normalize + messaging-service).

## The gate I added (these paths predated it)
- **Test-merchant** → `returns_test_mode`/`is_test` = SKIP every customer send (both the `ink.update` delivered-block AND the `fulfillments_update` dispatch). Steve/sm-test can never fire to a real buyer.
- **Fail-closed** — unresolved merchant → skip.
- **Arm switch** — branded receipt is OFF unless `SEND_DELIVERED_EMAIL=true`; unarmed → falls through to the existing generic dispatch (**zero live behavior change**).
- **Dynamic branded From** — `{brand}@in.ink` via `brandSlugFromDomain` + name + reply-to; neutral `notifications@in.ink` fallback (was hardcoded `noreply@in.ink`).

## ⚠️ Do not merge without Sam — this is the LIVE customer-facing send rail
Merging auto-deploys to Cloud Run. **Nothing fires today regardless** (arm switch off + backend SendGrid creds unset + Steve test-mode), but this is the delivered-notification path to real buyers — his explicit gate.

## Verification
- `tsc --noEmit` → 0 errors.
- Cherry-picks applied clean onto `main` (no conflicts).
- Gate logic traced: test-merchant / unresolved / unarmed all skip; only a real, armed, resolved merchant with a book+email+key+verify_url sends branded.

Pairs with the merged §19 work (outreach config, dynamic From on the return-passport path, backend send-gate). Completes the "recover the stranded send-stack" open item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)