### PR TITLE
fix(verify): resolve shop session via snake_case shop_domain (wrong-shop fallback)

### DIFF
--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -534,10 +534,15 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                         for (const doc of allMerchants.docs) {
                             const data = doc.data();
                             if (
+                                doc.id === proofShopId ||
                                 data.shop_id === proofShopId ||
                                 data.ink_shop_id === proofShopId
                             ) {
-                                targetShopDomain = data.shopDomain || "";
+                                // snake_case shop_domain is ink-backend's field (the
+                                // only one on Steve/sm-test); camelCase shopDomain is
+                                // the embed's. Read both or the resolution silently
+                                // misses and we fall back to the WRONG shop's session.
+                                targetShopDomain = data.shopDomain || data.shop_domain || "";
                                 if (targetShopDomain) break;
                             }
                         }


### PR DESCRIPTION
Observed live: a verify on the sm-test proof logged `FALLBACK: no offline session for proof shop` and searched ink-test-store-2 for the order. Root cause: the shop_id→domain loop reads only camelCase `shopDomain`; ink-backend merchant docs carry snake_case `shop_domain`. Now reads both + matches `doc.id`. Same bug class as #30/#32, same additive style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)