### PR TITLE
fix(webhooks): convention-proof merchant lookup + the tracking hop (fulfillments/create)

### DIFF
--- a/app/routes/webhooks.fulfillments_create.tsx
+++ b/app/routes/webhooks.fulfillments_create.tsx
@@ -1,16 +1,87 @@
 import type { ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
+import { NFSService } from "../services/nfs.server";
+import firestore from "../firestore.server";
+import { findMerchantDoc } from "../services/merchant-doc.server";
 
+// fulfillments/create — THE TRACKING HOP (Phase-1 rehearsal, 2026-07-02).
+//
+// Tracking is born here, not at order creation: the merchant fulfills, the
+// fulfillment carries carrier + tracking number, and until this handler was
+// implemented NO pipe carried them onto the proof (order #1015: fulfilled in
+// Shopify, tracking never arrived; every tracking number on a proof before
+// this was hand-patched). This handler forwards them to the backend
+// (PATCH /api/proofs/:id/tracking), which stores the fields and registers
+// the number with the Shippo feed — carrier scans then drive the delivery
+// journey on the customer page.
+//
+// Webhook discipline: ALWAYS 200 once authenticated (Shopify retries
+// non-200s and disables flaky subscriptions) — every failure inside is
+// logged and swallowed.
 export const action = async ({ request }: ActionFunctionArgs) => {
-  const { topic, shop, admin } = await authenticate.webhook(request);
+  const { topic, shop, payload, admin } = await authenticate.webhook(request);
 
   if (!admin) {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  // We are currently processing deliveries exclusively via orders/fulfilled
-  // This webhook just safely accepts the event to keep Shopify happy.
-  console.log(`[${topic}] Webhook received for shop: ${shop}. Safe ignoring as we use orders/fulfilled.`);
+  try {
+    // Payload is a Fulfillment object.
+    const orderId = payload.order_id;
+    const trackingNumber =
+      (Array.isArray(payload.tracking_numbers) && payload.tracking_numbers[0]) ||
+      payload.tracking_number ||
+      null;
+    const trackingCompany = payload.tracking_company || null;
+    const trackingUrl =
+      (Array.isArray(payload.tracking_urls) && payload.tracking_urls[0]) ||
+      payload.tracking_url ||
+      null;
+
+    if (!orderId) {
+      console.log(`[${topic}] No order_id on fulfillment payload. Ignoring.`);
+      return new Response("OK", { status: 200 });
+    }
+    if (!trackingNumber) {
+      console.log(`[${topic}] Fulfillment for order ${orderId} carries no tracking number. Nothing to forward.`);
+      return new Response("OK", { status: 200 });
+    }
+
+    // Which proof? The order's ink.proof_reference metafield is the link.
+    const response = await admin.graphql(
+      `query GetOrderMetafield($id: ID!) {
+        order(id: $id) {
+          name
+          metafield(namespace: "ink", key: "proof_reference") { value }
+        }
+      }`,
+      { variables: { id: `gid://shopify/Order/${orderId}` } },
+    );
+    const orderJson = await response.json();
+    const proofId: string | undefined = orderJson.data?.order?.metafield?.value;
+    const orderName: string = orderJson.data?.order?.name ?? String(orderId);
+
+    if (!proofId) {
+      console.log(`[${topic}] Order ${orderName} has no ink.proof_reference — not an enrolled order. Ignoring.`);
+      return new Response("OK", { status: 200 });
+    }
+
+    const merchantHit = await findMerchantDoc(firestore, shop);
+    const merchantApiKey = merchantHit?.apiKey ?? null;
+    if (!merchantApiKey) {
+      console.error(`[${topic}] No ink_api_key for ${shop} — cannot forward tracking for ${orderName} (${proofId}).`);
+      return new Response("OK", { status: 200 });
+    }
+
+    await NFSService.updateTracking(proofId, merchantApiKey, {
+      carrier_name: trackingCompany || undefined,
+      tracking_number: trackingNumber,
+      tracking_url: trackingUrl || undefined,
+    });
+    console.log(`✅ [${topic}] Tracking forwarded for ${orderName}: ${trackingCompany ?? "?"} ${trackingNumber} → ${proofId}`);
+  } catch (error: any) {
+    console.error(`❌ [${topic}] Tracking hop failed (webhook still 200s):`, error?.message ?? error);
+  }
 
   return new Response("OK", { status: 200 });
 };

--- a/app/routes/webhooks.fulfillments_update.tsx
+++ b/app/routes/webhooks.fulfillments_update.tsx
@@ -3,6 +3,7 @@ import { authenticate } from "../shopify.server";
 import { NotificationService } from "../services/notifications.server";
 import { NFSService } from "../services/nfs.server";
 import firestore from "../firestore.server";
+import { findMerchantDoc } from "../services/merchant-doc.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   console.log("\n📦 ================================================");
@@ -66,16 +67,19 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       return new Response("OK", { status: 200 });
     }
 
-    // 2. Fetch Merchant Notification Settings from Firestore
+    // 2. Fetch Merchant Notification Settings — convention-proof resolver.
+    //    The old shopDomain-only query silently exited here on shop/shop_domain
+    //    docs, which meant REAL CARRIER DELIVERIES never marked proofs
+    //    delivered on those shops (Phase-1 rehearsal finding, 2026-07-02).
     console.log(`📦 Fetching Merchant Settings for ${shop}...`);
-    const settingsSnap = await firestore.collection("merchants").where("shopDomain", "==", shop).limit(1).get();
-    
-    if (settingsSnap.empty) {
+    const merchantHit = await findMerchantDoc(firestore, shop);
+
+    if (!merchantHit) {
       console.log(`⚠️ No merchant document found for ${shop}. Exiting.`);
       return new Response("OK", { status: 200 });
     }
 
-    const merchantData = settingsSnap.docs[0].data();
+    const merchantData = merchantHit.data;
     const settings = merchantData.notification_settings;
     const merchantName = merchantData.shopName || shop;
 

--- a/app/routes/webhooks.orders_fulfilled.tsx
+++ b/app/routes/webhooks.orders_fulfilled.tsx
@@ -2,6 +2,7 @@ import type { ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import { NFSService } from "../services/nfs.server";
 import firestore from "../firestore.server";
+import { findMerchantDoc } from "../services/merchant-doc.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { payload, shop, topic, admin } = await authenticate.webhook(request);
@@ -24,18 +25,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   // Fetch the proof_reference metafield to see if this order was enrolled in INK
   try {
-    // 1. Look up the merchant's ink_api_key from Firestore using the shop domain.
-    //    The API spec requires Bearer <api_key> for PATCH /api/proofs/:proof_id/delivered.
-    let merchantApiKey: string | null = null;
-    const merchantSnap = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shop)
-      .limit(1)
-      .get();
-
-    if (!merchantSnap.empty) {
-      merchantApiKey = merchantSnap.docs[0].data()?.ink_api_key || null;
-    }
+    // 1. Look up the merchant's ink_api_key — convention-proof resolver
+    //    (doc-id first, then shop/shopDomain/shop_domain fields). The old
+    //    shopDomain-only query 500'd on every shop whose doc uses the other
+    //    conventions (Phase-1 rehearsal, order #1015, 2026-07-02).
+    const merchantHit = await findMerchantDoc(firestore, shop);
+    const merchantApiKey: string | null = merchantHit?.apiKey ?? null;
 
     if (!merchantApiKey) {
       console.error(`[${topic}] No ink_api_key found in Firestore for shop: ${shop}. Cannot mark delivered.`);

--- a/app/services/merchant-doc.server.ts
+++ b/app/services/merchant-doc.server.ts
@@ -1,0 +1,49 @@
+// Merchant-doc resolver — kills the shopDomain landmine class.
+//
+// The Phase-1 fulfillment rehearsal (order #1015, 2026-07-02) 500'd because
+// webhook handlers query `where("shopDomain" == shop)` — but NO merchant doc
+// carries that field: the embed's own docs are keyed by shop domain as the
+// DOCUMENT ID (field `shop`), and backend-provisioned docs use snake_case
+// `shop_domain`. Third appearance of this landmine (Bible §17.2).
+//
+// One resolver, every convention: direct doc-id read first (cheapest, the
+// embed's own shape), then field fallbacks. Prefer a doc that actually
+// carries ink_api_key when several match.
+
+import type { Firestore, DocumentData } from "firebase-admin/firestore";
+
+export interface MerchantDocHit {
+  data: DocumentData;
+  apiKey: string | null;
+}
+
+export async function findMerchantDoc(
+  firestore: Firestore,
+  shop: string,
+): Promise<MerchantDocHit | null> {
+  const hits: DocumentData[] = [];
+
+  try {
+    const direct = await firestore.collection("merchants").doc(shop).get();
+    if (direct.exists) hits.push(direct.data() as DocumentData);
+  } catch { /* fall through to field queries */ }
+
+  if (!hits.some((d) => d?.ink_api_key)) {
+    for (const field of ["shop", "shopDomain", "shop_domain"]) {
+      try {
+        const snap = await firestore
+          .collection("merchants")
+          .where(field, "==", shop)
+          .limit(5)
+          .get();
+        snap.docs.forEach((d) => hits.push(d.data()));
+        if (hits.some((d) => d?.ink_api_key)) break;
+      } catch { /* keep trying the next convention */ }
+    }
+  }
+
+  if (hits.length === 0) return null;
+  const withKey = hits.find((d) => typeof d?.ink_api_key === "string" && d.ink_api_key);
+  const data = withKey ?? hits[0];
+  return { data, apiKey: (withKey?.ink_api_key as string) ?? null };
+}

--- a/app/services/nfs.server.ts
+++ b/app/services/nfs.server.ts
@@ -204,6 +204,39 @@ export const NFSService = {
   },
 
   /**
+   * Attaches fulfillment-time tracking to a proof (the tracking hop).
+   * The backend stores carrier/tracking and registers the number with the
+   * Shippo feed so carrier scans drive the delivery journey. No delivered
+   * semantics. Called from the fulfillments/create Shopify webhook.
+   */
+  async updateTracking(
+    proofId: string,
+    apiKey: string,
+    payload: { carrier_name?: string; tracking_number: string; tracking_url?: string },
+  ): Promise<any> {
+    console.log(`📦 Forwarding tracking for proof ${proofId}:`, payload);
+
+    const response = await fetch(`${NFS_API_URL}/api/proofs/${proofId}/tracking`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error(`❌ ink. Tracking Update Failed [${response.status}]:`, errorText);
+      throw new Error(`ink. Tracking Update failed: ${errorText}`);
+    }
+
+    const data = await response.json();
+    console.log("✅ ink. Tracking Update Success:", data);
+    return data;
+  },
+
+  /**
    * Verifies the HMAC signature of an incoming webhook.
    */
   verifyWebhookSignature(payload: string, signature: string): boolean {


### PR DESCRIPTION
**Phase-1 fulfillment rehearsal findings** (order #1015, fulfilled through the real Shopify admin — the first fulfillment this pipeline has ever processed):

1. **`orders_fulfilled` → 500**: `where("shopDomain"==shop)` matches no existing doc convention (embed docs: doc-id + `shop`; backend docs: `shop_domain`). New `findMerchantDoc()` resolves doc-id first, then all three field conventions — used by both fulfilled handlers.
2. **`fulfillments_update` had the same broken lookup** — meaning real carrier deliveries would silently never mark proofs delivered. Fixed with the same resolver.
3. **The tracking hop, implemented**: `fulfillments/create` (previously a stub) now forwards carrier + tracking number + URL to the backend's new `PATCH /api/proofs/:id/tracking` (companion: **ink-backend #26**), which stores them and registers the number with the Shippo feed. Until now no pipe carried fulfillment-time tracking — every tracking number on a proof was hand-patched.

Webhook discipline: handler always 200s after auth (failures logged) — Shopify disables flaky subscriptions.

Build ✓. Verified next by re-driving #1015 (cancel + refulfill) once deployed. Note: ~8 more `shopDomain` query sites exist outside the fulfillment path — swept separately (chip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)