### PR TITLE
Phase 1: de-NFC (tabled behind flag) + honesty pass

### DIFF
--- a/app/components/CommunicationsUsage.tsx
+++ b/app/components/CommunicationsUsage.tsx
@@ -1,3 +1,6 @@
+// ⚠️ TABLED 2026-07-05 — NOT RENDERED ANYWHERE. This component shows mock/
+// hardcoded numbers (never real merchant data end-to-end). Kept in the tree
+// per consolidate≠delete; do not re-mount without wiring real data first.
 import { MessageSquare, Mail, Bell, Smartphone } from "lucide-react";
 
 interface ChannelUsage {

--- a/app/components/CurrentPlanCard.tsx
+++ b/app/components/CurrentPlanCard.tsx
@@ -1,3 +1,6 @@
+// ⚠️ TABLED 2026-07-05 — NOT RENDERED ANYWHERE. This component shows mock/
+// hardcoded numbers (never real merchant data end-to-end). Kept in the tree
+// per consolidate≠delete; do not re-mount without wiring real data first.
 import { Clock, Loader2 } from "lucide-react";
 import { useFetcher } from "react-router";
 import { useEffect } from "react";

--- a/app/components/EngagementFunnel.tsx
+++ b/app/components/EngagementFunnel.tsx
@@ -10,8 +10,9 @@ interface FunnelStep {
 
 const EngagementFunnel = () => {
   // Real funnel from the merchant's proofs (replaces the 1247/843/158 mock):
-  // Enrolled = all proofs, Tapped = proofs tapped at least once. Shared source
-  // with CurrentPlanCard + BillingWidget.
+  // Enrolled = all proofs, Opened = proofs the buyer opened at least once
+  // (the backend still calls an open a "tap" — API field names are load-bearing,
+  // merchant-facing copy says "opened").
   const fetcher = useFetcher<{ totalTaps: number; enrollments: number; engaged: number }>();
   useEffect(() => {
     if (fetcher.state === "idle" && !fetcher.data) {
@@ -25,7 +26,7 @@ const EngagementFunnel = () => {
 
   const steps: FunnelStep[] = [
     { label: "Enrolled", count: enrollments, color: "bg-amber-500" },
-    { label: "Tapped", count: engaged, color: "bg-emerald-500" },
+    { label: "Opened", count: engaged, color: "bg-emerald-500" },
   ];
   const maxCount = steps[0]?.count || 1;
 
@@ -33,7 +34,7 @@ const EngagementFunnel = () => {
     <div
       className="relative bg-card border border-border rounded-md p-4 sm:p-6 shadow-[0_1px_2px_rgba(0,0,0,0.04)]"
       role="region"
-      aria-label="Engagement funnel"
+      aria-label="Open funnel"
     >
       {isLoading && (
         <div className="absolute inset-0 bg-background/50 backdrop-blur-[1px] flex items-center justify-center z-10 rounded-md">
@@ -42,9 +43,9 @@ const EngagementFunnel = () => {
       )}
       {/* Header */}
       <div className="mb-5">
-        <h3 className="text-sm font-semibold text-foreground">Engagement Funnel</h3>
+        <h3 className="text-sm font-semibold text-foreground">Open Funnel</h3>
         <p className="text-xs text-muted-foreground mt-0.5">
-          How many enrolled shipments were tapped
+          How many enrolled orders' pages were opened
         </p>
       </div>
 
@@ -64,7 +65,7 @@ const EngagementFunnel = () => {
                 <div className="flex items-center gap-1.5 py-1 pl-4">
                   <ArrowDown className="h-3 w-3 text-muted-foreground" />
                   <span className="text-xs text-muted-foreground">
-                    {isLast ? `${dropoff}% didn't engage` : `${dropoff}% drop-off`}
+                    {isLast ? `${dropoff}% didn't open` : `${dropoff}% drop-off`}
                   </span>
                 </div>
               )}
@@ -92,7 +93,7 @@ const EngagementFunnel = () => {
 
       {/* Conversion summary */}
       <div className="mt-5 pt-4 border-t border-border flex items-center justify-between">
-        <span className="text-xs text-muted-foreground">Overall engagement rate</span>
+        <span className="text-xs text-muted-foreground">Overall open rate</span>
         <span className="text-sm font-semibold text-foreground tabular-nums">
           {((engaged / maxCount) * 100).toFixed(1)}%
         </span>

--- a/app/components/OrderDetailView.tsx
+++ b/app/components/OrderDetailView.tsx
@@ -206,9 +206,8 @@ export default function OrderDetailView({ order, onBack }: OrderDetailViewProps)
               )}
               <Divider />
               <Text as="p" variant="bodySm" tone="subdued">
-                The full delivery record — tap history, location, and the signed
-                cryptographic proof — lives in your ink. dashboard. Open it from the
-                Dashboard.
+                The full delivery record — open history, location, and the signed
+                record — lives in your ink. studio. Open it from the Dashboard.
               </Text>
             </BlockStack>
           </Card>

--- a/app/components/OrderExpandedRow.tsx
+++ b/app/components/OrderExpandedRow.tsx
@@ -203,8 +203,8 @@ const OrderExpandedRow = ({ order, onCollapse, onViewFull }: OrderExpandedRowPro
             )}
             <div style={{ borderTop: "1px solid var(--p-color-border)", paddingTop: "8px" }}>
               <Text as="p" variant="bodySm" tone="subdued">
-                Tap history, location, and the signed cryptographic proof live in your
-                ink. dashboard.
+                Open history, location, and the signed delivery record live in your
+                ink. studio.
               </Text>
             </div>
           </BlockStack>

--- a/app/components/TimeToEngagement.tsx
+++ b/app/components/TimeToEngagement.tsx
@@ -1,3 +1,6 @@
+// ⚠️ TABLED 2026-07-05 — NOT RENDERED ANYWHERE. This component shows mock/
+// hardcoded numbers (never real merchant data end-to-end). Kept in the tree
+// per consolidate≠delete; do not re-mount without wiring real data first.
 import { Clock, TrendingDown } from "lucide-react";
 
 interface TimeToEngagementProps {

--- a/app/components/billing/BillingCycleCard.tsx
+++ b/app/components/billing/BillingCycleCard.tsx
@@ -1,3 +1,6 @@
+// ⚠️ TABLED 2026-07-05 — NOT RENDERED ANYWHERE. This component shows mock/
+// hardcoded numbers (never real merchant data end-to-end). Kept in the tree
+// per consolidate≠delete; do not re-mount without wiring real data first.
 interface BillingCycleCardProps {
   enrollments?: number;
   taps?: number;

--- a/app/components/billing/BillingWidget.tsx
+++ b/app/components/billing/BillingWidget.tsx
@@ -1,3 +1,6 @@
+// ⚠️ TABLED 2026-07-05 — NOT RENDERED ANYWHERE. This component shows mock/
+// hardcoded numbers (never real merchant data end-to-end). Kept in the tree
+// per consolidate≠delete; do not re-mount without wiring real data first.
 import { useNavigate } from "react-router-dom";
 import { useFetcher } from "react-router";
 import { useEffect } from "react";

--- a/app/components/billing/PlanCard.tsx
+++ b/app/components/billing/PlanCard.tsx
@@ -1,0 +1,25 @@
+// The honest plan card. Replaces the mock billing widgets (BillingWidget /
+// CurrentPlanCard / UsageCapCard / BillingCycleCard / UsageHistoryCard —
+// all hardcoded fiction, tabled unreferenced) with the only true statement:
+// billing runs through Shopify's Managed Pricing, and during the pilot the
+// app is free. When paid tiers go live in the Partner Dashboard, this card
+// gains the current-plan readout — until then it shows NO invented numbers.
+import { CreditCard } from "lucide-react";
+
+const PlanCard = () => {
+  return (
+    <div className="bg-card border border-border rounded-sm p-5">
+      <div className="flex items-center gap-2 mb-2">
+        <CreditCard className="h-4 w-4 text-foreground" aria-hidden="true" />
+        <p className="text-sm font-medium text-foreground">Your plan</p>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        INK is free during the pilot. When paid plans launch they'll be flat
+        monthly tiers, billed through your Shopify invoice — no per-order
+        fees, and you'll approve any charge inside Shopify before it starts.
+      </p>
+    </div>
+  );
+};
+
+export default PlanCard;

--- a/app/components/billing/UsageCapCard.tsx
+++ b/app/components/billing/UsageCapCard.tsx
@@ -1,3 +1,6 @@
+// ⚠️ TABLED 2026-07-05 — NOT RENDERED ANYWHERE. This component shows mock/
+// hardcoded numbers (never real merchant data end-to-end). Kept in the tree
+// per consolidate≠delete; do not re-mount without wiring real data first.
 interface UsageCapCardProps {
   used?: number;
   cap?: number;

--- a/app/components/billing/UsageHistoryCard.tsx
+++ b/app/components/billing/UsageHistoryCard.tsx
@@ -1,3 +1,6 @@
+// ⚠️ TABLED 2026-07-05 — NOT RENDERED ANYWHERE. This component shows mock/
+// hardcoded numbers (never real merchant data end-to-end). Kept in the tree
+// per consolidate≠delete; do not re-mount without wiring real data first.
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { Badge } from "@shopify/polaris";

--- a/app/components/settings/AdvancedSettings.tsx
+++ b/app/components/settings/AdvancedSettings.tsx
@@ -6,11 +6,14 @@ import {
   Collapsible,
 } from "@shopify/polaris";
 import VerificationSettings from "./VerificationSettings";
-import WebhooksSettings from "./WebhooksSettings";
+// WebhooksSettings removed from render (kept in tree, unreferenced): it was
+// pure mock theater — a fake secret, a fake "Test webhook" that slept 1.5s
+// and claimed success, a fabricated activity log. Real webhook registration
+// is automatic (app.tsx registerWebhooks); there is nothing for a merchant
+// to configure here.
 
 const AdvancedSettings = () => {
   const [verificationOpen, setVerificationOpen] = useState(false);
-  const [webhooksOpen, setWebhooksOpen] = useState(false);
 
   return (
     <BlockStack gap="400">
@@ -43,30 +46,6 @@ const AdvancedSettings = () => {
         </BlockStack>
       </Card>
 
-      <Card>
-        <BlockStack gap="400">
-          <button
-            onClick={() => setWebhooksOpen(!webhooksOpen)}
-            style={{
-              width: "100%",
-              textAlign: "left",
-              background: "none",
-              border: "none",
-              cursor: "pointer",
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-              padding: 0,
-            }}
-          >
-            <Text as="h3" variant="headingSm">Webhooks</Text>
-            <Text as="span" tone="subdued">{webhooksOpen ? "−" : "+"}</Text>
-          </button>
-          <Collapsible open={webhooksOpen} id="webhooks-section">
-            <WebhooksSettings />
-          </Collapsible>
-        </BlockStack>
-      </Card>
     </BlockStack>
   );
 };

--- a/app/components/settings/WebhooksSettings.tsx
+++ b/app/components/settings/WebhooksSettings.tsx
@@ -1,3 +1,6 @@
+// ⚠️ TABLED 2026-07-05 — NOT RENDERED ANYWHERE. This component shows mock/
+// hardcoded numbers (never real merchant data end-to-end). Kept in the tree
+// per consolidate≠delete; do not re-mount without wiring real data first.
 import { useState } from "react";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";

--- a/app/flags.ts
+++ b/app/flags.ts
@@ -1,0 +1,9 @@
+// Feature flags — compile-time, one line to flip.
+//
+// FEATURE_NFC: the NFC-tag hardware lane (tag inventory, reorders, low-stock
+// alerts, warehouse tagging). TABLED 2026-07-05 — the product pivoted to
+// email/SMS comms + the order page; NFC returns later as a premium lane.
+// Tabled, never deleted: all NFC components/routes stay in the tree, this
+// flag just keeps them off merchant surfaces. Flip to true to bring the
+// hardware lane back.
+export const FEATURE_NFC = false;

--- a/app/routes/api.jobs.check-followups.tsx
+++ b/app/routes/api.jobs.check-followups.tsx
@@ -107,7 +107,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         const proofId = metafields.proof_reference;
         const link = proofId ? `https://in.ink/verify/${proofId}` : "https://in.ink";
 
-        const message = `🔓 Unlock your ${order.name} delivery! Tap the INK sticker on your package or click here to access your Return Passport: ${link}`;
+        const message = `Your ${order.name} has arrived. Your order page — delivery record and returns — is here: ${link}`;
 
         const success = await SMSService.sendSMS(customerPhone, message);
 

--- a/app/routes/app._index/route.tsx
+++ b/app/routes/app._index/route.tsx
@@ -15,7 +15,7 @@ export default function LandingPage() {
       showSignIn={false}
       headline="Your dashboard is ready."
       sub="A surface that opens on every Shopify order. You communicate in ink; you sign in ink — the brand half and the signature half, on every order."
-      footnote="New here? Open the dashboard to set up your brand and order your first stickers."
+      footnote="New here? Open the dashboard to set up your brand and turn on delivery notifications."
     />
   );
 }

--- a/app/routes/app.billing.tsx
+++ b/app/routes/app.billing.tsx
@@ -2,11 +2,17 @@ import { authenticate } from "../shopify.server";
 import type { LoaderFunctionArgs, HeadersFunction } from "react-router";
 import { useRouteError } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
-import { Page, BlockStack } from "@shopify/polaris";
+import { Page, BlockStack, Card, Text } from "@shopify/polaris";
 import PolarisAppLayout from "../components/PolarisAppLayout";
-import BillingCycleCard from "../components/billing/BillingCycleCard";
-import UsageCapCard from "../components/billing/UsageCapCard";
-import UsageHistoryCard from "../components/billing/UsageHistoryCard";
+import PlanCard from "../components/billing/PlanCard";
+
+// The honest billing page. The previous version rendered three mock cards
+// (hardcoded $233.22/$500 cap, a fabricated 47/31 cycle, and a fake usage
+// ledger of orders that never existed) — all tabled unreferenced in
+// components/billing/. Billing truth lives with Shopify (Managed Pricing):
+// the merchant approves any plan inside Shopify, sees charges on their
+// Shopify invoice, and changes plans from the app's App Store listing.
+// This page states exactly that and invents nothing.
 
 export async function loader({ request }: LoaderFunctionArgs) {
   await authenticate.admin(request);
@@ -17,13 +23,25 @@ export default function BillingPage() {
   return (
     <PolarisAppLayout>
       <Page
-        title="Usage & Billing"
+        title="Billing"
         backAction={{ content: "Settings", url: "/app/settings" }}
       >
         <BlockStack gap="400">
-          <BillingCycleCard />
-          <UsageCapCard />
-          <UsageHistoryCard />
+          <PlanCard />
+          <Card>
+            <BlockStack gap="200">
+              <Text as="h2" variant="headingSm">
+                How billing works
+              </Text>
+              <Text as="p" tone="subdued">
+                All INK charges run through Shopify — they appear on your
+                regular Shopify invoice, and no charge ever starts without
+                your approval inside Shopify. There is no separate card on
+                file and nothing to cancel outside Shopify: uninstalling the
+                app ends any subscription automatically.
+              </Text>
+            </BlockStack>
+          </Card>
         </BlockStack>
       </Page>
     </PolarisAppLayout>

--- a/app/routes/app.dashboard.tsx
+++ b/app/routes/app.dashboard.tsx
@@ -7,9 +7,7 @@ import {
   Text,
   Button,
   InlineStack,
-  EmptyState,
   Banner,
-  Layout,
   Collapsible,
 } from "@shopify/polaris";
 import { authenticate } from "../shopify.server";
@@ -17,14 +15,16 @@ import { mintMagicToken } from "../services/ink-api.server";
 import PolarisAppLayout from "~/components/PolarisAppLayout";
 import RecentActivity from "~/components/RecentActivity";
 import EngagementFunnel from "~/components/EngagementFunnel";
+// NFC hardware lane — tabled behind FEATURE_NFC (see app/flags.ts), never deleted.
 import NFCTagInventory from "~/components/NFCTagInventory";
 import RevenueThisPeriod from "~/components/RevenueThisPeriod";
-import TimeToEngagement from "~/components/TimeToEngagement";
-import CurrentPlanCard from "~/components/CurrentPlanCard";
-import BillingWidget from "~/components/billing/BillingWidget";
-import CommunicationsUsage from "~/components/CommunicationsUsage";
+import PlanCard from "~/components/billing/PlanCard";
 import AdvancedAnalytics from "~/components/AdvancedAnalytics";
-import { toast } from "sonner"; // Replaced with Sonner to match previous setup
+import { FEATURE_NFC } from "~/flags";
+// Removed from render (kept in tree, unreferenced): TimeToEngagement +
+// CommunicationsUsage rendered hardcoded fictional numbers; BillingWidget +
+// CurrentPlanCard priced real counts at fictional NFC-era rates. Nothing on
+// this dashboard may show a number that isn't the merchant's own.
 
 // Mint a single-use magic-login token for this shop and hand back a
 // www.in.ink/welcome URL the merchant can open already signed in.
@@ -49,8 +49,6 @@ export const action = async ({
 };
 
 const Dashboard = () => {
-  const [hasOrders, setHasOrders] = useState(true);
-  const [isTransitioning, setIsTransitioning] = useState(false);
   // The full operational-analytics BI lives in the standalone ink. dashboard;
   // here it's tucked behind an Advanced disclosure (collapsed by default) so the
   // embed leads with the lightweight engagement cards + handoff, not a second
@@ -85,38 +83,6 @@ const Dashboard = () => {
     }
   }, [fetcher.data]);
 
-  const handleViewDemo = () => {
-    setIsTransitioning(true);
-    toast("Loading demo data", { description: "Showing sample orders and verification data." });
-    setTimeout(() => {
-      setHasOrders(true);
-      setIsTransitioning(false);
-    }, 1000);
-  };
-
-  const handleDownloadGuide = () => {
-    toast("Downloading guide", { description: "Your warehouse setup guide is being prepared." });
-  };
-
-  if (!hasOrders) {
-    return (
-      <PolarisAppLayout>
-        <Page title="Dashboard">
-          <Card>
-            <EmptyState
-              heading="Your setup is complete! 🎉"
-              action={{ content: "View Demo", onAction: handleViewDemo, loading: isTransitioning }}
-              secondaryAction={{ content: "Download Setup Guide", onAction: handleDownloadGuide }}
-              image=""
-            >
-              <p>Your NFC tags will arrive in 3-5 business days. In the meantime, explore the app or read our warehouse setup guide.</p>
-            </EmptyState>
-          </Card>
-        </Page>
-      </PolarisAppLayout>
-    );
-  }
-
   return (
     <PolarisAppLayout>
       <Page title="Dashboard">
@@ -133,7 +99,7 @@ const Dashboard = () => {
                   Your ink. dashboard
                 </Text>
                 <Text as="p" tone="subdued">
-                  Open the INK surface — where your enrolled orders, tap pages,
+                  Open the INK studio — where your enrolled orders, pages,
                   and returns live. You'll be signed in automatically — no
                   password needed.
                 </Text>
@@ -144,29 +110,24 @@ const Dashboard = () => {
             </InlineStack>
           </Card>
 
-          {/* Row 1: Time to Engagement + Engagement Funnel */}
+          {/* Row 1: Open funnel + Enrolled Order Value — real numbers only */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <TimeToEngagement />
             <EngagementFunnel />
-          </div>
-
-          {/* Row 2: Tag Inventory + Enrolled Order Value */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <NFCTagInventory />
             <RevenueThisPeriod />
           </div>
 
-          {/* Row 3: Recent Activity + Billing Widget */}
+          {/* NFC hardware lane — tabled behind the flag, not deleted */}
+          {FEATURE_NFC && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <NFCTagInventory />
+            </div>
+          )}
+
+          {/* Row 2: Recent Activity + the honest plan card */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <RecentActivity />
-            <div className="flex flex-col gap-4">
-              <BillingWidget />
-              <CurrentPlanCard />
-            </div>
+            <PlanCard />
           </div>
-
-          {/* Row 4: Communications — full width */}
-          <CommunicationsUsage />
 
           {/* Advanced — the full operational-analytics BI, collapsed by default.
               Relocated here (not deleted) so the embed stays lean; the rich

--- a/app/routes/app.help.tsx
+++ b/app/routes/app.help.tsx
@@ -1,139 +1,104 @@
 import { useState } from "react";
-import { z } from "zod";
 import {
   Page,
   Card,
   BlockStack,
   Text,
-  TextField,
-  Select,
-  Button,
   Collapsible,
-  InlineStack,
   Layout,
+  Button,
 } from "@shopify/polaris";
 import PolarisAppLayout from "../components/PolarisAppLayout";
-import { useToast } from "../hooks/use-toast";
 
-const contactSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(1, "Name is required")
-    .max(100, "Name must be less than 100 characters"),
-  email: z
-    .string()
-    .trim()
-    .email("Please enter a valid email")
-    .max(255, "Email must be less than 255 characters"),
-  category: z.string().min(1, "Please select a category"),
-  message: z
-    .string()
-    .trim()
-    .min(10, "Message must be at least 10 characters")
-    .max(2000, "Message must be less than 2000 characters"),
-});
-
-type ContactFormData = z.infer<typeof contactSchema>;
+// Comms-first FAQ (2026-07-05 pivot). The NFC-era FAQ (stickers, tag
+// inventory, "ink. Drop", per-tap pricing) is gone — none of it described
+// the shipping product. The fake contact form (it validated, slept 1s, and
+// claimed "Message sent" without sending anything) is replaced by a real
+// mailto card. Rule: this page promises nothing the installed app doesn't do.
 
 const faqSections = [
   {
-    title: "Getting Started",
+    title: "Getting started",
     items: [
       {
-        question: "How do I get stickers?",
+        question: "What does INK do?",
         answer:
-          "Order NFC stickers through the Tag Inventory tab in Settings. Stickers are pre-encoded and ship to your warehouse. Apply one to each package before shipping.",
+          "Every order gets its own page — your brand, the order, and live delivery tracking in one place. Your customer gets a link by email or text when the order ships and when it arrives. The page is also where they can start a return.",
       },
       {
-        question: "How does enrollment work?",
+        question: "What do I have to set up?",
         answer:
-          "Open the ink. enrollment app, scan the order barcode, photograph the contents, and apply the sticker. The record is created before the package leaves your warehouse.",
+          "Almost nothing. Orders enroll automatically as they're placed. Your page is built from your existing brand and can be tuned any time from the INK studio. Email and text notifications are controlled in Settings.",
       },
       {
         question: "Do I need to change my shipping or carrier?",
         answer:
-          "No. ink. sits on top of your existing infrastructure. Your carrier, your warehouse workflow, your returns portal — nothing changes.",
+          "No. INK sits on top of your existing setup. Your carrier, your warehouse workflow, your returns policy — nothing changes.",
+      },
+      {
+        question: "Do I need any hardware or stickers?",
+        answer:
+          "No. INK is software only — every order gets its page automatically the moment it's placed.",
       },
     ],
   },
   {
-    title: "Customer Experience",
+    title: "Your customer's experience",
     items: [
       {
-        question: "What does my customer see when they tap?",
+        question: "What does my customer see?",
         answer:
-          "A branded full-screen experience — your logo, your colors, your message. Then a simple delivery confirmation. No app download, no login required.",
+          "A page in your brand — their order, where it is right now, and what you want them to see next. It opens in the browser from a link in their email or text. No app download, no login, no account creation.",
       },
       {
-        question: "What if my customer doesn't tap?",
+        question: "What emails and texts go out?",
         answer:
-          "The pre-shipment photos still exist. That record was created at enrollment regardless of whether the customer ever touches the sticker.",
-      },
-      {
-        question: "Does my customer need to download an app?",
-        answer:
-          "No. The tap opens directly in the phone's browser. No app, no login, no account creation.",
+          "Shipping and delivery updates, sent in your name. You control which notifications are on, and the wording, in Settings → Communications.",
       },
     ],
   },
   {
-    title: "Verification & Evidence",
+    title: "The delivery record",
     items: [
       {
-        question: "What data is captured on tap?",
+        question: "What does INK record about a delivery?",
         answer:
-          "GPS coordinates, timestamp, device model and OS, network type, and distance from the shipping address. All cryptographically signed and stored.",
+          "The carrier's delivery confirmation, timestamps, and — when your customer opens their page and allows location — where the order was opened. The record is cryptographically signed when it's created.",
       },
       {
         question: "How does this help with disputes?",
         answer:
-          "When a customer files a chargeback or claim, you have pre-shipment photos proving what was packed, and if they tapped, GPS-verified proof of delivery.",
-      },
-      {
-        question: "What is the verification window?",
-        answer:
-          "The period after delivery during which you send tap reminders. Default is 72 hours. The sticker itself stays active through the full return window.",
+          "When a customer files a chargeback or claim, you have a signed record of the delivery, and pre-shipment photos if you use them — evidence of what was packed and that it arrived.",
       },
     ],
   },
   {
-    title: "Returns & ink. Drop",
+    title: "Returns",
     items: [
       {
-        question: "What is ink. Drop?",
+        question: "How do returns work?",
         answer:
-          "ink. Drop is our return system. Customers who tap at delivery unlock an extended return window and the ability to return at any FedEx, UPS, or USPS location with a carrier-native QR code. Coming soon.",
+          "Your customer starts a return from their order page after delivery. They get a QR code — no printer needed — and you see the return's status live on the order.",
       },
       {
-        question: "Do customers who don't tap still get returns?",
+        question: "Does this replace my returns policy?",
         answer:
-          "Yes, through your standard return process. The tap unlocks the faster, frictionless return path.",
-      },
-      {
-        question: "What is a Return Passport?",
-        answer:
-          "A verified return credential generated when a customer walks into a participating retail location. GPS confirms they're in the store. Coming soon.",
+          "No. Your policy and your rules stay yours — INK handles the customer-facing flow and keeps the status visible to you and to them.",
       },
     ],
   },
   {
-    title: "Pricing & Billing",
+    title: "Pricing & billing",
     items: [
       {
         question: "How much does it cost?",
         answer:
-          "$0.99 per enrollment, $2.99 per verified tap, $0.80 per sticker. No monthly fee, no tiers, no minimums.",
+          "INK is free during the pilot. Paid plans will be flat monthly tiers based on your order volume — billed through Shopify, no per-order fees.",
       },
       {
-        question: "When am I charged for a tap?",
+        question: "How am I billed?",
         answer:
-          "Only when a customer successfully taps the sticker and the system captures a verified tap. You'll be billed monthly.",
-      },
-      {
-        question: "How do I order more stickers?",
-        answer:
-          "Through the Tag Inventory tab in Settings. You can set auto-refill thresholds so you never run out.",
+          "Through Shopify. Any plan appears on your regular Shopify invoice, you approve it inside Shopify before it starts, and uninstalling ends it automatically.",
       },
     ],
   },
@@ -183,45 +148,6 @@ const FAQItem = ({
 };
 
 const Help = () => {
-  const { toast } = useToast();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [errors, setErrors] = useState<
-    Partial<Record<keyof ContactFormData, string>>
-  >({});
-  const [formData, setFormData] = useState<ContactFormData>({
-    name: "",
-    email: "",
-    category: "",
-    message: "",
-  });
-
-  const handleChange = (field: keyof ContactFormData, value: string) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) setErrors((prev) => ({ ...prev, [field]: undefined }));
-  };
-
-  const handleSubmit = async () => {
-    setErrors({});
-    const result = contactSchema.safeParse(formData);
-    if (!result.success) {
-      const fieldErrors: Partial<Record<keyof ContactFormData, string>> = {};
-      result.error.issues.forEach((err) => {
-        fieldErrors[err.path[0] as keyof ContactFormData] = err.message;
-      });
-      setErrors(fieldErrors);
-      return;
-    }
-
-    setIsSubmitting(true);
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    toast({
-      title: "Message sent",
-      description: "We'll get back to you within 24 hours.",
-    });
-    setFormData({ name: "", email: "", category: "", message: "" });
-    setIsSubmitting(false);
-  };
-
   return (
     <PolarisAppLayout>
       <Page title="Help & Support">
@@ -248,69 +174,23 @@ const Help = () => {
           <Layout.Section variant="oneThird">
             <BlockStack gap="400">
               <Text as="h2" variant="headingSm">
-                Contact Us
+                Contact us
               </Text>
               <Card>
-                <BlockStack gap="400">
-                  <TextField
-                    label="Name"
-                    value={formData.name}
-                    onChange={(v) => handleChange("name", v)}
-                    error={errors.name}
-                    autoComplete="name"
-                  />
-                  <TextField
-                    label="Email"
-                    type="email"
-                    value={formData.email}
-                    onChange={(v) => handleChange("email", v)}
-                    error={errors.email}
-                    autoComplete="email"
-                  />
-                  <Select
-                    label="Category"
-                    value={formData.category}
-                    onChange={(v) => handleChange("category", v)}
-                    error={errors.category}
-                    options={[
-                      { label: "Select a topic", value: "" },
-                      { label: "General Inquiry", value: "general" },
-                      { label: "Technical Support", value: "technical" },
-                      { label: "Billing & Subscription", value: "billing" },
-                      { label: "Verification Issues", value: "verification" },
-                      { label: "Integration Help", value: "integration" },
-                      { label: "Feedback & Suggestions", value: "feedback" },
-                    ]}
-                  />
-                  <TextField
-                    label="Message"
-                    value={formData.message}
-                    onChange={(v) => handleChange("message", v)}
-                    error={errors.message}
-                    multiline={5}
-                    autoComplete="off"
-                    helpText={`${formData.message.length}/2000 characters`}
-                  />
-                  <InlineStack align="end">
-                    <Button
-                      variant="primary"
-                      onClick={handleSubmit}
-                      loading={isSubmitting}
-                    >
-                      Send Message
-                    </Button>
-                  </InlineStack>
+                <BlockStack gap="300">
+                  <Text as="p" tone="subdued" variant="bodySm">
+                    Questions, problems, or a feature you need? Email us —
+                    a person reads every message.
+                  </Text>
+                  <Button
+                    url="mailto:support@in.ink"
+                    external
+                    variant="primary"
+                  >
+                    Email support@in.ink
+                  </Button>
                 </BlockStack>
               </Card>
-              <Text as="p" tone="subdued" variant="bodySm">
-                Need immediate assistance? Email us at{" "}
-                <a
-                  href="mailto:support@in.ink"
-                  style={{ color: "inherit", textDecoration: "underline" }}
-                >
-                  support@in.ink
-                </a>
-              </Text>
             </BlockStack>
           </Layout.Section>
         </Layout>

--- a/app/routes/app.orders.$orderId.tsx
+++ b/app/routes/app.orders.$orderId.tsx
@@ -752,7 +752,7 @@ export default function OrderDetails() {
 
     const eventTabs = [
         { id: "write", content: "Write" },
-        { id: "tap", content: "Tap" },
+        { id: "tap", content: "Open" },
     ];
 
     const verificationStatusRaw = order.metafields.verification_status?.toLowerCase() || "pending";
@@ -923,7 +923,7 @@ export default function OrderDetails() {
                                         {/* NFC Tag & Proof ID */}
                                         <InlineStack gap="400" wrap={false}>
                                             <div style={{ flex: 1, background: "var(--p-color-bg-surface-secondary)", padding: "12px", borderRadius: "8px" }}>
-                                                <Text as="p" tone="subdued" variant="bodySm">NFC Tag UID</Text>
+                                                <Text as="p" tone="subdued" variant="bodySm">Tag UID</Text>
                                                 <Text as="p" variant="bodySm" fontWeight="medium">
                                                     <code style={{ fontFamily: "monospace" }}>{order.metafields.nfc_uid || "—"}</code>
                                                 </Text>
@@ -1022,7 +1022,7 @@ export default function OrderDetails() {
                                                                 <InlineStack gap="300" blockAlign="start">
                                                                     <div style={{ width: "10px", height: "10px", borderRadius: "50%", background: "var(--p-color-text)", marginTop: "4px", flexShrink: 0 }} />
                                                                     <BlockStack gap="100">
-                                                                        <Text as="p" variant="bodySm" fontWeight="medium">Tapped</Text>
+                                                                        <Text as="p" variant="bodySm" fontWeight="medium">Opened</Text>
                                                                         <Text as="p" tone="subdued" variant="bodySm">{order.localProof.verification_updated_at}</Text>
                                                                     </BlockStack>
                                                                 </InlineStack>
@@ -1061,7 +1061,7 @@ export default function OrderDetails() {
                                                 {deliveryCoords && (
                                                     <div style={{ flex: 1 }}>
                                                         <BlockStack gap="200">
-                                                            <Text as="p" tone="subdued" variant="bodySm" fontWeight="medium">Tap Location</Text>
+                                                            <Text as="p" tone="subdued" variant="bodySm" fontWeight="medium">Open location</Text>
                                                             <TapLocationCard
                                                                 lat={deliveryCoords.lat}
                                                                 lng={deliveryCoords.lng}
@@ -1075,8 +1075,8 @@ export default function OrderDetails() {
                                             </InlineStack>
                                         ) : (
                                             <BlockStack gap="200" inlineAlign="center">
-                                                <Text as="p" variant="bodySm" fontWeight="medium" tone="subdued">No tap has been recorded</Text>
-                                                <Text as="p" variant="bodySm" tone="subdued">Waiting for customer to tap the NFC tag</Text>
+                                                <Text as="p" variant="bodySm" fontWeight="medium" tone="subdued">No open recorded yet</Text>
+                                                <Text as="p" variant="bodySm" tone="subdued">Waiting for the customer to open their order page</Text>
                                             </BlockStack>
                                         )}
                                     </>

--- a/app/routes/app.payment.tsx
+++ b/app/routes/app.payment.tsx
@@ -29,7 +29,7 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     }`,
     {
       variables: {
-        name: "ink — Tap Pages",
+        name: "INK — Order Tracking Pages",
         returnUrl: `${process.env.SHOPIFY_APP_URL}/app/payment/callback`,
         lineItems: [
           {
@@ -92,9 +92,9 @@ export default function Payment() {
                   </Text>
                   
                   <List type="bullet">
-                    <List.Item>Automated Shipping Rates</List.Item>
-                    <List.Item>NFC Tag Enrollment</List.Item>
-                    <List.Item>Tap pages for every order</List.Item>
+                    <List.Item>A branded order page for every order</List.Item>
+                    <List.Item>Email &amp; text delivery notifications</List.Item>
+                    <List.Item>Printerless QR returns</List.Item>
                   </List>
 
                   <div style={{ padding: "20px", background: "#f1f1f1", borderRadius: "8px" }}>

--- a/app/routes/app.reorder-tags.tsx
+++ b/app/routes/app.reorder-tags.tsx
@@ -1,8 +1,11 @@
-import type { LoaderFunctionArgs } from "react-router";
+import { redirect, type LoaderFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
+import { FEATURE_NFC } from "../flags";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   await authenticate.admin(request);
+  // NFC hardware lane tabled (app/flags.ts) — page returns when the flag does.
+  if (!FEATURE_NFC) return redirect("/app/dashboard");
   return null;
 };
 


### PR DESCRIPTION
First PR of the Shopify App Store overhaul (spec: parallelreturns RUNBOOK_SHOPIFY_APP_OVERHAUL.md, merged #356 there).

**De-NFC — tabled, never deleted:** `FEATURE_NFC` flag (app/flags.ts) hides the hardware lane; all components/routes stay in the tree.

**Honesty pass:** every fictional number a reviewer would see in minute one is gone — fake billing rates/caps/ledger, fake comms usage, fake time-to-engagement, fake webhook settings, fake contact form, NFC empty states.

**Copy:** tapped→opened everywhere merchant-facing, comms-first Help FAQ, honest pricing copy (free pilot, Managed Pricing).

Verified: `npm run build` (react-router/esbuild) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)