### PR TITLE
Fix live leftovers: fake Account pricing + NFC Inventory tab

### DIFF
--- a/app/components/settings/AccountSettings.tsx
+++ b/app/components/settings/AccountSettings.tsx
@@ -60,10 +60,10 @@ const AccountSettings = () => {
           <Card>
             <BlockStack gap="300">
               <Text as="p" variant="bodyMd">
-                View your current billing cycle, usage history, and pricing details.
+                View your plan and how billing works.
               </Text>
               <div>
-                <Button onClick={() => navigate("/app/billing")}>View Usage & Billing</Button>
+                <Button onClick={() => navigate("/app/billing")}>View billing</Button>
               </div>
             </BlockStack>
           </Card>
@@ -71,11 +71,10 @@ const AccountSettings = () => {
           <Card>
             <BlockStack gap="300">
               <Text as="p" variant="bodyMd" fontWeight="semibold">Pricing</Text>
-              <Text as="p" variant="bodyMd">$2.99 per enrollment — sticker included</Text>
-              <Text as="p" variant="bodyMd">$2.99 per verified tap</Text>
-              <Text as="p" variant="bodyMd" fontWeight="semibold">$5.98 per verified shipment (enrollment + tap)</Text>
-              <Text as="p" variant="bodySm" tone="subdued">
-                No monthly fee. Billed through your Shopify invoice.
+              <Text as="p" variant="bodyMd">
+                INK is free during the pilot. Paid plans will be flat monthly
+                tiers based on your order volume — billed through Shopify, no
+                per-order fees.
               </Text>
             </BlockStack>
           </Card>

--- a/app/components/settings/Settings.tsx
+++ b/app/components/settings/Settings.tsx
@@ -4,6 +4,7 @@ import { Page, Tabs } from "@shopify/polaris";
 import PolarisAppLayout from "../PolarisAppLayout";
 import AccountSettings from "./AccountSettings";
 import TagsSettings from "./TagsSettings";
+import { FEATURE_NFC } from "../../flags";
 import BrandingSettings from "./BrandingSettings";
 import CommunicationSettings from "./CommunicationSettings";
 import UserManagementSettings from "./UserManagementSettings";
@@ -12,7 +13,8 @@ import DeliveryModeSettings from "./DeliveryModeSettings";
 const tabs = [
   { id: "account", content: "Account" },
   { id: "delivery", content: "Delivery" },
-  { id: "tags", content: "Inventory" },
+  // NFC tag inventory — tabled behind FEATURE_NFC (app/flags.ts)
+  ...(FEATURE_NFC ? [{ id: "tags", content: "Inventory" }] : []),
   { id: "branding", content: "Media" },
   { id: "communication", content: "Notifications" },
   { id: "users", content: "Users" },


### PR DESCRIPTION
Final-sweep catches on surfaces reachable from the Settings nav: replaced the fake per-enrollment/per-tap pricing card with honest copy, and gated the NFC 'Inventory' tab behind FEATURE_NFC.

Verified: react-router build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)