### PR TITLE
fix(webhooks): delivered gate = proof metafield, not exact INK tag (rehearsal finding #4)

### DIFF
--- a/app/routes/webhooks.fulfillments_update.tsx
+++ b/app/routes/webhooks.fulfillments_update.tsx
@@ -61,9 +61,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       return new Response("OK", { status: 200 });
     }
 
-    // Is it an INK order?
-    if (!order.tags.includes("INK")) {
-      console.log(`ℹ️ Order ${order.name} is not tagged with INK. Skipping.`);
+    // Is it an INK order? The proof_reference metafield is the enrollment
+    // marker — the old exact-tag check (`tags.includes("INK")`) failed on
+    // every real enrollment, which tags orders "INK-Verified-Delivery", so
+    // delivered events were silently skipped (Phase-1 rehearsal finding #4,
+    // order #1015, 2026-07-02).
+    if (!order.proofMetafield?.value) {
+      console.log(`ℹ️ Order ${order.name} has no ink.proof_reference — not an enrolled order. Skipping.`);
       return new Response("OK", { status: 200 });
     }
 


### PR DESCRIPTION
The delivered event from the #1015 re-drive reached fulfillments/update and was skipped: `Order #1015 is not tagged with INK`. Enrollment stamps `INK-Verified-Delivery`, the gate demanded exactly `INK` — so **no enrolled order could ever be marked delivered by the carrier feed**. Gate replaced with the `ink.proof_reference` metafield (already fetched in the same GraphQL query; it IS the enrollment marker). Build ✓. Verified next by re-firing the delivered fulfillment event on #1015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)