### PR TITLE
feat(email): email-as-tap-page — brand band, hero media, the buyer's aimed section

### DIFF
--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -898,7 +898,24 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                                 );
                             }
                             const productName = order.lineItems?.edges?.[0]?.node?.title || undefined;
+                            // Email-as-tap-page: pull the brand's public book
+                            // (logo, colors, hero, campaigns) and run the SAME
+                            // aimed-section selection the tap page runs for this
+                            // buyer — the email and the page always agree.
+                            // Fail-soft: any miss ⇒ neutral template, send goes out.
+                            const { fetchBrandEmailKit, selectEmailCampaign } = await import(
+                                "../services/brand-email.server"
+                            );
+                            const brandKit = await fetchBrandEmailKit(String(alanData.shop_id || ""));
+                            const emailCampaign = brandKit
+                                ? selectEmailCampaign(brandKit.campaigns, {
+                                      tier: (alanData.customer_tier as string | undefined) || null,
+                                      productTitles: [productName || ""],
+                                  })
+                                : null;
                             await EmailService.sendReturnPassportEmail({
+                                brand: brandKit,
+                                campaign: emailCampaign,
                                 to: order.customer.email,
                                 customerName: order.customer.firstName || "Customer",
                                 orderName: order.name,

--- a/app/services/brand-email.server.ts
+++ b/app/services/brand-email.server.ts
@@ -1,0 +1,149 @@
+// Email-as-tap-page (Sam, 2026-07-02): the delivered email should look like
+// the brand's page, not ink's generic band — and carry the SAME aimed
+// section the page shows for this buyer.
+//
+// Everything needed is already public per-brand: the Worker serves the
+// brand book (logo, colors, hero media, campaigns) by shop_id. This module
+// fetches it fail-soft (any error → null → the email falls back to today's
+// neutral template) and runs a server-side port of the page's campaign
+// selection (parallelreturns src/lib/campaigns.ts) so the email and the
+// page always agree on which aim this buyer sees.
+
+const WORKER_BASE = "https://ink-easypost-proxy.inink.workers.dev";
+
+export interface EmailCampaign {
+  id: string;
+  headline: string;
+  body?: string;
+  cta_label?: string;
+  cta_url: string;
+  code?: string;
+  images?: string[];
+  tiers?: string[];
+  product_match?: string;
+  starts_at?: string;
+  ends_at?: string;
+  enabled?: boolean;
+  updated_at?: string;
+  created_at?: string;
+  geo?: unknown;
+}
+
+export interface BrandEmailKit {
+  brandName: string | null;
+  /** Curated wordmark/logo image (https) — the same asset the tap page header renders. */
+  logoUrl: string | null;
+  /** Deep brand color for the header band + CTA. */
+  ink: string;
+  /** Page background tone. */
+  paper: string;
+  /** The page's own hero media (IG post / published hero) — the email's visual. */
+  heroUrl: string | null;
+  campaigns: EmailCampaign[];
+}
+
+const HEX = /^#[0-9a-fA-F]{3,8}$/;
+const pickHex = (v: unknown, fallback: string): string =>
+  typeof v === "string" && HEX.test(v.trim()) ? v.trim() : fallback;
+
+const httpsImage = (v: unknown): string | null =>
+  typeof v === "string" && /^https:\/\//i.test(v.trim()) && !/\b(1x1|pixel|blank|transparent|spacer)\b/i.test(v)
+    ? v.trim()
+    : null;
+
+/** Fetch + distill the public brand book. Fail-soft: null on ANY problem —
+ *  the caller renders the neutral template and the send never blocks. */
+export async function fetchBrandEmailKit(shopId: string): Promise<BrandEmailKit | null> {
+  try {
+    if (!shopId) return null;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch(
+      `${WORKER_BASE}/api/public/brand-book?shop_id=${encodeURIComponent(shopId)}`,
+      { signal: controller.signal, headers: { "User-Agent": "ink-embed-email" } },
+    );
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const wrap = (await res.json()) as Record<string, any>;
+    const inner = wrap?.brand_book ?? wrap;
+    const book = inner?.book ?? inner;
+    if (!book || typeof book !== "object") return null;
+
+    const colors = book?.runtime?.parallel_brand_runtime?.design_tokens?.colors ?? {};
+    const logo = book?.runtime?.parallel_brand_runtime?.design_tokens?.logo ?? {};
+    const igPosts: any[] = Array.isArray(book?.instagram?.posts) ? book.instagram.posts : [];
+
+    return {
+      brandName: null, // caller already resolves the display name (From-name precedence)
+      logoUrl: httpsImage(logo?.primary_logo_candidate),
+      ink: pickHex(colors?.primary, "#111111"),
+      paper: pickHex(colors?.surface, "#FAF8F4"),
+      heroUrl:
+        httpsImage(book?.tap_page?.hero_url) ??
+        httpsImage(igPosts.find((p) => p?.display_url && p?.enabled !== false)?.display_url) ??
+        httpsImage(book?.imagery?.hero?.[0]?.url) ??
+        null,
+      campaigns: Array.isArray(book?.campaigns) ? (book.campaigns as EmailCampaign[]) : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ── Campaign selection — server-side port of src/lib/campaigns.ts ──────
+// Same fail-closed semantics: a rule the email can't positively answer
+// does NOT match. Geo rules never match here (no coordinates at send
+// time), mirroring the page's fail-closed geo behavior for GPS-less taps.
+
+function withinWindow(c: EmailCampaign, now: number): boolean {
+  if (c.starts_at && now < Date.parse(c.starts_at)) return false;
+  if (c.ends_at && now > Date.parse(c.ends_at)) return false;
+  return true;
+}
+
+function specificity(c: EmailCampaign): number {
+  return (
+    (c.tiers && c.tiers.length ? 1 : 0) +
+    (c.product_match?.trim() ? 1 : 0) +
+    (c.geo ? 1 : 0) +
+    (c.starts_at || c.ends_at ? 1 : 0)
+  );
+}
+
+export function selectEmailCampaign(
+  campaigns: EmailCampaign[] | null | undefined,
+  buyer: { tier?: string | null; productTitles?: string[] },
+): EmailCampaign | null {
+  const now = Date.now();
+  const titles = (buyer.productTitles ?? []).join(" ").toLowerCase();
+  const matched = (campaigns ?? []).filter((c) => {
+    if (c.enabled === false) return false;
+    if (!c.headline?.trim() || !c.cta_url?.trim()) return false;
+    if (!withinWindow(c, now)) return false;
+    if (c.tiers && c.tiers.length > 0 && !(buyer.tier && c.tiers.includes(buyer.tier))) return false;
+    if (c.product_match?.trim() && !titles.includes(c.product_match.trim().toLowerCase())) return false;
+    if (c.geo) return false; // fail closed — no location at send time
+    return true;
+  });
+  if (matched.length === 0) return null;
+  return [...matched].sort(
+    (a, b) =>
+      specificity(b) - specificity(a) ||
+      Date.parse(b.updated_at || b.created_at || "") - Date.parse(a.updated_at || a.created_at || ""),
+  )[0];
+}
+
+/** Stamp email attribution onto a campaign link (mirrors the page's
+ *  TrackedLink, medium=email). Never throws; unparseable hrefs pass through. */
+export function stampEmailUtm(href: string, campaignId: string): string {
+  try {
+    const url = new URL(href);
+    if (url.searchParams.has("utm_source")) return href;
+    url.searchParams.set("utm_source", "ink");
+    url.searchParams.set("utm_medium", "email");
+    url.searchParams.set("utm_campaign", `campaign:${campaignId}`);
+    return url.toString();
+  } catch {
+    return href;
+  }
+}

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -1,5 +1,6 @@
 
 import sendgrid from "@sendgrid/mail";
+import { stampEmailUtm } from "./brand-email.server";
 
 // SendGrid credentials from environment variables. FROM defaults to a NEUTRAL
 // notifications@in.ink — the merchant-branded {brand}@in.ink From is passed in
@@ -57,6 +58,12 @@ interface ReturnPassportEmailPayload {
   fromEmail?: string;
   fromName?: string;
   replyTo?: string;
+  // Email-as-tap-page (2026-07-02): pre-resolved brand kit + the buyer's
+  // aimed section, resolved by the CALLER (which knows shop_id and the
+  // proof's customer_tier). Absent/null ⇒ the neutral template renders
+  // exactly as before — the send never depends on the brand-book fetch.
+  brand?: import("./brand-email.server").BrandEmailKit | null;
+  campaign?: import("./brand-email.server").EmailCampaign | null;
 }
 
 // One-pass template substitution. The TEMPLATE is trusted (merchant-authored),
@@ -127,6 +134,8 @@ export const EmailService = {
       fromEmail: fromEmailOverride,
       fromName,
       replyTo,
+      brand,
+      campaign,
     } = payload;
 
     // Branded sender: {brand}@in.ink + shop_name when provided, else the neutral
@@ -137,6 +146,37 @@ export const EmailService = {
 
     // Determine return button URL
     const returnButtonUrl = returnUrl || proofUrl;
+
+    // ── Email-as-tap-page pieces (all optional, all inline-styled) ──────
+    // The header band wears the brand (logo image > brand name in caps >
+    // today's "ink."), the page's own hero media rides under the heading,
+    // and the buyer's aimed section — the SAME campaign the tap page shows
+    // for this proof — renders after the primary CTA, links stamped
+    // utm_medium=email for attribution.
+    const headerHtml = brand
+      ? brand.logoUrl
+        ? `<img src="${brand.logoUrl}" alt="${escapeHtml(merchantName)}" style="max-height:30px;max-width:240px;" />`
+        : `<h1 class="header-title" style="letter-spacing:.12em;text-transform:uppercase;">${escapeHtml(merchantName)}</h1>`
+      : `<h1 class="header-title">ink.</h1>`;
+    const heroHtml = brand?.heroUrl
+      ? `<img src="${brand.heroUrl}" alt="" width="100%" style="width:100%;border-radius:6px;display:block;margin:16px 0 4px;" />`
+      : "";
+    const campaignCta = campaign ? stampEmailUtm(campaign.cta_url, campaign.id) : "";
+    const campaignHtml = campaign
+      ? `
+            <div style="text-align:left;border-top:1px solid #ececec;margin-top:28px;padding-top:20px;">
+              <p style="font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:#888;margin:0 0 8px;">From ${escapeHtml(merchantName)}</p>
+              <h3 style="font-family:'Playfair Display',Georgia,serif;font-size:24px;line-height:1.2;margin:0 0 8px;color:#111;">${escapeHtml(campaign.headline)}</h3>
+              ${campaign.body ? `<p style="font-size:14px;line-height:1.55;color:#555;margin:0 0 12px;">${escapeHtml(campaign.body)}</p>` : ""}
+              ${Array.isArray(campaign.images) && campaign.images.length
+                ? `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:4px 0 12px;"><tr>
+                    ${campaign.images.slice(0, 3).map((u) => `<td style="padding-right:6px;width:33%;"><a href="${campaignCta}"><img src="${u}" alt="" width="100%" style="width:100%;border-radius:4px;display:block;" /></a></td>`).join("")}
+                  </tr></table>`
+                : ""}
+              ${campaign.code ? `<p style="font-family:'Courier New',monospace;font-size:14px;letter-spacing:.08em;border:1px dashed #999;display:inline-block;padding:8px 12px;margin:0 0 12px;color:#111;">${escapeHtml(campaign.code)}</p>` : ""}
+              <div><a href="${campaignCta}" style="display:inline-block;background:${brand?.ink || "#111111"};color:#ffffff;text-decoration:none;padding:12px 22px;font-weight:700;font-size:14px;">${escapeHtml(campaign.cta_label || "Take a look")}</a></div>
+            </div>`
+      : "";
 
     // Template variables shared by merchant-authored subject + body.
     const tplVars: Record<string, string> = {
@@ -294,8 +334,8 @@ export const EmailService = {
       <body>
         <div class="email-container">
           <!-- Header -->
-          <div class="header">
-            <h1 class="header-title">ink.</h1>
+          <div class="header"${brand ? ` style="background:${brand.ink};"` : ""}>
+            ${headerHtml}
           </div>
 
           <!-- Main Content -->
@@ -306,6 +346,7 @@ export const EmailService = {
             <p class="sub-heading">
               Hi ${customerName}, your order from <strong>${merchantName}</strong> has arrived. Delivery confirmed.
             </p>
+            ${heroHtml}
 
             ${productImageUrl ? `
               <img src="${productImageUrl}" alt="Product" class="product-image" />
@@ -327,6 +368,7 @@ export const EmailService = {
                 ${proofUrl}
               </a>
             </div>
+            ${campaignHtml}
 
             <!-- Photos Section (if needed) -->
             ${photoUrls.length > 0 ? `


### PR DESCRIPTION
Sam: *"can this steve madden email be the tap page with the image?"* — yes:

- **Brand band**: header wears the brand's ink color + the same curated logo the tap page header renders (brand-name-in-caps fallback; ink. band only when no book exists).
- **Hero media**: the page's own published hero (IG post / hero image) rides under the heading.
- **The aimed section, in the email**: server-side port of the page's campaign selection (tier / product / window, fail-closed; geo rules fail closed at send time) — so a returning buyer's *email* carries "A thank-you, for coming back" + INK-STEVE15 exactly like their receipt. Links stamped `utm_source=ink&utm_medium=email&utm_campaign=campaign:{id}`.
- **Fail-soft everywhere**: book fetch is 5s-capped and any miss renders today's neutral template — the send never depends on it. Outreach overrides keep precedence. Send gates unchanged.

Build ✓. Verification after deploy: re-fire verify on order #1013 (returning buyer) → the branded email with the offer lands on the allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)