### PR TITLE
fix(email): logo on white band (black-on-black box) + SVG guard

### DIFF
--- a/app/services/brand-email.server.ts
+++ b/app/services/brand-email.server.ts
@@ -75,7 +75,10 @@ export async function fetchBrandEmailKit(shopId: string): Promise<BrandEmailKit 
 
     return {
       brandName: null, // caller already resolves the display name (From-name precedence)
-      logoUrl: httpsImage(logo?.primary_logo_candidate),
+      // .svg excluded: Gmail refuses SVG images, leaving an empty band.
+      logoUrl: /\.svg(\?|$)/i.test(String(logo?.primary_logo_candidate ?? ""))
+        ? null
+        : httpsImage(logo?.primary_logo_candidate),
       ink: pickHex(colors?.primary, "#111111"),
       paper: pickHex(colors?.surface, "#FAF8F4"),
       heroUrl:

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -153,6 +153,15 @@ export const EmailService = {
     // and the buyer's aimed section — the SAME campaign the tap page shows
     // for this proof — renders after the primary CTA, links stamped
     // utm_medium=email for attribution.
+    // Logo images render on a WHITE band: brand logo assets are authored for
+    // light ground (Steve Madden ships "SM_logo_…_Black.png" — on the brand's
+    // near-black ink band it disappeared into an empty black box, caught in
+    // Sam's inbox 2026-07-02). Text fallbacks keep the ink-colored band.
+    const headerBandStyle = brand
+      ? brand.logoUrl
+        ? ` style="background:#ffffff;border-bottom:1px solid #ececec;"`
+        : ` style="background:${brand.ink};"`
+      : "";
     const headerHtml = brand
       ? brand.logoUrl
         ? `<img src="${brand.logoUrl}" alt="${escapeHtml(merchantName)}" style="max-height:30px;max-width:240px;" />`
@@ -334,7 +343,7 @@ export const EmailService = {
       <body>
         <div class="email-container">
           <!-- Header -->
-          <div class="header"${brand ? ` style="background:${brand.ink};"` : ""}>
+          <div class="header"${headerBandStyle}>
             ${headerHtml}
           </div>
 


### PR DESCRIPTION
Sam's inbox caught it: the email header was an empty black box — Steve's curated logo is `SM_logo_…_Black.png` rendered on the near-black brand band. Logos are authored for light ground: when a logo image renders, the band is white with a hairline; the caps-name fallback keeps the brand-ink band. Plus `.svg` logos are rejected (Gmail blocks SVG). Build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)