### PR TITLE
feat(emails): state-aware sends — shipped='track it', arrival only on real delivery

### DIFF
--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -627,11 +627,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                 };
                 
                 const queryFields = `
-                  edges { 
-                      node { 
+                  edges {
+                      node {
                           id
                           name
                           customer { email firstName }
+                          arrivalEmailSent: metafield(namespace: "ink", key: "arrival_email_sent") { value }
                           lineItems(first: 1) {
                               edges {
                                   node {
@@ -642,7 +643,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                                   }
                               }
                           }
-                      } 
+                      }
                   }
                 `;
 
@@ -661,6 +662,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                           id
                           name
                           customer { email firstName }
+                          arrivalEmailSent: metafield(namespace: "ink", key: "arrival_email_sent") { value }
                           lineItems(first: 1) {
                             edges { node { title image { url } } }
                           }
@@ -687,6 +689,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                                         id
                                         name
                                         customer { email firstName }
+                                        arrivalEmailSent: metafield(namespace: "ink", key: "arrival_email_sent") { value }
                                         lineItems(first: 1) {
                                             edges { node { title image { url } } }
                                         }
@@ -740,7 +743,23 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                     // Production customer notifications are the fulfillments/update
                     // webhook → NotificationService. Set SEND_VERIFY_EMAIL=true only
                     // for manual testing.
-                    if (order.customer?.email && process.env.SEND_VERIFY_EMAIL === "true") {
+                    // State-aware (Phase-1, 2026-07-02): a page-open send may only
+                    // claim arrival when the CARRIER said delivered — the proof's
+                    // delivered_at, stamped by fulfillments/update. Pre-delivery
+                    // opens get the "on its way — track it" copy instead of the
+                    // old unconditional arrival lie.
+                    const emailState: "shipped" | "delivered" = alanData.delivered_at
+                        ? "delivered"
+                        : "shipped";
+                    // The REAL arrival email now fires from the delivered webhook
+                    // (arrival-email.server.ts) and stamps ink.arrival_email_sent.
+                    // A later tap must not repeat the arrival claim into the inbox.
+                    const arrivalAlreadySent = Boolean(order.arrivalEmailSent?.value);
+                    if (emailState === "delivered" && arrivalAlreadySent) {
+                        console.log(
+                            `📧 SKIP tap-triggered email: arrival email already sent (${order.arrivalEmailSent.value}) for ${order.name}.`,
+                        );
+                    } else if (order.customer?.email && process.env.SEND_VERIFY_EMAIL === "true") {
                         const { EmailService } = await import("../services/email.server");
                         const { default: firestore } = await import("../firestore.server");
 
@@ -916,6 +935,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                             await EmailService.sendReturnPassportEmail({
                                 brand: brandKit,
                                 campaign: emailCampaign,
+                                state: emailState,
                                 to: order.customer.email,
                                 customerName: order.customer.firstName || "Customer",
                                 orderName: order.name,
@@ -941,8 +961,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                                     senderFromName ||
                                     session.shop.replace('.myshopify.com', ''),
                                 productImageUrl: productImageUrl,
-                                subjectOverride: outreachSubject,
-                                bodyOverride: outreachBody,
+                                // Merchant-authored Outreach copy is written for the
+                                // ARRIVAL moment ("return unlocked") — applying it to
+                                // a pre-delivery send would re-introduce the lie in
+                                // the merchant's own words. Shipped sends use the
+                                // state template.
+                                subjectOverride: emailState === "delivered" ? outreachSubject : undefined,
+                                bodyOverride: emailState === "delivered" ? outreachBody : undefined,
                                 productName: productName,
                                 fromEmail: senderFromEmail,
                                 fromName: senderFromName,

--- a/app/routes/webhooks.fulfillments_create.tsx
+++ b/app/routes/webhooks.fulfillments_create.tsx
@@ -52,6 +52,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       `query GetOrderMetafield($id: ID!) {
         order(id: $id) {
           name
+          customer { email firstName }
           metafield(namespace: "ink", key: "proof_reference") { value }
         }
       }`,
@@ -60,6 +61,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     const orderJson = await response.json();
     const proofId: string | undefined = orderJson.data?.order?.metafield?.value;
     const orderName: string = orderJson.data?.order?.name ?? String(orderId);
+    const customer = orderJson.data?.order?.customer;
 
     if (!proofId) {
       console.log(`[${topic}] Order ${orderName} has no ink.proof_reference — not an enrolled order. Ignoring.`);
@@ -79,6 +81,27 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       tracking_url: trackingUrl || undefined,
     });
     console.log(`✅ [${topic}] Tracking forwarded for ${orderName}: ${trackingCompany ?? "?"} ${trackingNumber} → ${proofId}`);
+
+    // The SHIPPED email belongs to this moment — tracking just landed on
+    // the proof, so the page is live as a tracker. "On its way — track it",
+    // CTA = the customer's own page. Gated + deduped inside (one per order);
+    // never blocks the 200.
+    try {
+      const { sendStateEmailOnce } = await import("../services/state-email.server");
+      await sendStateEmailOnce({
+        state: "shipped",
+        admin,
+        shop,
+        orderGid: `gid://shopify/Order/${orderId}`,
+        orderName,
+        customerEmail: customer?.email,
+        customerName: customer?.firstName || "Customer",
+        proofId,
+        merchantData: merchantHit?.data ?? {},
+      });
+    } catch (e: any) {
+      console.error(`❌ shipped email failed (non-fatal):`, e?.message);
+    }
   } catch (error: any) {
     console.error(`❌ [${topic}] Tracking hop failed (webhook still 200s):`, error?.message ?? error);
   }

--- a/app/routes/webhooks.fulfillments_update.tsx
+++ b/app/routes/webhooks.fulfillments_update.tsx
@@ -108,6 +108,28 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       } else {
         console.log(`⚠️ No ink_api_key for ${shop}; cannot mark proof delivered.`);
       }
+
+      // The ARRIVAL email belongs to this moment — the carrier said
+      // delivered — not to page-open (api.verify), which used to claim
+      // arrival whenever it fired. Gated + deduped inside; never blocks
+      // the 200. Sent even if our mark-delivered write hiccuped above:
+      // the carrier event, not our ledger, makes the claim true.
+      try {
+        const { sendStateEmailOnce } = await import("../services/state-email.server");
+        await sendStateEmailOnce({
+          state: "delivered",
+          admin,
+          shop,
+          orderGid,
+          orderName: order.name,
+          customerEmail: order.customer?.email,
+          customerName: order.customer?.firstName || "Customer",
+          proofId: order.proofMetafield.value,
+          merchantData,
+        });
+      } catch (e: any) {
+        console.error(`❌ arrival email failed (non-fatal):`, e?.message);
+      }
     }
 
     if (!settings) {

--- a/app/services/email.server.ts
+++ b/app/services/email.server.ts
@@ -64,6 +64,13 @@ interface ReturnPassportEmailPayload {
   // exactly as before — the send never depends on the brand-book fetch.
   brand?: import("./brand-email.server").BrandEmailKit | null;
   campaign?: import("./brand-email.server").EmailCampaign | null;
+  // State-aware copy (Phase-1, 2026-07-02). "shipped" = the order left the
+  // building but the carrier hasn't said delivered: the email says ON ITS
+  // WAY and the CTA is "track it" — it must NOT claim arrival or cite a
+  // return window (the old always-arrival copy lied whenever a pre-delivery
+  // page open fired a send). "delivered" keeps today's arrival copy exactly.
+  // Callers derive this from the proof's carrier-authoritative delivered_at.
+  state?: "shipped" | "delivered";
 }
 
 // One-pass template substitution. The TEMPLATE is trusted (merchant-authored),
@@ -136,7 +143,9 @@ export const EmailService = {
       replyTo,
       brand,
       campaign,
+      state = "delivered",
     } = payload;
+    const shipped = state === "shipped";
 
     // Branded sender: {brand}@in.ink + shop_name when provided, else the neutral
     // notifications@in.ink env default. Reply-to = merchant support (omitted if
@@ -193,13 +202,32 @@ export const EmailService = {
             </div>
           </td></tr>`
       : "";
+    // State copy: the shipped email is the tracking page's herald — same
+    // headline register as StatusHero ("On its way."), CTA = track. No
+    // arrival claim, no return button (eligibility is NOT_YET_DELIVERED
+    // until the carrier says otherwise), no return-window arithmetic.
+    const eyebrowText = shipped ? "On its way" : "Delivery confirmed";
+    const brandedH1 = shipped
+      ? `${escapeHtml(customerName)}, your ${escapeHtml(productName || "order")} is on its way.`
+      : `${escapeHtml(customerName)}, your ${escapeHtml(productName || "order")} is here.`;
+    const brandedCtaLabel = shipped ? "Track your order &rarr;" : "See your order &rarr;";
+    const brandedFooterRow = shipped
+      ? `<tr><td style="padding:16px 24px 30px;">
+              <p style="font-size:11px;color:${mut(0.4)};margin:0 0 6px;">This page tracks your delivery live &middot; with <span style="font-weight:700;color:${mut(0.7)};">ink.</span></p>
+              <p style="font-size:11px;margin:0;word-break:break-all;"><a href="${proofUrl}" style="color:${mut(0.35)};">${proofUrl}</a></p>
+            </td></tr>`
+      : `<tr><td style="padding:16px 24px 30px;">
+              <a href="${returnButtonUrl}" style="display:inline-block;border:1px solid ${mut(0.5)};color:#ffffff;text-decoration:none;padding:11px 20px;font-size:12px;letter-spacing:.14em;text-transform:uppercase;">Start return &rarr;</a>
+              <p style="font-size:11px;color:${mut(0.4)};margin:22px 0 6px;">Return window ${returnWindowDays} days &middot; Delivered with <span style="font-weight:700;color:${mut(0.7)};">ink.</span></p>
+              <p style="font-size:11px;margin:0;word-break:break-all;"><a href="${proofUrl}" style="color:${mut(0.35)};">${proofUrl}</a></p>
+            </td></tr>`;
     const brandedHtml = `
       <!DOCTYPE html>
       <html>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>Your order has arrived — ${orderName}</title>
+        <title>${shipped ? "On its way" : "Your order has arrived"} — ${orderName}</title>
       </head>
       <body style="margin:0;padding:0;background:${ground};">
         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:${ground};"><tr><td align="center">
@@ -208,16 +236,12 @@ export const EmailService = {
             ${heroRow}
             <tr><td style="padding:24px 24px 6px;">
               ${productThumb}
-              <p style="font-family:'Courier New',monospace;font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:${mut(0.55)};margin:0 0 12px;">Order ${escapeHtml(orderName)} · Delivery confirmed</p>
-              <h1 style="font-family:Georgia,'Times New Roman',serif;font-weight:400;font-size:30px;line-height:1.15;color:#ffffff;margin:0 0 20px;">${escapeHtml(customerName)}, your ${escapeHtml(productName || "order")} is here.</h1>
-              <a href="${proofUrl}" style="display:inline-block;background:#ffffff;color:${ground};text-decoration:none;padding:14px 26px;font-weight:700;font-size:14px;letter-spacing:.02em;">See your order &rarr;</a>
+              <p style="font-family:'Courier New',monospace;font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:${mut(0.55)};margin:0 0 12px;">Order ${escapeHtml(orderName)} · ${eyebrowText}</p>
+              <h1 style="font-family:Georgia,'Times New Roman',serif;font-weight:400;font-size:30px;line-height:1.15;color:#ffffff;margin:0 0 20px;">${brandedH1}</h1>
+              <a href="${proofUrl}" style="display:inline-block;background:#ffffff;color:${ground};text-decoration:none;padding:14px 26px;font-weight:700;font-size:14px;letter-spacing:.02em;">${brandedCtaLabel}</a>
             </td></tr>
             ${campaignRow}
-            <tr><td style="padding:16px 24px 30px;">
-              <a href="${returnButtonUrl}" style="display:inline-block;border:1px solid ${mut(0.5)};color:#ffffff;text-decoration:none;padding:11px 20px;font-size:12px;letter-spacing:.14em;text-transform:uppercase;">Start return &rarr;</a>
-              <p style="font-size:11px;color:${mut(0.4)};margin:22px 0 6px;">Return window ${returnWindowDays} days &middot; Delivered with <span style="font-weight:700;color:${mut(0.7)};">ink.</span></p>
-              <p style="font-size:11px;margin:0;word-break:break-all;"><a href="${proofUrl}" style="color:${mut(0.35)};">${proofUrl}</a></p>
-            </td></tr>
+            ${brandedFooterRow}
           </table>
         </td></tr></table>
       </body>
@@ -246,7 +270,7 @@ export const EmailService = {
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>Your order has arrived — ${orderName}</title>
+        <title>${shipped ? "On its way" : "Your order has arrived"} — ${orderName}</title>
         <style type="text/css">
           @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Inter:wght@400;500;600&display=swap');
           
@@ -393,9 +417,11 @@ export const EmailService = {
           <div class="content">
             <div class="order-badge">Order ${orderName}</div>
             
-            <h2 class="main-heading">Your order has arrived</h2>
+            <h2 class="main-heading">${shipped ? "Your order is on its way" : "Your order has arrived"}</h2>
             <p class="sub-heading">
-              Hi ${customerName}, your order from <strong>${merchantName}</strong> has arrived. Delivery confirmed.
+              ${shipped
+                ? `Hi ${customerName}, your order from <strong>${merchantName}</strong> is with the carrier. This page tracks it as it moves.`
+                : `Hi ${customerName}, your order from <strong>${merchantName}</strong> has arrived. Delivery confirmed.`}
             </p>
             ${heroHtml}
 
@@ -406,8 +432,8 @@ export const EmailService = {
             <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
               <tr>
                 <td align="center">
-                   <a href="${returnButtonUrl}" class="cta-button" style="color: #ffffff !important;">
-                     Start Return
+                   <a href="${shipped ? proofUrl : returnButtonUrl}" class="cta-button" style="color: #ffffff !important;">
+                     ${shipped ? "Track Your Order" : "Start Return"}
                    </a>
                 </td>
               </tr>
@@ -451,7 +477,7 @@ export const EmailService = {
                  <tr>
                     <td valign="top" width="50%">
                         <div class="info-label">Status</div>
-                        <div class="info-value">Confirmed on arrival</div>
+                        <div class="info-value">${shipped ? "With the carrier" : "Confirmed on arrival"}</div>
                     </td>
                     <td valign="top" width="50%">
                         <div class="info-label">Date</div>
@@ -479,7 +505,9 @@ export const EmailService = {
     // author full HTML in the Outreach panel.
     const finalSubject = subjectOverride && subjectOverride.trim()
       ? fillTemplate(subjectOverride, tplVars)
-      : `Your ${merchantName} order ${orderName} is here`;
+      : shipped
+        ? `Your ${merchantName} order ${orderName} is on its way`
+        : `Your ${merchantName} order ${orderName} is here`;
 
     const filledBody = bodyOverride && bodyOverride.trim()
       ? fillTemplate(bodyOverride, tplVars)
@@ -505,7 +533,9 @@ export const EmailService = {
         : htmlContent;
     const finalText = filledBody
       ? filledBody + `\n\nOpen your order: ${returnButtonUrl}`
-      : `Your ${merchantName} order ${orderName} has arrived. Delivery confirmed. Your receipt + returns: ${returnButtonUrl}`;
+      : shipped
+        ? `Your ${merchantName} order ${orderName} is on its way. Track it live: ${proofUrl}`
+        : `Your ${merchantName} order ${orderName} has arrived. Delivery confirmed. Your receipt + returns: ${returnButtonUrl}`;
 
     // One retry on transient transport failures (undici "fetch failed",
     // ECONNRESET, SendGrid 5xx). The first live send for order #1012

--- a/app/services/state-email.server.ts
+++ b/app/services/state-email.server.ts
@@ -1,0 +1,214 @@
+// State emails on truthful triggers (Phase-1, 2026-07-02). Until now the
+// only branded send fired from api.verify — i.e. on page OPEN — which
+// claimed arrival whenever it ran, including before delivery. This module
+// ties each claim to the event that makes it true:
+//   shipped   → fulfillments/create, right after the tracking hop lands
+//               ("on its way — track it", CTA = the live page)
+//   delivered → fulfillments/update `delivered`, right after the proof is
+//               marked delivered (the arrival email)
+//
+// Send discipline mirrors api.verify exactly (Bible §20):
+//   - SEND_VERIFY_EMAIL=true is the env master switch (dev default: off)
+//   - SEND_ALLOWLIST, when set, is the only audience mail can reach
+//   - test-flagged merchants (returns_test_mode / is_test) never reach real
+//     customers; an allowlisted recipient may still receive (that's the point)
+//   - merchant outreach toggles (email_enabled / delivered_on) are honored
+//
+// Idempotency: one email per state per order, enforced with the
+// ink.shipped_email_sent / ink.arrival_email_sent order metafields (Shopify
+// redelivers webhooks and carriers repeat scans; the customer gets ONE of each).
+
+import { EmailService, brandSlugFromDomain } from "./email.server";
+import { fetchBrandEmailKit, selectEmailCampaign } from "./brand-email.server";
+import { getProof } from "./ink-api.server";
+
+const INK_NAMESPACE = "ink";
+const SENT_KEYS = {
+  shipped: "shipped_email_sent",
+  delivered: "arrival_email_sent",
+} as const;
+
+interface StateEmailArgs {
+  state: "shipped" | "delivered";
+  admin: any; // Shopify admin GraphQL client from authenticate.webhook
+  shop: string;
+  orderGid: string;
+  orderName: string;
+  customerEmail: string | null | undefined;
+  customerName: string;
+  proofId: string;
+  merchantData: Record<string, any>; // resolved merchant doc (findMerchantDoc)
+}
+
+export async function sendStateEmailOnce(args: StateEmailArgs): Promise<void> {
+  const {
+    state,
+    admin,
+    shop,
+    orderGid,
+    orderName,
+    customerEmail,
+    customerName,
+    proofId,
+    merchantData,
+  } = args;
+
+  const SENT_KEY = SENT_KEYS[state];
+  const label = state === "shipped" ? "shipped email" : "arrival email";
+
+  if (process.env.SEND_VERIFY_EMAIL !== "true") {
+    console.log(`📧 SKIP ${label} (SEND_VERIFY_EMAIL is not 'true').`);
+    return;
+  }
+  if (!customerEmail) {
+    console.log(`📧 SKIP ${label} (order has no customer email).`);
+    return;
+  }
+
+  // ── Gates (same semantics as api.verify) ──
+  const isTestMerchant = Boolean(merchantData.returns_test_mode || merchantData.is_test);
+  const sendAllowlist = (process.env.SEND_ALLOWLIST || "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  const recipientAllowlisted = sendAllowlist.includes(customerEmail.trim().toLowerCase());
+
+  if (sendAllowlist.length > 0 && !recipientAllowlisted) {
+    console.log(`📧 SKIP ${label} (allowlist): ${customerEmail} not on SEND_ALLOWLIST.`);
+    return;
+  }
+  if (isTestMerchant && !recipientAllowlisted) {
+    console.log(`📧 SKIP ${label} (test-mode merchant): refusing real customer send for ${customerEmail}.`);
+    return;
+  }
+  const outreach = (merchantData.outreach as Record<string, any> | undefined) || {};
+  const notifications = (outreach.notifications as Record<string, any> | undefined) || {};
+  const emailEnabled = typeof notifications.email_enabled === "boolean" ? notifications.email_enabled : true;
+  // delivered_on is the merchant's arrival-moment toggle; there is no
+  // per-state shipped toggle yet, so shipped rides email_enabled alone.
+  const deliveredOn = typeof notifications.delivered_on === "boolean" ? notifications.delivered_on : true;
+  if (!emailEnabled || (state === "delivered" && !deliveredOn)) {
+    console.log(`📧 SKIP ${label} (merchant outreach off): email_enabled=${emailEnabled}, delivered_on=${deliveredOn}.`);
+    return;
+  }
+
+  // ── Idempotency: has this order already had this state's email? ──
+  const check = await admin.graphql(
+    `query StateEmailSent($id: ID!) {
+      order(id: $id) {
+        metafield(namespace: "${INK_NAMESPACE}", key: "${SENT_KEY}") { value }
+        lineItems(first: 1) { edges { node { title image { url } } } }
+      }
+    }`,
+    { variables: { id: orderGid } },
+  );
+  const checkJson = await check.json();
+  if (checkJson.data?.order?.metafield?.value) {
+    console.log(`📧 SKIP ${label} (already sent ${checkJson.data.order.metafield.value}) for ${orderName}.`);
+    return;
+  }
+  const firstItem = checkJson.data?.order?.lineItems?.edges?.[0]?.node;
+  const productName: string | undefined = firstItem?.title || undefined;
+  const productImageUrl: string | undefined = firstItem?.image?.url || undefined;
+
+  // ── Proof (authoritative): nfc_token for the page link, tier for aiming ──
+  const merchantApiKey: string | undefined = merchantData.ink_api_key;
+  let nfcToken: string | undefined;
+  let customerTier: string | null = null;
+  let proofShopId = "";
+  if (merchantApiKey) {
+    try {
+      const proof = await getProof(merchantApiKey, proofId);
+      nfcToken = proof?.nfc_token || undefined;
+      customerTier = (proof?.customer_tier as string | undefined) || null;
+      proofShopId = String(proof?.shop_id || "");
+    } catch (e: any) {
+      console.warn(`📧 ${label}: proof fetch failed (${e?.message}) — sending with fallback link.`);
+    }
+  }
+
+  // ── Branded sender + the same live link the physical tag resolves to ──
+  const brandDomain =
+    (merchantData.shop_domain as string | undefined) ||
+    (merchantData.shopDomain as string | undefined) ||
+    shop;
+  const brandSlug =
+    brandSlugFromDomain(merchantData.brand_slug as string | undefined) ||
+    brandSlugFromDomain(brandDomain);
+  const senderFromEmail = brandSlug && brandSlug.length >= 2 ? `${brandSlug}@in.ink` : undefined;
+  const senderFromName =
+    (merchantData.shop_name as string | undefined) ||
+    (merchantData.name as string | undefined) ||
+    undefined;
+  const senderReplyTo =
+    (merchantData.support_email as string | undefined) ||
+    (merchantData.owner_email as string | undefined) ||
+    undefined;
+  const proofUrl =
+    brandSlug && nfcToken
+      ? `https://${brandSlug}.in.ink/r/${nfcToken}`
+      : `https://www.in.ink/r/${nfcToken || proofId}`;
+
+  // ── Email-as-tap-page: brand kit + the buyer's aimed section (fail-soft) ──
+  const brandKit = await fetchBrandEmailKit(proofShopId);
+  const emailCampaign = brandKit
+    ? selectEmailCampaign(brandKit.campaigns, {
+        tier: customerTier,
+        productTitles: [productName || ""],
+      })
+    : null;
+
+  if (isTestMerchant) {
+    console.log(`📧 DEV-MODE ${label} send: test-flagged merchant but ${customerEmail} is allowlisted — sending (from ${senderFromEmail || "notifications@in.ink"}).`);
+  }
+
+  const sent = await EmailService.sendReturnPassportEmail({
+    brand: brandKit,
+    campaign: emailCampaign,
+    state,
+    to: customerEmail,
+    customerName,
+    orderName,
+    proofUrl,
+    merchantName: senderFromName || shop.replace(".myshopify.com", ""),
+    productImageUrl,
+    productName,
+    fromEmail: senderFromEmail,
+    fromName: senderFromName,
+    replyTo: senderReplyTo,
+  });
+
+  if (!sent) {
+    console.error(`❌ ${label} send failed for ${orderName}; NOT stamping ${SENT_KEY} (will retry on the next event).`);
+    return;
+  }
+
+  // Stamp AFTER a successful send: a failed send must stay retryable.
+  const stamp = await admin.graphql(
+    `mutation StampStateEmailSent($metafields: [MetafieldsSetInput!]!) {
+      metafieldsSet(metafields: $metafields) {
+        userErrors { field message }
+      }
+    }`,
+    {
+      variables: {
+        metafields: [
+          {
+            ownerId: orderGid,
+            namespace: INK_NAMESPACE,
+            key: SENT_KEY,
+            type: "single_line_text_field",
+            value: new Date().toISOString(),
+          },
+        ],
+      },
+    },
+  );
+  const stampJson = await stamp.json();
+  const stampErrors = stampJson.data?.metafieldsSet?.userErrors;
+  if (stampErrors?.length) {
+    console.warn(`⚠️ ${label} sent but stamp failed (duplicate possible on redelivery):`, stampErrors);
+  } else {
+    console.log(`✅ ${label} sent + stamped for ${orderName} → ${customerEmail}.`);
+  }
+}


### PR DESCRIPTION
Phase-1: kills the premature-arrival lie. **Shipped** email fires from the tracking hop (fulfillments/create) — 'on its way', CTA = the live tracking page. **Arrival** email fires from the real carrier delivered event (fulfillments/update, after markDelivered). Page-open (api.verify) sends now derive copy from the proof's `delivered_at` and never re-claim arrival once the webhook has sent it. One send per state per order via `ink.shipped_email_sent`/`ink.arrival_email_sent` metafields. All existing send gates (env master switch, allowlist, test-merchant, outreach toggles) replicated in the new trigger path. Build ✓, tsc clean on touched files. Verify plan post-merge: re-drive a fresh Steve order end-to-end and watch both emails land in the allowlisted inbox at the right moments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)