### PR TITLE
fix(copy): strip verification/NFC framing from customer emails + SMS (Brand Bible sweep)

### DIFF
--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -116,7 +116,7 @@ export const EmailService = {
       customerName,
       orderName,
       proofUrl,
-      merchantName = "InInk Verified Merchant",
+      merchantName = "your store",
       photoUrls = [],
       returnWindowDays = 30,
       returnUrl,
@@ -155,7 +155,7 @@ export const EmailService = {
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>Delivery Unlocked - ${orderName}</title>
+        <title>Your order has arrived — ${orderName}</title>
         <style type="text/css">
           @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Inter:wght@400;500;600&display=swap');
           
@@ -302,9 +302,9 @@ export const EmailService = {
           <div class="content">
             <div class="order-badge">Order ${orderName}</div>
             
-            <h2 class="main-heading">Delivery Unlocked</h2>
+            <h2 class="main-heading">Your order has arrived</h2>
             <p class="sub-heading">
-              Hi ${customerName}, your package from <strong>${merchantName}</strong> has been successfully verified and unlocked.
+              Hi ${customerName}, your order from <strong>${merchantName}</strong> has arrived. Delivery confirmed.
             </p>
 
             ${productImageUrl ? `
@@ -331,11 +331,11 @@ export const EmailService = {
             <!-- Photos Section (if needed) -->
             ${photoUrls.length > 0 ? `
               <div style="margin-top: 40px; text-align: left;">
-                <p style="font-size: 13px; font-weight: 600; color: #000; margin-bottom: 12px;">ENROLLMENT PHOTOS</p>
+                <p style="font-size: 13px; font-weight: 600; color: #000; margin-bottom: 12px;">PACKED FOR SHIPMENT</p>
                 <div style="white-space: nowrap; overflow-x: auto; padding-bottom: 10px;">
                   ${photoUrls.slice(0, 3).map(url => `
                     <div style="display: inline-block; width: 80px; height: 80px; margin-right: 8px; border-radius: 4px; background-color: #eee; overflow: hidden; vertical-align: top;">
-                        <img src="${url}" style="width: 100%; height: 100%; object-fit: cover;" alt="Enrollment Photo" />
+                        <img src="${url}" style="width: 100%; height: 100%; object-fit: cover;" alt="Packing photo" />
                     </div>
                   `).join('')}
                 </div>
@@ -358,7 +358,7 @@ export const EmailService = {
                  <tr>
                     <td valign="top" width="50%">
                         <div class="info-label">Status</div>
-                        <div class="info-value">Verified & Unlocked</div>
+                        <div class="info-value">Confirmed on arrival</div>
                     </td>
                     <td valign="top" width="50%">
                         <div class="info-label">Date</div>
@@ -372,7 +372,7 @@ export const EmailService = {
 
           <!-- Footer -->
           <div class="footer">
-            <p style="margin: 0 0 10px 0;">Secured by ink.</p>
+            <p style="margin: 0 0 10px 0;">Delivered with ink.</p>
             <p style="margin: 0;">&copy; ${new Date().getFullYear()} ink. All rights reserved.</p>
           </div>
         </div>
@@ -386,7 +386,7 @@ export const EmailService = {
     // author full HTML in the Outreach panel.
     const finalSubject = subjectOverride && subjectOverride.trim()
       ? fillTemplate(subjectOverride, tplVars)
-      : `Your Order ${orderName} from ${merchantName} is Verified`;
+      : `Your ${merchantName} order ${orderName} is here`;
 
     const filledBody = bodyOverride && bodyOverride.trim()
       ? fillTemplate(bodyOverride, tplVars)
@@ -410,7 +410,7 @@ export const EmailService = {
       : htmlContent;
     const finalText = filledBody
       ? filledBody + `\n\nOpen your order: ${returnButtonUrl}`
-      : `Your delivery for order ${orderName} from ${merchantName} has been verified! Use this link to manage returns: ${returnButtonUrl}`;
+      : `Your ${merchantName} order ${orderName} has arrived. Delivery confirmed. Your receipt + returns: ${returnButtonUrl}`;
 
     try {
       await sendgrid.send({

--- a/app/services/notifications.server.ts
+++ b/app/services/notifications.server.ts
@@ -90,28 +90,28 @@ export const NotificationService = {
     
     switch (payload.type) {
       case "outForDelivery":
-        messageBody = `Hi ${payload.customerName}, your order ${payload.orderName} from ${payload.merchantName} is out for delivery today. Get ready to tap your ink. sticker!`;
+        messageBody = `Hi ${payload.customerName}, your order ${payload.orderName} from ${payload.merchantName} is out for delivery today.`;
         break;
       case "delivered":
-        messageBody = `Your package ${payload.orderName} has arrived! Tap the ink. sticker on the box with your phone to verify delivery and unlock your return window.`;
+        messageBody = `Your ${payload.merchantName} order ${payload.orderName} has arrived.${payload.verifyUrl ? ` Your receipt + returns: ${payload.verifyUrl}` : ""}`;
         break;
       case "deliveryConfirmed":
-        messageBody = `Verified! Your ink. delivery for ${payload.orderName} is confirmed. ${payload.verifyUrl ? `View your passport: ${payload.verifyUrl}` : ""}`;
+        messageBody = `Delivery confirmed for your ${payload.merchantName} order ${payload.orderName}.${payload.verifyUrl ? ` Your receipt + returns: ${payload.verifyUrl}` : ""}`;
         break;
       case "hours4":
-        messageBody = `Hi ${payload.customerName}, we noticed your package ${payload.orderName} arrived earlier today. Please tap the ink. sticker to verify it!`;
+        messageBody = `Hi ${payload.customerName}, your order ${payload.orderName} arrived today.${payload.verifyUrl ? ` Your receipt + returns: ${payload.verifyUrl}` : ""}`;
         break;
       case "hours24":
-        messageBody = `Reminder: Tap the ink. sticker on your recent delivery (${payload.orderName}) to verify it and unlock your ${payload.returnWindowDays || 30}-day return window.`;
+        messageBody = `Your ${payload.returnWindowDays || 30}-day return window for order ${payload.orderName} is open.${payload.verifyUrl ? ` Start a return: ${payload.verifyUrl}` : ""}`;
         break;
       case "hours48":
-        messageBody = `Final reminder from ${payload.merchantName}: Please tap the ink. sticker on your order ${payload.orderName} to properly register your delivery.`;
+        messageBody = `A note from ${payload.merchantName}: your order ${payload.orderName} has arrived.${payload.verifyUrl ? ` Your receipt + returns: ${payload.verifyUrl}` : ""}`;
         break;
       case "return7d":
         messageBody = `Hi ${payload.customerName}, you have 7 days left to return order ${payload.orderName}. Need to start a return? Click here: ${payload.verifyUrl}`;
         break;
       case "return48h":
-        messageBody = `Warning: Your return window for ${payload.merchantName} order ${payload.orderName} closes in 48 hours. Manage it here: ${payload.verifyUrl}`;
+        messageBody = `Your return window for ${payload.merchantName} order ${payload.orderName} closes in 48 hours. Manage it here: ${payload.verifyUrl}`;
         break;
     }
 
@@ -153,17 +153,17 @@ export const NotificationService = {
     switch (payload.type) {
       case "outForDelivery":
         subject = subjectPrefix + "Out for Delivery";
-        body = `Hi ${payload.customerName},\n\nYour order is out for delivery today. Get ready to tap your ink. sticker!`;
+        body = `Hi ${payload.customerName},\n\nYour order is out for delivery today.`;
         break;
       case "delivered":
-        subject = subjectPrefix + "Delivered - Tap Your Sticker!";
-        body = `Your package has arrived!\n\nTap the ink. sticker on the box with your phone to verify delivery and unlock your return window.`;
+        subject = subjectPrefix + "Delivered";
+        body = `Your package has arrived.${payload.verifyUrl ? `\n\nYour receipt + returns: ${payload.verifyUrl}` : ""}`;
         break;
       case "hours4":
       case "hours24":
       case "hours48":
-        subject = subjectPrefix + "Friendly Reminder to Tap Your Sticker";
-        body = `Hi ${payload.customerName},\n\nWe noticed your package arrived recently. Please tap the ink. sticker to verify it and unlock returns.`;
+        subject = subjectPrefix + "Your order has arrived";
+        body = `Hi ${payload.customerName},\n\nYour package arrived recently.${payload.verifyUrl ? `\n\nYour receipt + returns: ${payload.verifyUrl}` : ""}`;
         break;
       case "return7d":
         subject = subjectPrefix + "7 Days Left to Return";
@@ -171,7 +171,7 @@ export const NotificationService = {
         break;
       case "return48h":
         subject = subjectPrefix + "Return Window Closing Soon";
-        body = `Warning: Your return window closes in 48 hours. Manage it here: ${payload.verifyUrl}`;
+        body = `Your return window closes in 48 hours. Manage it here: ${payload.verifyUrl}`;
         break;
     }
 


### PR DESCRIPTION
Sam caught it live: the delivered email said **"Your Order #1008 from Steve Madden is Verified"** — we are not selling verification. These templates predate the Brand Bible and were never swept.

**email.server.ts** — subject → `Your {merchant} order {order} is here`; heading "Delivery Unlocked" → "Your order has arrived"; "successfully verified and unlocked" → "has arrived. Delivery confirmed."; status "Verified & Unlocked" → "Confirmed on arrival"; "ENROLLMENT PHOTOS" → "PACKED FOR SHIPMENT"; footer "Secured by ink." → "Delivered with ink."; default merchant "InInk Verified Merchant" → neutral "your store"; plain-text fallback rewritten.

**notifications.server.ts** — all 8 SMS + email templates: dropped "tap the ink. sticker", "verify delivery", "Verified!", "View your passport", "Warning:"; delivered/confirmed/reminder copy now plain arrival + "Your receipt + returns: {url}" (link included wherever the payload has one).

Merchant-authored Outreach overrides untouched — this only fixes the hardcoded fallbacks. Sends remain behind the layered gate (arm switch + allowlist), so deploy is safe.

Build: `react-router build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)