### PR TITLE
Phase 3b: onboarding checklist + live brand preview (the wow)

### DIFF
--- a/app/components/BrandPreviewCard.tsx
+++ b/app/components/BrandPreviewCard.tsx
@@ -1,0 +1,108 @@
+import type { OnboardingStatus } from "../routes/app.api.onboarding.status";
+
+// The "wow": a mini render of the merchant's OWN page — their logo, hero
+// image, and brand colors, pulled live from the brand book. Not a mockup,
+// not stock — what their buyer sees. Shown in onboarding so, seconds after
+// install, the merchant recognizes their brand already living on a page.
+
+const BrandPreviewCard = ({
+  brand,
+  previewUrl,
+  built,
+}: {
+  brand: OnboardingStatus["brand"];
+  previewUrl: string;
+  built: boolean;
+}) => {
+  const ink = brand?.ink || "#111111";
+  const paper = brand?.paper || "#FAF8F4";
+
+  return (
+    <div className="rounded-md border border-border overflow-hidden bg-card">
+      {/* The phone-ish page preview */}
+      <div
+        className="relative aspect-[4/5] w-full flex flex-col"
+        style={{ backgroundColor: paper }}
+      >
+        {/* Brand band */}
+        <div
+          className="px-4 py-3 flex items-center justify-center"
+          style={{ backgroundColor: "#ffffff", borderBottom: `1px solid ${ink}14` }}
+        >
+          {brand?.logoUrl ? (
+            <img
+              src={brand.logoUrl}
+              alt={brand?.name || "Your brand"}
+              className="max-h-6 max-w-[60%] object-contain"
+            />
+          ) : (
+            <span
+              className="text-sm font-semibold tracking-tight"
+              style={{ color: ink }}
+            >
+              {brand?.name || "Your brand"}
+            </span>
+          )}
+        </div>
+
+        {/* Hero */}
+        <div className="flex-1 relative overflow-hidden">
+          {brand?.heroUrl ? (
+            <img
+              src={brand.heroUrl}
+              alt=""
+              className="absolute inset-0 h-full w-full object-cover"
+            />
+          ) : (
+            <div
+              className="absolute inset-0 flex items-center justify-center"
+              style={{ backgroundColor: ink }}
+            >
+              <span className="text-xs" style={{ color: paper }}>
+                {built ? "Your page" : "Your page — building"}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Faux tracking strip + CTA, in-brand */}
+        <div className="px-4 py-3 space-y-2" style={{ backgroundColor: paper }}>
+          <div className="flex items-center gap-1.5">
+            {["Ordered", "Shipped", "Delivered"].map((s, i) => (
+              <div key={s} className="flex-1">
+                <div
+                  className="h-1 rounded-full"
+                  style={{ backgroundColor: i <= 1 ? ink : `${ink}22` }}
+                />
+                <span
+                  className="mt-1 block text-[9px]"
+                  style={{ color: `${ink}99` }}
+                >
+                  {s}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div
+            className="rounded-sm py-1.5 text-center text-[11px] font-medium"
+            style={{ backgroundColor: ink, color: paper }}
+          >
+            Track your order
+          </div>
+        </div>
+      </div>
+
+      {/* Footer link to the real page */}
+      <a
+        href={previewUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block px-4 py-2.5 text-xs text-muted-foreground hover:text-foreground border-t border-border transition-colors"
+      >
+        {previewUrl.replace("https://", "")} ↗
+      </a>
+    </div>
+  );
+};
+
+export default BrandPreviewCard;

--- a/app/components/OnboardingChecklist.tsx
+++ b/app/components/OnboardingChecklist.tsx
@@ -1,0 +1,141 @@
+import { useEffect } from "react";
+import { Link, useFetcher } from "react-router";
+import { Card, BlockStack, InlineStack, Text, Button, Badge } from "@shopify/polaris";
+import { Check } from "lucide-react";
+import type { OnboardingStatus } from "../routes/app.api.onboarding.status";
+import BrandPreviewCard from "./BrandPreviewCard";
+
+// First-run setup, in-admin. Every step's done-state is REAL (from
+// /app/api/onboarding/status). When all steps are complete the whole card
+// self-hides — no permanent nag. This is also what makes the app clearly
+// "operational through a UI on install" for App Store review.
+
+type Step = {
+  key: string;
+  title: string;
+  done: boolean;
+  body: string;
+  cta?: { label: string; to?: string; onOpenStudio?: boolean };
+};
+
+const OnboardingChecklist = ({
+  onOpenStudio,
+  studioOpening,
+}: {
+  onOpenStudio: () => void;
+  studioOpening: boolean;
+}) => {
+  const fetcher = useFetcher<OnboardingStatus>();
+  useEffect(() => {
+    if (fetcher.state === "idle" && !fetcher.data) {
+      fetcher.load("/app/api/onboarding/status");
+    }
+  }, [fetcher]);
+
+  const s = fetcher.data;
+  if (!s) return null; // silent until we know the real state (no flicker of a fake checklist)
+
+  const steps: Step[] = [
+    {
+      key: "brand",
+      title: "Build your page",
+      done: s.brandBuilt,
+      body: s.brandBuilt
+        ? "Your branded page is live — every order opens on it."
+        : "Open the studio and enter your website — your page builds itself from your brand in about a minute.",
+      cta: s.brandBuilt ? undefined : { label: "Open studio to build", onOpenStudio: true },
+    },
+    {
+      key: "notifications",
+      title: "Turn on delivery notifications",
+      done: s.notificationsOn,
+      body: s.notificationsOn
+        ? "Shipping and delivery updates send in your brand's name."
+        : "Let buyers know when their order ships and arrives — sent as you, by email or text.",
+      cta: s.notificationsOn ? undefined : { label: "Open Settings", to: "/app/settings" },
+    },
+    {
+      key: "firstorder",
+      title: "See it on a real order",
+      done: s.ordersEnrolled > 0,
+      body:
+        s.ordersEnrolled > 0
+          ? `${s.ordersEnrolled} order${s.ordersEnrolled === 1 ? "" : "s"} enrolled${
+              s.deliveries > 0 ? ` · ${s.deliveries} delivered` : ""
+            }${s.opens > 0 ? ` · ${s.opens} opened` : ""}.`
+          : "New orders enroll automatically. Place a test order, or wait for your next real one.",
+      cta: s.ordersEnrolled > 0 ? { label: "View orders", to: "/app/tagged-shipments" } : undefined,
+    },
+  ];
+
+  const doneCount = steps.filter((x) => x.done).length;
+  if (doneCount === steps.length) return null; // fully set up → disappear
+
+  return (
+    <Card>
+      <BlockStack gap="400">
+        <InlineStack align="space-between" blockAlign="center" wrap={false} gap="400">
+          <BlockStack gap="100">
+            <Text as="h2" variant="headingMd">
+              Set up INK
+            </Text>
+            <Text as="p" tone="subdued">
+              {doneCount} of {steps.length} done
+            </Text>
+          </BlockStack>
+          <Badge tone={doneCount === 0 ? "attention" : "info"}>
+            {`${doneCount}/${steps.length}`}
+          </Badge>
+        </InlineStack>
+
+        <div className="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-6">
+          {/* Steps */}
+          <BlockStack gap="300">
+            {steps.map((step) => (
+              <div
+                key={step.key}
+                className="flex items-start gap-3 rounded-md border border-border p-3"
+              >
+                <div
+                  className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full ${
+                    step.done ? "bg-foreground text-background" : "border border-border"
+                  }`}
+                >
+                  {step.done && <Check className="h-3 w-3" />}
+                </div>
+                <div className="flex-1">
+                  <Text as="p" variant="bodyMd" fontWeight="medium">
+                    {step.title}
+                  </Text>
+                  <Text as="p" variant="bodySm" tone="subdued">
+                    {step.body}
+                  </Text>
+                  {step.cta && !step.done && (
+                    <div className="mt-2">
+                      {step.cta.onOpenStudio ? (
+                        <Button size="slim" onClick={onOpenStudio} loading={studioOpening}>
+                          {step.cta.label}
+                        </Button>
+                      ) : step.cta.to ? (
+                        <Link to={step.cta.to}>
+                          <Button size="slim">{step.cta.label}</Button>
+                        </Link>
+                      ) : null}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </BlockStack>
+
+          {/* Live brand preview — the wow */}
+          <div className="w-full md:w-56">
+            <BrandPreviewCard brand={s.brand} previewUrl={s.previewUrl} built={s.brandBuilt} />
+          </div>
+        </div>
+      </BlockStack>
+    </Card>
+  );
+};
+
+export default OnboardingChecklist;

--- a/app/routes/app._index/route.tsx
+++ b/app/routes/app._index/route.tsx
@@ -14,7 +14,7 @@ export default function LandingPage() {
       ctaLabel="Open dashboard"
       showSignIn={false}
       headline="Your dashboard is ready."
-      sub="A surface that opens on every Shopify order. You communicate in ink; you sign in ink — the brand half and the signature half, on every order."
+      sub="Every order gets its own branded page — live tracking, delivery notifications, and returns, opened the moment it ships."
       footnote="New here? Open the dashboard to set up your brand and turn on delivery notifications."
     />
   );

--- a/app/routes/app.api.onboarding.status.tsx
+++ b/app/routes/app.api.onboarding.status.tsx
@@ -1,0 +1,109 @@
+import { type LoaderFunctionArgs } from "react-router";
+import { authenticate } from "../shopify.server";
+import firestore from "../firestore.server";
+import { brandSlugFromDomain } from "../services/email.server";
+import { fetchBrandEmailKit } from "../services/brand-email.server";
+import { getShopIdByDomain, getMerchantTapStats } from "../services/ink-api.server";
+
+const json = (data: any, init?: ResponseInit) =>
+  new Response(JSON.stringify(data), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+export interface OnboardingStatus {
+  brandBuilt: boolean;
+  brand: {
+    name: string | null;
+    logoUrl: string | null;
+    heroUrl: string | null;
+    ink: string;
+    paper: string;
+  } | null;
+  previewUrl: string; // {brand}.in.ink
+  notificationsOn: boolean;
+  ordersEnrolled: number;
+  deliveries: number;
+  opens: number;
+}
+
+// GET /app/api/onboarding/status — the first-run setup state, all REAL:
+// does a brand page exist yet (worker brand book), are notifications on
+// (merchant doc), have any orders enrolled/delivered/opened (proof stats).
+// Powers the in-admin OnboardingChecklist + BrandPreviewCard. Fail-soft:
+// every failure degrades to "not done yet", never throws the dashboard.
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  try {
+    const { session } = await authenticate.admin(request);
+    const shop = session.shop;
+
+    // Merchant doc: notifications + optional brand_slug override.
+    let notificationsOn = false;
+    let brandSlugOverride: string | undefined;
+    try {
+      const doc = await firestore.collection("merchants").doc(shop).get();
+      const d = doc.exists ? doc.data() ?? {} : {};
+      const ch = d.notification_settings?.channels;
+      notificationsOn = Boolean(ch?.email || ch?.sms);
+      if (typeof d.brand_slug === "string" && d.brand_slug) brandSlugOverride = d.brand_slug;
+    } catch { /* default false */ }
+
+    const slug = brandSlugFromDomain(brandSlugOverride || shop);
+    const previewUrl = slug ? `https://${slug}.in.ink` : "https://www.in.ink";
+
+    // Brand book (worker) + proof stats (backend) — independent, fail-soft each.
+    let brand: OnboardingStatus["brand"] = null;
+    let brandBuilt = false;
+    let ordersEnrolled = 0;
+    let deliveries = 0;
+    let opens = 0;
+
+    try {
+      const shopId = await getShopIdByDomain(shop);
+      const [kit, stats] = await Promise.all([
+        fetchBrandEmailKit(shopId).catch(() => null),
+        getMerchantTapStats(shop).catch(() => null),
+      ]);
+      if (kit) {
+        brand = {
+          name: kit.brandName,
+          logoUrl: kit.logoUrl,
+          heroUrl: kit.heroUrl,
+          ink: kit.ink,
+          paper: kit.paper,
+        };
+        // "Built" = the book has real brand media (logo or hero), not just a
+        // provisioned shell.
+        brandBuilt = Boolean(kit.logoUrl || kit.heroUrl);
+      }
+      if (stats) {
+        ordersEnrolled = stats.enrollments ?? 0;
+        deliveries = stats.delivered ?? 0;
+        opens = stats.engaged ?? 0;
+      }
+    } catch { /* brand not built / merchant not resolvable yet */ }
+
+    const status: OnboardingStatus = {
+      brandBuilt,
+      brand,
+      previewUrl,
+      notificationsOn,
+      ordersEnrolled,
+      deliveries,
+      opens,
+    };
+    return json(status);
+  } catch (err: any) {
+    if (err instanceof Response) throw err;
+    console.error("[onboarding/status] error:", err?.message || err);
+    return json({
+      brandBuilt: false,
+      brand: null,
+      previewUrl: "https://www.in.ink",
+      notificationsOn: false,
+      ordersEnrolled: 0,
+      deliveries: 0,
+      opens: 0,
+    } satisfies OnboardingStatus);
+  }
+};

--- a/app/routes/app.dashboard.tsx
+++ b/app/routes/app.dashboard.tsx
@@ -20,6 +20,7 @@ import NFCTagInventory from "~/components/NFCTagInventory";
 import RevenueThisPeriod from "~/components/RevenueThisPeriod";
 import PlanCard from "~/components/billing/PlanCard";
 import CommsCard from "~/components/CommsCard";
+import OnboardingChecklist from "~/components/OnboardingChecklist";
 import AdvancedAnalytics from "~/components/AdvancedAnalytics";
 import { FEATURE_NFC } from "~/flags";
 // Removed from render (kept in tree, unreferenced): TimeToEngagement +
@@ -91,6 +92,9 @@ const Dashboard = () => {
           {fetcher.data?.error && (
             <Banner tone="critical">{fetcher.data.error}</Banner>
           )}
+
+          {/* First-run setup — self-hides once complete (real state). */}
+          <OnboardingChecklist onOpenStudio={openParallel} studioOpening={opening} />
 
           {/* Open the merchant's ink. dashboard, auto-signed-in. */}
           <Card>


### PR DESCRIPTION
Seconds after install, the merchant sees their OWN brand — real logo, hero, colors, pulled live from the brand book — rendered as their order page, next to a 3-step setup checklist whose done-states are all real and which self-hides when complete. Makes onboarding self-evident and satisfies the App Store 'operational through its own UI on install' bar. Stale landing copy fixed.

Verified: `react-router build` green. (Embedded app — no standalone preview; esbuild is the gate per Bible law.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)