### PR TITLE
Phase 2b: fail-closed token verification + public API rate limits

### DIFF
--- a/app/routes/api.enroll.tsx
+++ b/app/routes/api.enroll.tsx
@@ -1,4 +1,5 @@
 import { type ActionFunctionArgs } from "react-router";
+import { allowRequest, clientIp, rateLimitResponse } from "../services/rate-limit.server";
 import { NFSService } from "../services/nfs.server";
 import { INK_NAMESPACE } from "../utils/metafields.server";
 import { serialNumberToToken } from "../utils/nfc-conversion.server";
@@ -18,6 +19,9 @@ export const loader = async () => {
 };
 
 export const action = async ({ request }: ActionFunctionArgs) => {
+  // Public endpoint — per-IP rate limit (services/rate-limit.server.ts).
+  if (!allowRequest(`enroll:${clientIp(request)}`, 30)) return rateLimitResponse();
+
   const { getOfflineSession } = await import("../session-utils.server");
 
   try {

--- a/app/routes/api.orders.fetch.tsx
+++ b/app/routes/api.orders.fetch.tsx
@@ -1,4 +1,5 @@
 import { type LoaderFunctionArgs } from "react-router";
+import { allowRequest, clientIp, rateLimitResponse } from "../services/rate-limit.server";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -18,6 +19,10 @@ export const action = async ({ request }: any) => {
 };
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
+  if (request.method !== "OPTIONS" && !allowRequest(`ordersfetch:${clientIp(request)}`, 60)) {
+    return rateLimitResponse(CORS_HEADERS);
+  }
+
   if (request.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }
@@ -39,19 +44,17 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     }
 
     const token = authHeader.slice(7);
-    let shopDomain = "";
-    try {
-      const payloadBase64 = token.split(".")[1];
-      const decoded = JSON.parse(Buffer.from(payloadBase64, "base64url").toString("utf8"));
-      shopDomain = decoded.shop || decoded.shop_id || decoded.merchant_id;
-      console.log("🔍 [orders/fetch] Step 3: Decoded token. shopDomain:", shopDomain, "| decoded keys:", Object.keys(decoded).join(", "));
-    } catch (err) {
-      console.error("🔍 [orders/fetch] Step 3 FAILED: Token decode error:", err);
-      return new Response(JSON.stringify({ error: "Invalid token format" }), {
+    // Verified (local HMAC or remote /auth/validate) — the previous raw
+    // decode accepted ANY well-formed JWT and handed back the shop's orders.
+    const { verifyProxyToken } = await import("../services/token-verify.server");
+    const verified = await verifyProxyToken(token);
+    if (!verified) {
+      return new Response(JSON.stringify({ error: "Invalid or expired token" }), {
         status: 401,
         headers: { ...CORS_HEADERS, "Content-Type": "application/json" }
       });
     }
+    const shopDomain = (verified.shop || verified.shop_id || verified.merchant_id || "") as string;
 
     if (!shopDomain) {
       console.error("🔍 [orders/fetch] Step 3 FAILED: shopDomain is empty/null");

--- a/app/routes/api.retrieve.$proofId.tsx
+++ b/app/routes/api.retrieve.$proofId.tsx
@@ -1,4 +1,5 @@
 import { type LoaderFunctionArgs } from "react-router";
+import { allowRequest, clientIp, rateLimitResponse } from "../services/rate-limit.server";
 import { getProof } from "../services/ink-api.server";
 
 const CORS_HEADERS = {
@@ -16,6 +17,9 @@ export const action = async () => {
 };
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
+  // Public endpoint — per-IP rate limit (services/rate-limit.server.ts).
+  if (!allowRequest(`retrieve:${clientIp(request)}`, 60)) return rateLimitResponse();
+
     console.log("\n🔍 =================================================");
     console.log("🔍 /api/retrieve ENDPOINT HIT");
     console.log("🔍 Time:", new Date().toISOString());

--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -1,4 +1,5 @@
 import { type ActionFunctionArgs } from "react-router";
+import { allowRequest, clientIp, rateLimitResponse } from "../services/rate-limit.server";
 import { serialNumberToToken } from "../utils/nfc-conversion.server";
 import { INK_NAMESPACE } from "../utils/metafields.server";
 import { getProof } from "../services/ink-api.server";
@@ -20,6 +21,9 @@ export const loader = async () => {
 };
 
 export const action = async ({ request }: ActionFunctionArgs) => {
+  // Public endpoint — per-IP rate limit (services/rate-limit.server.ts).
+  if (!allowRequest(`verify:${clientIp(request)}`, 60)) return rateLimitResponse();
+
     // CRITICAL: Log EVERY request that hits this endpoint
     console.log("\n🚨 =================================================");
     console.log("🚨 /api/verify ENDPOINT HIT");

--- a/app/routes/app.api.auth.login.tsx
+++ b/app/routes/app.api.auth.login.tsx
@@ -17,13 +17,15 @@ const json = (data: any, init?: ResponseInit) =>
   });
 
 const COLLECTION = "warehouse_users";
+// No dev-secret fallback: a token signed with a published constant would
+// fail verification anyway (services/token-verify.server.ts) — better to
+// fail loudly at mint time than mint tokens that 401 downstream.
 const JWT_SECRET =
-  process.env.WAREHOUSE_JWT_SECRET ||
-  process.env.SHOPIFY_API_SECRET ||
-  "fallback-dev-secret";
+  process.env.WAREHOUSE_JWT_SECRET || process.env.SHOPIFY_API_SECRET;
 
 // Simple JWT-like token using HMAC-SHA256
 function createToken(payload: object): string {
+  if (!JWT_SECRET) throw new Error("WAREHOUSE_JWT_SECRET / SHOPIFY_API_SECRET not configured — cannot mint tokens");
   const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   const signature = crypto

--- a/app/routes/app.api.orders.tsx
+++ b/app/routes/app.api.orders.tsx
@@ -1,6 +1,6 @@
 import { type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
-import crypto from "crypto";
+import { verifyProxyToken } from "../services/token-verify.server";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 const json = (data: any, init?: ResponseInit) =>
@@ -14,35 +14,7 @@ const json = (data: any, init?: ResponseInit) =>
     ...init,
   });
 
-const JWT_SECRET =
-  process.env.WAREHOUSE_JWT_SECRET ||
-  process.env.SHOPIFY_API_SECRET ||
-  "fallback-dev-secret";
-
-// Verify our HMAC-based token from app.api.auth.login.tsx
-function verifyToken(token: string): { sub: string; shop: string; email: string; name: string } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-
-    const [header, body, signature] = parts;
-    const expectedSig = crypto
-      .createHmac("sha256", JWT_SECRET)
-      .update(`${header}.${body}`)
-      .digest("base64url");
-
-    if (signature !== expectedSig) return null;
-
-    const payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
-
-    // Check expiry
-    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
-
-    return payload;
-  } catch {
-    return null;
-  }
-}
+// Token verification: services/token-verify.server.ts (shared, fail-closed).
 
 // ─── Shopify GraphQL helper ────────────────────────────────────────────────────
 async function fetchShopifyOrders(shopDomain: string, search: string): Promise<any[]> {
@@ -240,7 +212,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   }
 
   const token = authHeader.slice(7);
-  const payload = verifyToken(token);
+  const payload = await verifyProxyToken(token);
   if (!payload) {
     return json({ error: "Invalid or expired token" }, { status: 401 });
   }

--- a/app/routes/app.api.settings.inventory.tsx
+++ b/app/routes/app.api.settings.inventory.tsx
@@ -11,11 +11,6 @@ import crypto from "crypto";
  * POST /app/api/settings/inventory → update settings
  */
 
-const JWT_SECRET =
-  process.env.WAREHOUSE_JWT_SECRET ||
-  process.env.SHOPIFY_API_SECRET ||
-  "fallback-dev-secret";
-
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
@@ -28,26 +23,8 @@ const json = (data: any, init?: ResponseInit) =>
     ...init,
   });
 
-function decodeToken(token: string): { shop?: string; merchant_id?: string } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const [header, body, signature] = parts;
-
-    // Try HMAC verify first
-    const expectedSig = crypto
-      .createHmac("sha256", JWT_SECRET)
-      .update(`${header}.${body}`)
-      .digest("base64url");
-
-    const payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
-    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
-
-    return { shop: payload.shop, merchant_id: payload.merchant_id };
-  } catch {
-    return null;
-  }
-}
+// Token verification: services/token-verify.server.ts (fail-closed; the old
+// decodeToken computed an HMAC and then never checked it — pure decode).
 
 async function getMerchantDoc(shopDomain?: string, merchantId?: string) {
   // Try by document ID (merchant_id)
@@ -79,7 +56,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     return json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const tokenPayload = decodeToken(authHeader.slice(7));
+  const tokenPayload = await verifyProxyToken(authHeader.slice(7));
   if (!tokenPayload) {
     return json({ error: "Invalid or expired token" }, { status: 401 });
   }
@@ -110,7 +87,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     return json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const tokenPayload = decodeToken(authHeader.slice(7));
+  const tokenPayload = await verifyProxyToken(authHeader.slice(7));
   if (!tokenPayload) {
     return json({ error: "Invalid or expired token" }, { status: 401 });
   }

--- a/app/routes/app.api.settings.media.tsx
+++ b/app/routes/app.api.settings.media.tsx
@@ -1,6 +1,6 @@
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
-import crypto from "crypto";
+import { verifyProxyToken } from "../services/token-verify.server";
 import { authenticate } from "../shopify.server";
 
 const INK_API_URL = process.env.INK_API_URL || "https://us-central1-inink-c76d3.cloudfunctions.net/api";
@@ -22,11 +22,6 @@ function toMerchantSlug(shopDomain: string): string {
   return shopDomain.replace('.myshopify.com', '').replace(/[^a-z0-9-]/gi, '-').toLowerCase();
 }
 
-const JWT_SECRET =
-  process.env.WAREHOUSE_JWT_SECRET ||
-  process.env.SHOPIFY_API_SECRET ||
-  "fallback-dev-secret";
-
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, DELETE, PATCH, OPTIONS",
@@ -39,54 +34,24 @@ const json = (data: any, init?: ResponseInit) =>
     ...init,
   });
 
-function decodeToken(token: string): { shop?: string; merchant_id?: string } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const [header, body, signature] = parts;
-
-    const payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
-    console.log(`[settings/media] Decoding token payload keys: ${Object.keys(payload).join(", ")}`);
-
-    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
-      console.warn(`[settings/media] Token expired at ${new Date(payload.exp * 1000).toISOString()}`);
-      return null;
-    }
-
-    // Case 1: Our own HMAC-signed warehouse JWT (has 'shop' or 'merchant_id')
-    const expectedSig = crypto
-      .createHmac("sha256", JWT_SECRET)
-      .update(`${header}.${body}`)
-      .digest("base64url");
-
-    if (signature === expectedSig) {
-      console.log(`[settings/media] Token verified as our own HMAC JWT. shop=${payload.shop}, merchant_id=${payload.merchant_id}`);
-      return { shop: payload.shop, merchant_id: payload.merchant_id };
-    }
-
-    // Case 2: Shopify App Bridge session token.
-    // These have: iss (store URL), dest (store URL), sub (user gid), aud (api_key)
-    // The 'dest' field contains the full store URL like https://taimoor1-2.myshopify.com
-    if (payload.dest) {
-      // Extract the myshopify domain from the dest URL
-      const destUrl = payload.dest as string;
-      const shopDomain = destUrl.replace("https://", "").replace("http://", "").replace(/\/$/, "");
-      console.log(`[settings/media] Token is Shopify App Bridge session token. Extracted shop domain: ${shopDomain}`);
-      return { shop: shopDomain };
-    }
-
-    // Case 3: Unknown JWT but has shop or merchant_id - accept with warning
-    if (payload.shop || payload.merchant_id) {
-      console.warn(`[settings/media] Token not HMAC-verified but has shop/merchant_id. shop=${payload.shop}, merchant_id=${payload.merchant_id}`);
-      return { shop: payload.shop, merchant_id: payload.merchant_id };
-    }
-
-    console.warn(`[settings/media] Token has none of: dest, shop, merchant_id. Cannot identify merchant.`);
-    return null;
-  } catch (e: any) {
-    console.error(`[settings/media] Failed to decode token:`, e.message);
-    return null;
+// Verified token → merchant identity. All three legit token kinds now verify:
+// our HMAC tokens + App Bridge session tokens verify locally in
+// verifyProxyToken (App Bridge tokens are HS256-signed with the app's client
+// secret), ink-backend JWTs verify remotely via /auth/validate. The old
+// Case 3 ("not HMAC-verified but has shop/merchant_id — accept with
+// warning") let any crafted JWT write another merchant's media — gone.
+async function decodeToken(token: string): Promise<{ shop?: string; merchant_id?: string } | null> {
+  const payload = await verifyProxyToken(token);
+  if (!payload) return null;
+  // App Bridge session token: shop domain lives in the dest URL.
+  if (!payload.shop && !payload.merchant_id && payload.dest) {
+    const shopDomain = String(payload.dest)
+      .replace("https://", "")
+      .replace("http://", "")
+      .replace(/\/$/, "");
+    return { shop: shopDomain };
   }
+  return { shop: payload.shop as string | undefined, merchant_id: payload.merchant_id as string | undefined };
 }
 
 async function getMerchantDoc(shopDomain?: string, merchantId?: string) {
@@ -134,7 +99,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       }
       const rawToken = authHeader.slice(7);
       console.log(`[settings/media] GET auth: Attempting to decode Bearer token (length=${rawToken.length})...`);
-      const tokenPayload = decodeToken(rawToken);
+      const tokenPayload = await decodeToken(rawToken);
       if (!tokenPayload) {
         console.error(`[settings/media] GET auth: Bearer token could not be decoded or has no shop identifier. Returning 401.`);
         return json({ error: "Invalid or expired token" }, { status: 401 });
@@ -198,7 +163,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       }
       const rawToken = authHeader.slice(7);
       console.log(`[settings/media] ${request.method} auth: Decoding Bearer token (length=${rawToken.length})...`);
-      const tokenPayload = decodeToken(rawToken);
+      const tokenPayload = await decodeToken(rawToken);
       if (!tokenPayload) {
         console.error(`[settings/media] ${request.method} auth: Token invalid or no shop identifier. Returning 401.`);
         return json({ error: "Invalid or expired token" }, { status: 401 });

--- a/app/routes/app.api.settings.notifications.tsx
+++ b/app/routes/app.api.settings.notifications.tsx
@@ -11,11 +11,6 @@ import crypto from "crypto";
  * POST /app/api/settings/notifications → update settings
  */
 
-const JWT_SECRET =
-  process.env.WAREHOUSE_JWT_SECRET ||
-  process.env.SHOPIFY_API_SECRET ||
-  "fallback-dev-secret";
-
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
@@ -28,20 +23,8 @@ const json = (data: any, init?: ResponseInit) =>
     ...init,
   });
 
-function decodeToken(token: string): { shop?: string; merchant_id?: string } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const [header, body] = parts;
-
-    const payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
-    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
-
-    return { shop: payload.shop, merchant_id: payload.merchant_id };
-  } catch {
-    return null;
-  }
-}
+// Token verification: services/token-verify.server.ts (fail-closed; the old
+// decodeToken computed an HMAC and then never checked it — pure decode).
 
 async function getMerchantDocRef(shopDomain?: string, merchantId?: string) {
   if (merchantId) {
@@ -79,7 +62,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     return json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const tokenPayload = decodeToken(authHeader.slice(7));
+  const tokenPayload = await verifyProxyToken(authHeader.slice(7));
   if (!tokenPayload) {
     return json({ error: "Invalid or expired token" }, { status: 401 });
   }
@@ -113,7 +96,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     return json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const tokenPayload = decodeToken(authHeader.slice(7));
+  const tokenPayload = await verifyProxyToken(authHeader.slice(7));
   if (!tokenPayload) {
     return json({ error: "Invalid or expired token" }, { status: 401 });
   }

--- a/app/routes/app.api.users.tsx
+++ b/app/routes/app.api.users.tsx
@@ -4,11 +4,6 @@ import { adminCreateUser, getShopIdByDomain, getMerchantUsers, deleteMerchantUse
 import sgMail from "@sendgrid/mail";
 import crypto from "crypto";
 
-const JWT_SECRET =
-  process.env.WAREHOUSE_JWT_SECRET ||
-  process.env.SHOPIFY_API_SECRET ||
-  "fallback-dev-secret";
-
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
@@ -21,23 +16,7 @@ const json = (data: any, init?: ResponseInit) =>
     ...init,
   });
 
-function verifyToken(token: string): { shop: string } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const [header, body, signature] = parts;
-    const expectedSig = crypto
-      .createHmac("sha256", JWT_SECRET)
-      .update(`${header}.${body}`)
-      .digest("base64url");
-    if (signature !== expectedSig) return null;
-    const payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
-    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
-    return payload;
-  } catch {
-    return null;
-  }
-}
+// Token verification: services/token-verify.server.ts (shared, fail-closed).
 
 // ─── GET: list all users for this shop ───────────────────────────────────────
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -57,7 +36,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       const authHeader = request.headers.get("Authorization");
       if (authHeader && authHeader.startsWith("Bearer ")) {
         const token = authHeader.split(" ")[1];
-        const payload = verifyToken(token);
+        const payload = await verifyProxyToken(token);
         shopDomain = payload?.shop || "";
         
         if (!shopDomain) {
@@ -124,7 +103,7 @@ export async function action({ request }: ActionFunctionArgs) {
       const authHeader = request.headers.get("Authorization");
       if (authHeader && authHeader.startsWith("Bearer ")) {
         const token = authHeader.split(" ")[1];
-        const payload = verifyToken(token);
+        const payload = await verifyProxyToken(token);
         shopDomain = payload?.shop || "";
         
         if (!shopDomain) {

--- a/app/routes/app.api.warehouse.enroll.tsx
+++ b/app/routes/app.api.warehouse.enroll.tsx
@@ -1,6 +1,6 @@
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
-import crypto from "crypto";
+import { verifyProxyToken } from "../services/token-verify.server";
 
 /**
  * Public endpoint (authenticated by warehouse JWT only).
@@ -28,38 +28,9 @@ const INK_API_URL =
   process.env.NFS_API_URL ||
   "https://us-central1-inink-c76d3.cloudfunctions.net/api";
 
-const JWT_SECRET =
-  process.env.WAREHOUSE_JWT_SECRET ||
-  process.env.SHOPIFY_API_SECRET ||
-  "fallback-dev-secret";
-
-function extractTokenPayload(token: string): { shop?: string; merchant_id?: string } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const [header, body, signature] = parts;
-
-    // 1. Try strict HMAC verification (our own issued tokens)
-    const expectedSig = crypto
-      .createHmac("sha256", JWT_SECRET)
-      .update(`${header}.${body}`)
-      .digest("base64url");
-
-    let payload: any;
-    if (signature === expectedSig) {
-      payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
-      if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
-      return { shop: payload.shop, merchant_id: payload.merchant_id };
-    }
-
-    // 2. Fall back to decode-without-verify (Alan's JWTs)
-    payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
-    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
-    return { shop: payload.shop, merchant_id: payload.merchant_id };
-  } catch {
-    return null;
-  }
-}
+// Token verification now lives in services/token-verify.server.ts —
+// local HMAC for our own tokens, REMOTE /auth/validate for ink-backend
+// JWTs. The old decode-without-verify fallback is gone (fix-list #2).
 
 import { createMerchant, enrollOrder, getShopIdByDomain, adjustMerchantInventory, getInventoryByShopDomain } from "../services/ink-api.server";
 
@@ -147,7 +118,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     console.log("[ENROLL] ❌ Missing or malformed Authorization header");
     return json({ error: "Unauthorized" }, { status: 401 });
   }
-  const tokenPayload = extractTokenPayload(authHeader.slice(7));
+  const tokenPayload = await verifyProxyToken(authHeader.slice(7));
   console.log("[ENROLL] Token payload decoded:", tokenPayload ? JSON.stringify(tokenPayload) : "NULL (invalid/expired)");
   if (!tokenPayload) {
     console.log("[ENROLL] ❌ Token rejected");

--- a/app/routes/app.api.warehouse.inventory.tsx
+++ b/app/routes/app.api.warehouse.inventory.tsx
@@ -12,11 +12,6 @@ import crypto from "crypto";
  * Response: { current_count, recent_transactions }
  */
 
-const JWT_SECRET =
-  process.env.WAREHOUSE_JWT_SECRET ||
-  process.env.SHOPIFY_API_SECRET ||
-  "fallback-dev-secret";
-
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, OPTIONS",
@@ -29,23 +24,7 @@ const json = (data: any, init?: ResponseInit) =>
     ...init,
   });
 
-function verifyToken(token: string): { shop: string } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const [header, body, signature] = parts;
-    const expectedSig = crypto
-      .createHmac("sha256", JWT_SECRET)
-      .update(`${header}.${body}`)
-      .digest("base64url");
-    if (signature !== expectedSig) return null;
-    const payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
-    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
-    return payload;
-  } catch {
-    return null;
-  }
-}
+// Token verification: services/token-verify.server.ts (shared, fail-closed).
 
 export async function loader({ request }: LoaderFunctionArgs) {
   // 1. Handle CORS preflight
@@ -61,7 +40,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
 
     const token = authHeader.split(" ")[1];
-    const payload = verifyToken(token);
+    const payload = await verifyProxyToken(token);
     
     let shopDomain = payload?.shop;
     

--- a/app/routes/app.api.warehouse.upload.tsx
+++ b/app/routes/app.api.warehouse.upload.tsx
@@ -1,7 +1,7 @@
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
 import { uploadMedia, createMerchant, adjustMerchantInventory, getShopIdByDomain } from "../services/ink-api.server";
-import crypto from "crypto";
+import { verifyProxyToken } from "../services/token-verify.server";
 
 /**
  * Public endpoint (authenticated by warehouse JWT only).
@@ -11,11 +11,6 @@ import crypto from "crypto";
  * Headers: Authorization: Bearer <warehouse_token>
  * Body: multipart/form-data with fields: proof_id, media_type, file
  */
-
-const JWT_SECRET =
-  process.env.WAREHOUSE_JWT_SECRET ||
-  process.env.SHOPIFY_API_SECRET ||
-  "fallback-dev-secret";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -29,42 +24,9 @@ const json = (data: any, init?: ResponseInit) =>
     ...init,
   });
 
-/**
- * Extracts a shop identifier from either our HMAC-signed JWT or Alan's JWT.
- * Returns { shop, merchant_id } — at least one will be set on success.
- */
-function extractTokenPayload(token: string): { shop?: string; merchant_id?: string } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const [header, body, signature] = parts;
-
-    // 1. Try strict HMAC verification (our own issued tokens)
-    const expectedSig = crypto
-      .createHmac("sha256", JWT_SECRET)
-      .update(`${header}.${body}`)
-      .digest("base64url");
-
-    let payload: any;
-    if (signature === expectedSig) {
-      payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
-      if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
-      return { shop: payload.shop, merchant_id: payload.merchant_id };
-    }
-
-    // 2. Fall back to decode-without-verify (Alan's JWTs)
-    payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
-    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
-
-    // Alan JWT contains: merchant_id, user_id, email, role
-    return {
-      shop: payload.shop,
-      merchant_id: payload.merchant_id,
-    };
-  } catch {
-    return null;
-  }
-}
+// Token verification now lives in services/token-verify.server.ts —
+// local HMAC for our own tokens, REMOTE /auth/validate for ink-backend
+// JWTs. The old decode-without-verify fallback is gone (fix-list #2).
 
 async function getMerchantApiKey(shopDomain?: string, merchantId?: string): Promise<string | null> {
   // 1. Try matching by Firestore document ID (=== merchant_id from Alan JWT)
@@ -136,7 +98,7 @@ export async function action({ request }: ActionFunctionArgs) {
     return json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const tokenPayload = extractTokenPayload(authHeader.slice(7));
+  const tokenPayload = await verifyProxyToken(authHeader.slice(7));
   console.log("[UPLOAD] Token decoded:", tokenPayload ? JSON.stringify(tokenPayload) : "NULL");
   if (!tokenPayload) {
     console.log("[UPLOAD] ❌ Token rejected");

--- a/app/services/rate-limit.server.ts
+++ b/app/services/rate-limit.server.ts
@@ -1,0 +1,43 @@
+// Minimal in-memory IP rate limiter for the public API routes (api.enroll,
+// api.verify, api.retrieve, api.orders.fetch). Fixed window per key.
+//
+// Honest scope: per-INSTANCE memory — Cloud Run may run several instances,
+// so the effective global limit is (limit × instances). That still kills
+// single-source abuse (enumeration, brute force), which is the review/security
+// bar here. A shared store (Redis/Firestore counter) is the upgrade path if
+// traffic ever justifies it.
+
+type Bucket = { count: number; windowStart: number };
+const buckets = new Map<string, Bucket>();
+const WINDOW_MS = 60_000;
+const MAX_KEYS = 10_000; // memory backstop — clears oldest windows wholesale
+
+export function allowRequest(key: string, limitPerMinute: number): boolean {
+  const now = Date.now();
+  if (buckets.size > MAX_KEYS) {
+    for (const [k, b] of buckets) {
+      if (now - b.windowStart > WINDOW_MS) buckets.delete(k);
+    }
+    if (buckets.size > MAX_KEYS) buckets.clear();
+  }
+  const b = buckets.get(key);
+  if (!b || now - b.windowStart > WINDOW_MS) {
+    buckets.set(key, { count: 1, windowStart: now });
+    return true;
+  }
+  b.count += 1;
+  return b.count <= limitPerMinute;
+}
+
+export function clientIp(request: Request): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown"
+  );
+}
+
+export function rateLimitResponse(headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify({ error: "Too many requests" }), {
+    status: 429,
+    headers: { "Content-Type": "application/json", "Retry-After": "60", ...headers },
+  });
+}

--- a/app/services/token-verify.server.ts
+++ b/app/services/token-verify.server.ts
@@ -1,0 +1,97 @@
+import crypto from "crypto";
+
+// Shared Bearer-token verification for the proxy endpoints (warehouse
+// enroll/upload, orders fetch, app.api.orders). Replaces the per-route
+// copies whose "fall back to decode-without-verify (Alan's JWTs)" step
+// accepted ANY well-formed JWT — an attacker could mint
+// {shop: "victim.myshopify.com"} and act as that store (fix-list #2).
+//
+// Two legitimate issuers, two verification paths, zero unverified accepts:
+//  1. Our own tokens (app.api.auth.login / warehouse mint) — HMAC-SHA256
+//     with WAREHOUSE_JWT_SECRET / SHOPIFY_API_SECRET, verified locally.
+//     The old "fallback-dev-secret" constant is gone: a guessable published
+//     secret is worse than no local path (Cloud Run always has
+//     SHOPIFY_API_SECRET; local dev without env falls through to 2).
+//  2. ink-backend merchant JWTs — signed with the backend's JWT_SECRET,
+//     which this app deliberately does not hold. Validated REMOTELY via the
+//     backend's own GET /auth/validate; only if the backend says valid:true
+//     is the payload trusted (the backend signed it, so its claims are
+//     authentic). Backend unreachable → fail CLOSED (null → 401).
+
+const INK_API_URL =
+  process.env.INK_API_URL ||
+  process.env.NFS_API_URL ||
+  "https://us-central1-inink-c76d3.cloudfunctions.net/api";
+
+// Both candidate local secrets are tried: WAREHOUSE_JWT_SECRET signs our own
+// minted tokens; SHOPIFY_API_SECRET signs App Bridge session tokens (Shopify
+// signs those HS256 with the app's client secret — so an App Bridge token
+// verifies LOCALLY here; routes that accept them read payload.dest after).
+const LOCAL_SECRETS = [
+  process.env.WAREHOUSE_JWT_SECRET,
+  process.env.SHOPIFY_API_SECRET,
+].filter((s): s is string => Boolean(s));
+
+export interface VerifiedTokenPayload {
+  shop?: string;
+  merchant_id?: string;
+  shop_id?: string;
+  sub?: string;
+  email?: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+export async function verifyProxyToken(
+  token: string
+): Promise<VerifiedTokenPayload | null> {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [header, body, signature] = parts;
+
+  let payload: VerifiedTokenPayload & { exp?: number };
+  try {
+    payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
+
+  // Path 1 — locally verifiable tokens (ours + App Bridge session tokens).
+  for (const secret of LOCAL_SECRETS) {
+    try {
+      const expected = crypto
+        .createHmac("sha256", secret)
+        .update(`${header}.${body}`)
+        .digest("base64url");
+      const sigBuf = Buffer.from(signature);
+      const expBuf = Buffer.from(expected);
+      if (sigBuf.length === expBuf.length && crypto.timingSafeEqual(sigBuf, expBuf)) {
+        return payload;
+      }
+    } catch {
+      // try next candidate / fall through to remote validation
+    }
+  }
+
+  // Path 2 — ink-backend JWTs, validated by the issuer itself.
+  try {
+    const res = await fetch(`${INK_API_URL}/auth/validate`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const v = (await res.json()) as { valid?: boolean; shop_id?: string };
+      if (v?.valid) {
+        return {
+          ...payload,
+          shop_id: v.shop_id ?? payload.shop_id,
+          merchant_id: (payload.merchant_id as string) ?? v.shop_id,
+        };
+      }
+    }
+  } catch {
+    // backend unreachable → fail closed below
+  }
+
+  return null;
+}


### PR DESCRIPTION
Closes the decode-without-verify class (fix-list #2) across 9 routes via one shared verifier; kills `fallback-dev-secret`; adds per-IP rate limits to the 4 public endpoints. Legit callers preserved: our HMAC tokens + App Bridge session tokens verify locally, ink-backend JWTs verify against the backend's own /auth/validate. Forged `{shop: victim}` tokens now 401.

Verified: `react-router build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)