### PR TITLE
fix(email): subject/body use brand name, not raw store handle

### DIFF
--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -892,7 +892,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                                 proofUrl: alanData.verify_url || `https://in.ink/verify/${alanData.proof_id}`,
                                 photoUrls: photoUrls,
                                 returnWindowDays: rWindow,
-                                merchantName: session.shop.replace('.myshopify.com', ''),
+                                // Brand name, never the raw store handle: the subject
+                                // and body render this ("Your Order … from X"), and a
+                                // handle like sm-test-hhawzn52 mismatching the branded
+                                // From is both spam-filter bait and broken-looking in
+                                // a demo. Same precedence as the From-name.
+                                merchantName:
+                                    senderFromName ||
+                                    session.shop.replace('.myshopify.com', ''),
                                 productImageUrl: productImageUrl,
                                 subjectOverride: outreachSubject,
                                 bodyOverride: outreachBody,


### PR DESCRIPTION
First live sends landed in spam; one contributor is the subject 'Your Order #1008 from sm-test-hhawzn52' mismatching the Steve Madden branded From. merchantName now uses the same shop_name precedence as the From-name, with the handle as fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)