### PR TITLE
Phase 2a: register GDPR compliance topics + stage app rename

### DIFF
--- a/app/routes/webhooks.customers.data_request.tsx
+++ b/app/routes/webhooks.customers.data_request.tsx
@@ -7,9 +7,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   console.log(`Received ${topic} webhook for ${shop}`);
 
   // CUSTOMERS/DATA_REQUEST
-  // We don't store customer PII in our App's database.
-  // If we did, we would email the data to the merchant or customer.
-  // Since we don't, we just acknowledge.
+  // This app's own DB stores merchant config only. Customer data lives on the
+  // proof in the ink-backend; the merchant can already read it there. The
+  // 30-day obligation is on the merchant; we acknowledge receipt and log.
+  // TODO(Phase 5 — PCD): surface a proof-data export keyed on
+  // payload.customer.id so merchants can answer these requests in one click.
 
   return new Response("OK", { status: 200 });
 };

--- a/app/routes/webhooks.customers.redact.tsx
+++ b/app/routes/webhooks.customers.redact.tsx
@@ -7,9 +7,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   console.log(`Received ${topic} webhook for ${shop}`);
   
   // CUSTOMERS/REDACT
-  // We don't store customer PII in our App's database (Firestore only stores Merchant config).
-  // The customer data is either in Shopify (which handles this) or passed to INK API (which is external).
-  // So we just acknowledge.
+  // This app's own DB (Firestore) stores merchant config only — no customer
+  // PII to erase here. But proofs in the ink-backend DO carry order_details
+  // (name/email/address), so full compliance forwards this redaction there.
+  // TODO(Phase 5 — PCD): call the ink-backend redaction endpoint once it
+  // exists (RUNBOOK_SHOPIFY_APP_OVERHAUL.md, parallelreturns), keyed on
+  // payload.customer.id + payload.orders_to_redact.
 
   return new Response("OK", { status: 200 });
 };

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -1,7 +1,9 @@
 # Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "8da1addef3dcd4251db5057cda3c85fa"
-name = "INK — Dynamic Receipts"
+# Working title per the 2026-07-05 overhaul decision ("Dynamic Receipts" is
+# banned copy). Goes live only on the next gated `shopify app deploy`.
+name = "INK — Order Tracking Pages"
 application_url = "https://shopify-app-250065525755.us-central1.run.app"
 embedded = true
 
@@ -31,7 +33,22 @@ api_version = "2025-10"
   topics = [ "orders/fulfilled" ]
   uri = "/webhooks/orders_fulfilled"
 
+  # GDPR compliance topics — MANDATORY for App Store review (auto-fail if
+  # missing). Handlers already existed; this registers them. HMAC is verified
+  # by authenticate.webhook(), which 401s invalid signatures (also required).
+  # Takes effect on the next gated `shopify app deploy` (§17.7/§17.8: after
+  # deploying, audit shops for duplicate shop-level subs + delivery counts).
+  [[webhooks.subscriptions]]
+  compliance_topics = [ "customers/data_request" ]
+  uri = "/webhooks/customers/data_request"
 
+  [[webhooks.subscriptions]]
+  compliance_topics = [ "customers/redact" ]
+  uri = "/webhooks/customers/redact"
+
+  [[webhooks.subscriptions]]
+  compliance_topics = [ "shop/redact" ]
+  uri = "/webhooks/shop/redact"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes


### PR DESCRIPTION
- Registers `customers/data_request` / `customers/redact` / `shop/redact` as compliance_topics (handlers existed — missing registration was an App Store auto-fail). `authenticate.webhook()` already 401s invalid HMAC.
- Stages toml rename to **INK — Order Tracking Pages** (working title, Sam 2026-07-05).
- ⚠️ toml config goes live only on a **gated** `shopify app deploy` (Sam's OK) + §17.8 duplicate-subscription audit after.

Verified: `react-router build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)