### PR TITLE
Phase 5: marketing-consent enforcement on the aimed section (STAGED — Sam merges)

### DIFF
--- a/app/routes/api.verify.tsx
+++ b/app/routes/api.verify.tsx
@@ -635,7 +635,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                       node {
                           id
                           name
-                          customer { email firstName }
+                          customer { email firstName emailMarketingConsent { marketingState } }
                           arrivalEmailSent: metafield(namespace: "ink", key: "arrival_email_sent") { value }
                           lineItems(first: 1) {
                               edges {
@@ -665,7 +665,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                         order(id: $id) {
                           id
                           name
-                          customer { email firstName }
+                          customer { email firstName emailMarketingConsent { marketingState } }
                           arrivalEmailSent: metafield(namespace: "ink", key: "arrival_email_sent") { value }
                           lineItems(first: 1) {
                             edges { node { title image { url } } }
@@ -692,7 +692,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                                     node {
                                         id
                                         name
-                                        customer { email firstName }
+                                        customer { email firstName emailMarketingConsent { marketingState } }
                                         arrivalEmailSent: metafield(namespace: "ink", key: "arrival_email_sent") { value }
                                         lineItems(first: 1) {
                                             edges { node { title image { url } } }
@@ -929,13 +929,31 @@ export const action = async ({ request }: ActionFunctionArgs) => {
                             const { fetchBrandEmailKit, selectEmailCampaign } = await import(
                                 "../services/brand-email.server"
                             );
+                            // Marketing-consent gate (Phase 5): the state email is
+                            // TRANSACTIONAL and sends regardless; only the embedded
+                            // aimed section is marketing. Missing/unknown consent
+                            // fails CLOSED (email goes out without the section).
+                            const { mayIncludeMarketing } = await import(
+                                "../services/consent.server"
+                            );
+                            const buyerEmailConsent = order.customer?.emailMarketingConsent ?? null;
+                            const aimedSectionAllowed = mayIncludeMarketing(
+                                "aimed_section",
+                                "email",
+                                buyerEmailConsent,
+                            );
                             const brandKit = await fetchBrandEmailKit(String(alanData.shop_id || ""));
-                            const emailCampaign = brandKit
+                            const emailCampaign = brandKit && aimedSectionAllowed
                                 ? selectEmailCampaign(brandKit.campaigns, {
                                       tier: (alanData.customer_tier as string | undefined) || null,
                                       productTitles: [productName || ""],
                                   })
                                 : null;
+                            if (!aimedSectionAllowed && brandKit?.campaigns?.length) {
+                                console.log(
+                                    `📧 aimed section WITHHELD (buyer email marketing consent=${buyerEmailConsent?.marketingState || "unknown"}) — transactional content only.`,
+                                );
+                            }
                             await EmailService.sendReturnPassportEmail({
                                 brand: brandKit,
                                 campaign: emailCampaign,

--- a/app/services/state-email.server.ts
+++ b/app/services/state-email.server.ts
@@ -21,6 +21,7 @@
 import { EmailService, brandSlugFromDomain } from "./email.server";
 import { fetchBrandEmailKit, selectEmailCampaign } from "./brand-email.server";
 import { getProof } from "./ink-api.server";
+import { CUSTOMER_CONSENT_FRAGMENT, mayIncludeMarketing } from "./consent.server";
 
 const INK_NAMESPACE = "ink";
 const SENT_KEYS = {
@@ -98,6 +99,7 @@ export async function sendStateEmailOnce(args: StateEmailArgs): Promise<void> {
       order(id: $id) {
         metafield(namespace: "${INK_NAMESPACE}", key: "${SENT_KEY}") { value }
         lineItems(first: 1) { edges { node { title image { url } } } }
+        customer { ${CUSTOMER_CONSENT_FRAGMENT} }
       }
     }`,
     { variables: { id: orderGid } },
@@ -110,6 +112,11 @@ export async function sendStateEmailOnce(args: StateEmailArgs): Promise<void> {
   const firstItem = checkJson.data?.order?.lineItems?.edges?.[0]?.node;
   const productName: string | undefined = firstItem?.title || undefined;
   const productImageUrl: string | undefined = firstItem?.image?.url || undefined;
+  // Marketing-consent gate (Phase 5): the state email itself is TRANSACTIONAL
+  // and always sends; only the embedded aimed section is marketing. Missing/
+  // unknown consent fails CLOSED (transactional-only email).
+  const buyerEmailConsent = checkJson.data?.order?.customer?.emailMarketingConsent ?? null;
+  const aimedSectionAllowed = mayIncludeMarketing("aimed_section", "email", buyerEmailConsent);
 
   // ── Proof (authoritative): nfc_token for the page link, tier for aiming ──
   const merchantApiKey: string | undefined = merchantData.ink_api_key;
@@ -187,12 +194,17 @@ export async function sendStateEmailOnce(args: StateEmailArgs): Promise<void> {
 
   // ── Email-as-tap-page: brand kit + the buyer's aimed section (fail-soft) ──
   const brandKit = await fetchBrandEmailKit(proofShopId);
-  const emailCampaign = brandKit
+  const emailCampaign = brandKit && aimedSectionAllowed
     ? selectEmailCampaign(brandKit.campaigns, {
         tier: customerTier,
         productTitles: [productName || ""],
       })
     : null;
+  if (!aimedSectionAllowed && brandKit?.campaigns?.length) {
+    console.log(
+      `📧 ${label}: aimed section WITHHELD (buyer email marketing consent=${buyerEmailConsent?.marketingState || "unknown"}) — transactional content only.`,
+    );
+  }
 
   if (isTestMerchant) {
     console.log(`📧 DEV-MODE ${label} send: test-flagged merchant but ${customerEmail} is allowlisted — sending (from ${senderFromEmail || "notifications@in.ink"}).`);


### PR DESCRIPTION
## ⚠️ SAM-GATED — do not merge without Sam (merges auto-deploy to Cloud Run)

Buyer-facing behavior change, staged per the RUNBOOK Phase-5 plan (scaffold shipped inert in #55; this PR turns it on).

## What changes
The shipped/delivered emails stay **transactional** and always send. The **aimed/campaign section** embedded in them is marketing, and now renders **only** for buyers whose Shopify `emailMarketingConsent.marketingState = SUBSCRIBED`.

- `state-email.server.ts` — consent fragment rides the existing idempotency order query (zero extra round-trips); `selectEmailCampaign` gated via `mayIncludeMarketing('aimed_section','email',consent)`; a withheld section logs loudly.
- `api.verify.tsx` — all three order lookups (direct GID / verified metafield search / name fallback) now fetch `emailMarketingConsent { marketingState }`; identical gate at the email build.
- **Fail-closed:** missing, unknown, PENDING, UNSUBSCRIBED, or PCD-nulled consent ⇒ the email goes out with **no** aimed section.
- SMS + follow-up paths verified to carry no marketing content — no gate sites there (helpers stand ready).
- **No scope changes** ⇒ no merchant re-consent triggered.

## The call that makes this Sam-gated
Until PCD Level-2 approval lands, Shopify may null customer consent fields for us — meaning **aimed sections in emails will be withheld for most/all buyers once this merges**. That is the compliant posture for App Store review (and what the PCD forms will state), but it visibly changes the email Sam shipped in #42 — his call on timing.

## Verify
- `react-router build` green (esbuild, per Bible law).
- Post-merge check: trigger a shipped email on the SM rig to an allowlisted recipient — expect `aimed section WITHHELD` in Cloud Run logs and a transactional-only email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)