### PR TITLE
fix(webhooks): stop double-enrolling orders — dedupe token alignment + no re-registration of toml-managed topics

### DIFF
--- a/app/routes/app.register-webhook.tsx
+++ b/app/routes/app.register-webhook.tsx
@@ -3,6 +3,25 @@ import type { ActionFunctionArgs } from "react-router";
 
 const APP_URL = "https://shopify-app-250065525755.us-central1.run.app";
 
+const WEBHOOK_SUBSCRIPTIONS_QUERY = `
+  query existingWebhookSubscriptions {
+    webhookSubscriptions(first: 50) {
+      edges {
+        node {
+          id
+          topic
+          endpoint {
+            __typename
+            ... on WebhookHttpEndpoint {
+              callbackUrl
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 const WEBHOOK_SUBSCRIPTION_CREATE = `
   mutation webhookSubscriptionCreate($topic: WebhookSubscriptionTopic!, $webhookSubscription: WebhookSubscriptionInput!) {
     webhookSubscriptionCreate(topic: $topic, webhookSubscription: $webhookSubscription) {
@@ -25,21 +44,40 @@ const WEBHOOK_SUBSCRIPTION_CREATE = `
 `;
 
 /**
- * Manually registers all required webhooks for this app in Shopify.
- * Hit this route once after deploying to ensure webhooks are registered.
+ * Idempotently registers the shop-level webhooks this app still manages
+ * imperatively. Safe to hit any number of times: existing topics are skipped.
  * Route: POST /app/register-webhook
+ *
+ * ⚠️ ORDERS_CREATE / ORDERS_FULFILLED are deliberately NOT here — they are
+ * app-level declarative subscriptions in shopify.app.toml (since the 07-01
+ * config deploy). Registering them here AGAIN gives every order TWO webhook
+ * deliveries → duplicate proofs (order #1010, 2026-07-01). Only the
+ * fulfillments topics, which the toml does not declare, stay imperative.
  */
 export async function action({ request }: ActionFunctionArgs) {
   const { admin } = await authenticate.admin(request);
 
   const webhooks = [
-    { topic: "ORDERS_CREATE",    path: "/webhooks/orders_create" }, // must match webhooks.orders_create.ts (underscore)
-    { topic: "ORDERS_FULFILLED", path: "/webhooks/orders_fulfilled" },
+    { topic: "FULFILLMENTS_CREATE", path: "/webhooks/fulfillments_create" },
+    // The delivered_at rail — real carrier "delivered" events land here.
+    { topic: "FULFILLMENTS_UPDATE", path: "/webhooks/fulfillments_update" },
   ];
+
+  const existingRes = await admin.graphql(WEBHOOK_SUBSCRIPTIONS_QUERY);
+  const existingJson = await existingRes.json();
+  const existing = (existingJson?.data?.webhookSubscriptions?.edges || []).map(
+    (e: any) => e.node
+  );
+  const existingTopics = new Set(existing.map((n: any) => n.topic));
 
   const results: any[] = [];
 
   for (const { topic, path } of webhooks) {
+    if (existingTopics.has(topic)) {
+      console.log(`⏭️ ${topic} already registered; skipping`);
+      results.push({ topic, skipped: true });
+      continue;
+    }
     console.log(`📝 Registering ${topic} webhook...`);
     const response = await admin.graphql(WEBHOOK_SUBSCRIPTION_CREATE, {
       variables: {
@@ -62,8 +100,7 @@ export async function action({ request }: ActionFunctionArgs) {
     results.push({ topic, result });
   }
 
-  return new Response(JSON.stringify(results, null, 2), {
+  return new Response(JSON.stringify({ registered: results, existing }, null, 2), {
     headers: { "Content-Type": "application/json" },
   });
 }
-

--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -340,9 +340,21 @@ export const action = async ({ request }: ActionFunctionArgs) => {
           }
           proofReference = inkData?.proof_id || "";
           verificationStatus = proofReference ? "enrolled" : "pending";
-          console.log(
-            `✅ [orders/create] Auto-enrolled ${orderName} → proof ${proofReference}, token ${inkToken}`
-          );
+          if (inkData?.already_enrolled && inkData?.nfc_token) {
+            // Backend deduped on (shop_id, order_id) — this delivery was a
+            // duplicate (Shopify is at-least-once). Stamp the EXISTING
+            // proof's token, not the fresh one minted above, or the
+            // ink_token metafield would point at a token that was never
+            // enrolled.
+            inkToken = inkData.nfc_token;
+            console.log(
+              `[orders/create] ${orderName} already enrolled on backend (proof ${proofReference}); aligned token`
+            );
+          } else {
+            console.log(
+              `✅ [orders/create] Auto-enrolled ${orderName} → proof ${proofReference}, token ${inkToken}`
+            );
+          }
         }
       }
     } catch (enrollErr: any) {


### PR DESCRIPTION
## Bug

Order #1010 (sm-test) → **two proofs seconds apart** on 2026-07-01. The 07-01 toml deploy (#27) created an **app-level** `orders/create` subscription on top of the legacy June-5 **shop-level** API registration — Cloud Run logs show two `Webhook received` 0.29s apart, and each delivery mints a fresh nfc_token so the backend token-dedupe never fires.

## Already done live (no deploy needed)

- Deleted the duplicate shop-level ORDERS_CREATE on sm-test via the Admin API.
- **Verified**: test order #1011 → exactly one webhook delivery, one proof (`proof_af503fc6…`). This also proves the app-level toml subscription is live.
- Remaining duplicates on dmg4mi-8i / jatin-98208 / taimoor1-2 (+ doubled ORDERS_FULFILLED everywhere) are flagged for a follow-up task — deletes there are gated.

## This PR (embed half — backend half is ink-backend#23)

1. **orders/create handler**: when the backend replies `already_enrolled` (new (shop_id, order_id) idempotency), stamp the **existing proof's** `nfc_token` into the metafields instead of the freshly-minted one — otherwise the printed/emailed tap URL would point at a token that was never enrolled. No-op until ink-backend#23 deploys (safe in either order).
2. **register-webhook route**: never registers ORDERS_CREATE/ORDERS_FULFILLED again (toml-managed — re-registering is exactly what re-creates the double delivery), and registers the remaining fulfillments topics idempotently (skips topics that already have a subscription).

Typecheck + build pass. No UI callers of the route's response shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)