### PR TITLE
Complete the funnel (Clicked) + studio pull-link

### DIFF
--- a/app/components/EngagementFunnel.tsx
+++ b/app/components/EngagementFunnel.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, Loader2 } from "lucide-react";
+import { ArrowDown, ArrowRight, Loader2 } from "lucide-react";
 import { useFetcher } from "react-router";
 import { useEffect } from "react";
 
@@ -8,12 +8,26 @@ interface FunnelStep {
   color: string;
 }
 
-const EngagementFunnel = () => {
-  // Real funnel from the merchant's proofs (replaces the 1247/843/158 mock):
-  // Enrolled = all proofs, Opened = proofs the buyer opened at least once
-  // (the backend still calls an open a "tap" — API field names are load-bearing,
-  // merchant-facing copy says "opened").
-  const fetcher = useFetcher<{ totalTaps: number; enrollments: number; engaged: number; delivered: number }>();
+// The full real funnel — Enrolled → Delivered → Opened → Clicked — from the
+// merchant's proofs (backend field names say "tap"/"engaged"; merchant copy
+// says "opened"/"clicked"). Ends with the pull to the studio: this is the
+// deliberately-light TASTE of the money story; the full insights (returns $,
+// opens by tier, reopen rate) live in in.ink.
+const EngagementFunnel = ({
+  onOpenStudio,
+  studioOpening,
+}: {
+  onOpenStudio?: () => void;
+  studioOpening?: boolean;
+}) => {
+  const fetcher = useFetcher<{
+    totalTaps: number;
+    enrollments: number;
+    engaged: number;
+    delivered: number;
+    clicked: number;
+    totalClicks: number;
+  }>();
   useEffect(() => {
     if (fetcher.state === "idle" && !fetcher.data) {
       fetcher.load(`/app/api/dashboard/tap-stats?_t=${Date.now()}`);
@@ -24,11 +38,13 @@ const EngagementFunnel = () => {
   const enrollments = fetcher.data?.enrollments ?? 0;
   const engaged = fetcher.data?.engaged ?? 0;
   const delivered = fetcher.data?.delivered ?? 0;
+  const clicked = fetcher.data?.clicked ?? 0;
 
   const steps: FunnelStep[] = [
     { label: "Enrolled", count: enrollments, color: "bg-amber-500" },
     { label: "Delivered", count: delivered, color: "bg-sky-500" },
     { label: "Opened", count: engaged, color: "bg-emerald-500" },
+    { label: "Clicked", count: clicked, color: "bg-violet-500" },
   ];
   const maxCount = steps[0]?.count || 1;
 
@@ -47,7 +63,7 @@ const EngagementFunnel = () => {
       <div className="mb-5">
         <h3 className="text-sm font-semibold text-foreground">Open Funnel</h3>
         <p className="text-xs text-muted-foreground mt-0.5">
-          How many enrolled orders' pages were opened
+          Enrolled orders → delivered → page opened → clicked onward
         </p>
       </div>
 
@@ -55,10 +71,14 @@ const EngagementFunnel = () => {
       <div className="space-y-1">
         {steps.map((step, index) => {
           const widthPercent = Math.max((step.count / maxCount) * 100, 12);
-          const dropoff = index > 0
-            ? (((steps[index - 1].count - step.count) / (steps[index - 1].count || 1)) * 100).toFixed(0)
-            : null;
-          const isLast = index === steps.length - 1;
+          const dropoff =
+            index > 0
+              ? (
+                  ((steps[index - 1].count - step.count) /
+                    (steps[index - 1].count || 1)) *
+                  100
+                ).toFixed(0)
+              : null;
 
           return (
             <div key={step.label}>
@@ -67,7 +87,9 @@ const EngagementFunnel = () => {
                 <div className="flex items-center gap-1.5 py-1 pl-4">
                   <ArrowDown className="h-3 w-3 text-muted-foreground" />
                   <span className="text-xs text-muted-foreground">
-                    {isLast ? `${dropoff}% didn't open` : `${dropoff}% drop-off`}
+                    {step.label === "Opened"
+                      ? `${dropoff}% didn't open`
+                      : `${dropoff}% drop-off`}
                   </span>
                 </div>
               )}
@@ -100,6 +122,18 @@ const EngagementFunnel = () => {
           {((engaged / maxCount) * 100).toFixed(1)}%
         </span>
       </div>
+
+      {/* Pull to the studio — the taste ends here; the full story lives in in.ink */}
+      {onOpenStudio && (
+        <button
+          onClick={onOpenStudio}
+          disabled={studioOpening}
+          className="mt-3 flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+        >
+          See full insights in the studio — returns $, opens by buyer, reopens
+          <ArrowRight className="h-3 w-3" />
+        </button>
+      )}
     </div>
   );
 };

--- a/app/routes/app.api.dashboard.tap-stats.tsx
+++ b/app/routes/app.api.dashboard.tap-stats.tsx
@@ -20,6 +20,6 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     // App Bridge can recover; only swallow real errors to zeros.
     if (err instanceof Response) throw err;
     console.error("[tap-stats] error:", err?.message || err);
-    return json({ totalTaps: 0, enrollments: 0, engaged: 0, delivered: 0 });
+    return json({ totalTaps: 0, enrollments: 0, engaged: 0, delivered: 0, clicked: 0, totalClicks: 0 });
   }
 };

--- a/app/routes/app.dashboard.tsx
+++ b/app/routes/app.dashboard.tsx
@@ -115,9 +115,10 @@ const Dashboard = () => {
             </InlineStack>
           </Card>
 
-          {/* Row 1: Open funnel + Enrolled Order Value — real numbers only */}
+          {/* Row 1: Open funnel + Enrolled Order Value — real numbers only.
+              The funnel ends with the pull to the in.ink studio (full insights). */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <EngagementFunnel />
+            <EngagementFunnel onOpenStudio={openParallel} studioOpening={opening} />
             <RevenueThisPeriod />
           </div>
 

--- a/app/services/ink-api.server.ts
+++ b/app/services/ink-api.server.ts
@@ -100,7 +100,7 @@ export const getShopIdByDomain = async (shopDomain: string): Promise<string> => 
 // 843/1247 mock. Degrades to zeros on any failure so the card never throws.
 export const getMerchantTapStats = async (
     shopDomain: string,
-): Promise<{ totalTaps: number; enrollments: number; engaged: number; delivered: number }> => {
+): Promise<{ totalTaps: number; enrollments: number; engaged: number; delivered: number; clicked: number; totalClicks: number }> => {
     try {
         const shopId = await getShopIdByDomain(shopDomain);
         const res = await fetch(
@@ -109,7 +109,7 @@ export const getMerchantTapStats = async (
         );
         if (!res.ok) {
             console.warn(`[ink-api] getMerchantTapStats ${res.status} for ${shopDomain}`);
-            return { totalTaps: 0, enrollments: 0, engaged: 0, delivered: 0 };
+            return { totalTaps: 0, enrollments: 0, engaged: 0, delivered: 0, clicked: 0, totalClicks: 0 };
         }
         const body = await res.json();
         const proofs: any[] = Array.isArray(body) ? body : (body.proofs ?? []);
@@ -118,10 +118,14 @@ export const getMerchantTapStats = async (
         const engaged = proofs.reduce((n, p) => n + ((Number(p.tap_count) || 0) > 0 ? 1 : 0), 0);
         // delivered = proofs with a real delivered_at (the list carries it — admin.js:1095).
         const delivered = proofs.reduce((n, p) => n + (p.delivered_at ? 1 : 0), 0);
-        return { totalTaps, enrollments: proofs.length, engaged, delivered };
+        // clicked = proofs with an outbound click (click_count on the row);
+        // totalClicks = all outbound clicks. The "Clicked" funnel stage.
+        const clicked = proofs.reduce((n, p) => n + ((Number(p.click_count) || 0) > 0 ? 1 : 0), 0);
+        const totalClicks = proofs.reduce((sum, p) => sum + (Number(p.click_count) || 0), 0);
+        return { totalTaps, enrollments: proofs.length, engaged, delivered, clicked, totalClicks };
     } catch (e: any) {
         console.error("[ink-api] getMerchantTapStats error:", e?.message || e);
-        return { totalTaps: 0, enrollments: 0, engaged: 0, delivered: 0 };
+        return { totalTaps: 0, enrollments: 0, engaged: 0, delivered: 0, clicked: 0, totalClicks: 0 };
     }
 };
 


### PR DESCRIPTION
Adds the real Clicked stage to the Open Funnel (click_count is on the proof rows) and ends the card with 'See full insights in the studio →' — the deliberately-light taste that pulls merchants to the richer in.ink dashboard rather than duplicating returns-$/by-tier/reopens in the embed. Serves the instrument-panel-vs-studio division.

Verified: react-router build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)