### PR TITLE
Phase 3a: real Delivered funnel + comms card + real owner email

### DIFF
--- a/app/components/CommsCard.tsx
+++ b/app/components/CommsCard.tsx
@@ -1,0 +1,79 @@
+import { useEffect } from "react";
+import { Link } from "react-router";
+import { useFetcher } from "react-router";
+import { Mail, MessageSquare, Loader2 } from "lucide-react";
+
+// The dashboard Communications card — REAL state only (the merchant's actual
+// notification_settings via /app/api/dashboard/comms). Replaces the old
+// CommunicationsUsage card, which rendered 48,726 fictional messages.
+
+type CommsSettings = {
+  channels?: { email?: boolean; sms?: boolean };
+  delivery?: Record<string, boolean>;
+  reminders?: Record<string, boolean>;
+} | null;
+
+const CommsCard = () => {
+  const fetcher = useFetcher<{ settings: CommsSettings }>();
+
+  useEffect(() => {
+    if (fetcher.state === "idle" && !fetcher.data) {
+      fetcher.load("/app/api/dashboard/comms");
+    }
+  }, [fetcher]);
+
+  const isLoading = fetcher.state === "loading" || !fetcher.data;
+  const s = fetcher.data?.settings;
+  const emailOn = s?.channels?.email !== false; // default-on mirrors settings
+  const smsOn = s?.channels?.sms === true;
+
+  const Row = ({
+    icon: Icon,
+    label,
+    on,
+  }: {
+    icon: React.ComponentType<{ className?: string }>;
+    label: string;
+    on: boolean;
+  }) => (
+    <div className="flex items-center justify-between text-sm py-1.5">
+      <span className="text-muted-foreground flex items-center gap-1.5">
+        <Icon className="h-3.5 w-3.5" />
+        {label}
+      </span>
+      <span
+        className={`text-xs font-medium px-2 py-0.5 rounded-sm ${
+          on ? "bg-foreground text-background" : "bg-secondary text-muted-foreground"
+        }`}
+      >
+        {on ? "On" : "Off"}
+      </span>
+    </div>
+  );
+
+  return (
+    <div className="relative bg-card border border-border rounded-sm p-5">
+      {isLoading && (
+        <div className="absolute inset-0 bg-background/50 backdrop-blur-[1px] flex items-center justify-center z-10 rounded-sm">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      )}
+      <p className="text-sm font-medium text-foreground mb-1">Communications</p>
+      <p className="text-xs text-muted-foreground mb-2">
+        Shipping and delivery updates, sent in your brand's name.
+      </p>
+      <div className="divide-y divide-border">
+        <Row icon={Mail} label="Email notifications" on={emailOn} />
+        <Row icon={MessageSquare} label="Text notifications" on={smsOn} />
+      </div>
+      <Link
+        to="/app/settings"
+        className="mt-3 inline-block text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        Manage in Settings →
+      </Link>
+    </div>
+  );
+};
+
+export default CommsCard;

--- a/app/components/EngagementFunnel.tsx
+++ b/app/components/EngagementFunnel.tsx
@@ -13,7 +13,7 @@ const EngagementFunnel = () => {
   // Enrolled = all proofs, Opened = proofs the buyer opened at least once
   // (the backend still calls an open a "tap" — API field names are load-bearing,
   // merchant-facing copy says "opened").
-  const fetcher = useFetcher<{ totalTaps: number; enrollments: number; engaged: number }>();
+  const fetcher = useFetcher<{ totalTaps: number; enrollments: number; engaged: number; delivered: number }>();
   useEffect(() => {
     if (fetcher.state === "idle" && !fetcher.data) {
       fetcher.load(`/app/api/dashboard/tap-stats?_t=${Date.now()}`);
@@ -23,9 +23,11 @@ const EngagementFunnel = () => {
   const isLoading = fetcher.state === "loading" || !fetcher.data;
   const enrollments = fetcher.data?.enrollments ?? 0;
   const engaged = fetcher.data?.engaged ?? 0;
+  const delivered = fetcher.data?.delivered ?? 0;
 
   const steps: FunnelStep[] = [
     { label: "Enrolled", count: enrollments, color: "bg-amber-500" },
+    { label: "Delivered", count: delivered, color: "bg-sky-500" },
     { label: "Opened", count: engaged, color: "bg-emerald-500" },
   ];
   const maxCount = steps[0]?.count || 1;

--- a/app/routes/app.api.dashboard.comms.tsx
+++ b/app/routes/app.api.dashboard.comms.tsx
@@ -1,0 +1,26 @@
+import { type LoaderFunctionArgs } from "react-router";
+import { authenticate } from "../shopify.server";
+import firestore from "../firestore.server";
+
+const json = (data: any, init?: ResponseInit) =>
+  new Response(JSON.stringify(data), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+// GET /app/api/dashboard/comms — the merchant's real notification toggles for
+// the dashboard Communications card (session-authed, mirrors tap-stats).
+// Reads the same merchants/{shop}.notification_settings the Settings panel
+// writes — never invented numbers, just the actual on/off state.
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  try {
+    const { session } = await authenticate.admin(request);
+    const doc = await firestore.collection("merchants").doc(session.shop).get();
+    const settings = doc.exists ? (doc.data()?.notification_settings ?? null) : null;
+    return json({ settings });
+  } catch (err: any) {
+    if (err instanceof Response) throw err;
+    console.error("[dashboard/comms] error:", err?.message || err);
+    return json({ settings: null });
+  }
+};

--- a/app/routes/app.api.dashboard.tap-stats.tsx
+++ b/app/routes/app.api.dashboard.tap-stats.tsx
@@ -20,6 +20,6 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     // App Bridge can recover; only swallow real errors to zeros.
     if (err instanceof Response) throw err;
     console.error("[tap-stats] error:", err?.message || err);
-    return json({ totalTaps: 0, enrollments: 0 });
+    return json({ totalTaps: 0, enrollments: 0, engaged: 0, delivered: 0 });
   }
 };

--- a/app/routes/app.dashboard.tsx
+++ b/app/routes/app.dashboard.tsx
@@ -19,6 +19,7 @@ import EngagementFunnel from "~/components/EngagementFunnel";
 import NFCTagInventory from "~/components/NFCTagInventory";
 import RevenueThisPeriod from "~/components/RevenueThisPeriod";
 import PlanCard from "~/components/billing/PlanCard";
+import CommsCard from "~/components/CommsCard";
 import AdvancedAnalytics from "~/components/AdvancedAnalytics";
 import { FEATURE_NFC } from "~/flags";
 // Removed from render (kept in tree, unreferenced): TimeToEngagement +
@@ -123,10 +124,13 @@ const Dashboard = () => {
             </div>
           )}
 
-          {/* Row 2: Recent Activity + the honest plan card */}
+          {/* Row 2: Recent Activity + comms state + the honest plan card */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <RecentActivity />
-            <PlanCard />
+            <div className="flex flex-col gap-4">
+              <CommsCard />
+              <PlanCard />
+            </div>
           </div>
 
           {/* Advanced — the full operational-analytics BI, collapsed by default.

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -51,7 +51,22 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   (async () => {
     const existing = await getMerchant(session.shop);
     if (!existing?.ink_api_key) {
-      const inkData = await createMerchant(session.shop, session.shop, `admin@${session.shop}`);
+      // Real owner identity, not the old admin@{domain} placeholder — that
+      // placeholder made the magic link the ONLY door into in.ink (the
+      // merchant could never log in with their real email).
+      let shopName = session.shop;
+      let ownerEmail = `admin@${session.shop}`;
+      try {
+        const res = await admin.graphql(`#graphql
+          query ShopIdentity { shop { name email contactEmail } }`);
+        const shopData = (await res.json())?.data?.shop;
+        if (shopData?.name) shopName = shopData.name;
+        const realEmail = shopData?.email || shopData?.contactEmail;
+        if (realEmail) ownerEmail = realEmail;
+      } catch (e) {
+        console.warn("[App] shop identity fetch failed, using placeholders:", e);
+      }
+      const inkData = await createMerchant(session.shop, shopName, ownerEmail);
       if (inkData?.api_key) {
         await updateMerchant(session.shop, {
           ink_api_key: inkData.api_key,

--- a/app/services/ink-api.server.ts
+++ b/app/services/ink-api.server.ts
@@ -100,7 +100,7 @@ export const getShopIdByDomain = async (shopDomain: string): Promise<string> => 
 // 843/1247 mock. Degrades to zeros on any failure so the card never throws.
 export const getMerchantTapStats = async (
     shopDomain: string,
-): Promise<{ totalTaps: number; enrollments: number; engaged: number }> => {
+): Promise<{ totalTaps: number; enrollments: number; engaged: number; delivered: number }> => {
     try {
         const shopId = await getShopIdByDomain(shopDomain);
         const res = await fetch(
@@ -109,17 +109,19 @@ export const getMerchantTapStats = async (
         );
         if (!res.ok) {
             console.warn(`[ink-api] getMerchantTapStats ${res.status} for ${shopDomain}`);
-            return { totalTaps: 0, enrollments: 0, engaged: 0 };
+            return { totalTaps: 0, enrollments: 0, engaged: 0, delivered: 0 };
         }
         const body = await res.json();
         const proofs: any[] = Array.isArray(body) ? body : (body.proofs ?? []);
         const totalTaps = proofs.reduce((sum, p) => sum + (Number(p.tap_count) || 0), 0);
         // "engaged" = proofs tapped at least once (tap_count > 0) — the Engagement Funnel's "Tapped" bucket.
         const engaged = proofs.reduce((n, p) => n + ((Number(p.tap_count) || 0) > 0 ? 1 : 0), 0);
-        return { totalTaps, enrollments: proofs.length, engaged };
+        // delivered = proofs with a real delivered_at (the list carries it — admin.js:1095).
+        const delivered = proofs.reduce((n, p) => n + (p.delivered_at ? 1 : 0), 0);
+        return { totalTaps, enrollments: proofs.length, engaged, delivered };
     } catch (e: any) {
         console.error("[ink-api] getMerchantTapStats error:", e?.message || e);
-        return { totalTaps: 0, enrollments: 0, engaged: 0 };
+        return { totalTaps: 0, enrollments: 0, engaged: 0, delivered: 0 };
     }
 };
 

--- a/extensions/ink-cart-selector/shopify.extension.toml
+++ b/extensions/ink-cart-selector/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2025-01"
+api_version = "2025-10"
 
 [[extensions]]
 


### PR DESCRIPTION
Dashboard now shows the full real funnel (Enrolled→Delivered→Opened), the merchant's actual comms toggles, and new installs provision with the shop's real owner email instead of the admin@{domain} placeholder (which made the magic link the only login door). Extension api_version bumped off the expired 2025-01.

Verified: `react-router build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)