### PR TITLE
fix(webhooks): always 200 after HMAC — cut the 47.5% failure rate

### DIFF
--- a/app/routes/webhooks.fulfillments_create.tsx
+++ b/app/routes/webhooks.fulfillments_create.tsx
@@ -21,8 +21,11 @@ import { findMerchantDoc } from "../services/merchant-doc.server";
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { topic, shop, payload, admin } = await authenticate.webhook(request);
 
+  // "ALWAYS 200 once authenticated" (the discipline noted above): admin missing
+  // here is a post-HMAC edge case a Shopify retry can't fix — ack it, don't 401.
   if (!admin) {
-    return new Response("Unauthorized", { status: 401 });
+    console.warn(`[${topic}] No admin context for ${shop}; acking.`);
+    return new Response("OK", { status: 200 });
   }
 
   try {

--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -152,8 +152,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   const orderName = data?.name || data?.order_number || "Unknown";
 
   if (!orderGid) {
-    console.error("[orders/create] Missing order id in payload");
-    return new Response("Missing order id", { status: 400 });
+    // Malformed payload — a Shopify retry can't fix it, so ack (200) instead of
+    // 400. (A genuine processing error below still returns 500 on purpose, so
+    // Shopify retries and the idempotent enroll — backend #23 — eventually lands.)
+    console.error("[orders/create] Missing order id in payload; acking.");
+    return new Response("ok - missing order id", { status: 200 });
   }
 
   console.log(`\n📦 [orders/create] Processing order ${orderName} (${shop})`);

--- a/app/routes/webhooks.orders_fulfilled.tsx
+++ b/app/routes/webhooks.orders_fulfilled.tsx
@@ -7,16 +7,24 @@ import { findMerchantDoc } from "../services/merchant-doc.server";
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { payload, shop, topic, admin } = await authenticate.webhook(request);
 
+  // Webhook discipline: once authenticate.webhook() validates the HMAC this is
+  // a REAL Shopify delivery — every downstream condition (missing admin, bad
+  // payload, unprovisioned merchant, transient read error) ALWAYS returns 200.
+  // A non-2xx just makes Shopify retry something a retry can't fix, inflates the
+  // dashboard failure rate, and risks Shopify auto-disabling the subscription.
+  // This handler is now a read-only shipped-logger anyway (delivery is marked on
+  // the real carrier event in webhooks.fulfillments_update).
   if (!admin) {
-    return new Response("Unauthorized", { status: 401 });
+    console.warn(`[${topic}] No admin context for ${shop}; acking.`);
+    return new Response("OK", { status: 200 });
   }
 
   // Payload for orders/fulfilled webhook is an Order object.
   const orderId = payload.id;
-  
+
   if (!orderId) {
-    console.error(`[${topic}] No order payload found.`);
-    return new Response("Bad Request", { status: 400 });
+    console.error(`[${topic}] No order payload found; acking.`);
+    return new Response("OK", { status: 200 });
   }
 
   const orderGid = `gid://shopify/Order/${orderId}`;
@@ -33,8 +41,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     const merchantApiKey: string | null = merchantHit?.apiKey ?? null;
 
     if (!merchantApiKey) {
-      console.error(`[${topic}] No ink_api_key found in Firestore for shop: ${shop}. Cannot mark delivered.`);
-      return new Response("Merchant API key not found", { status: 500 });
+      // Not fatal + not retryable: an unprovisioned merchant won't provision by
+      // Shopify retrying this webhook. Ack and skip. (This handler doesn't even
+      // use the key anymore — delivery marking moved to fulfillments_update.)
+      console.warn(`[${topic}] No ink_api_key for shop ${shop}; acking + skipping.`);
+      return new Response("OK", { status: 200 });
     }
     console.log(`[${topic}] Found ink_api_key for ${shop} (prefix: ${merchantApiKey.slice(0, 12)}...)`);
 
@@ -79,8 +90,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     }
 
   } catch (error) {
-    console.error(`[${topic}] Error processing fulfilled webhook:`, error);
-    return new Response("Internal Server Error", { status: 500 });
+    // Read-only logger — nothing to retry. Swallow + ack (see discipline note above).
+    console.error(`[${topic}] Error processing fulfilled webhook (acked):`, error);
+    return new Response("OK", { status: 200 });
   }
 
   return new Response("OK", { status: 200 });


### PR DESCRIPTION
Handlers were returning non-2xx on conditions a Shopify retry can't fix (missing admin, bad payload, unprovisioned merchant), inflating the failure metric and risking auto-disable. Now: HMAC valid → always 200 for non-retryable cases. Kept 500-on-genuine-error in orders_create (idempotent enroll SHOULD retry). Compliance webhooks unchanged (401-on-bad-HMAC is required).

Deferred w/ notes: duplicate-subscription cleanup (§17.8) + async enroll via a real queue.

Verified: react-router build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)