### PR TITLE
GDPR: forward customers/redact to the ink-backend redaction endpoint

### DIFF
--- a/app/routes/webhooks.customers.redact.tsx
+++ b/app/routes/webhooks.customers.redact.tsx
@@ -1,18 +1,60 @@
 import { type ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
+import { redactCustomerInInk } from "../services/ink-api.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { topic, shop, payload } = await authenticate.webhook(request);
 
   console.log(`Received ${topic} webhook for ${shop}`);
-  
-  // CUSTOMERS/REDACT
-  // This app's own DB (Firestore) stores merchant config only — no customer
-  // PII to erase here. But proofs in the ink-backend DO carry order_details
-  // (name/email/address), so full compliance forwards this redaction there.
-  // TODO(Phase 5 — PCD): call the ink-backend redaction endpoint once it
-  // exists (RUNBOOK_SHOPIFY_APP_OVERHAUL.md, parallelreturns), keyed on
-  // payload.customer.id + payload.orders_to_redact.
 
-  return new Response("OK", { status: 200 });
+  // CUSTOMERS/REDACT — this app's own DB stores merchant config only; the
+  // buyer's PII lives on the ink-backend (proof order_details / buyer profile
+  // / GPS, return docs, raw tap+click event rows). Forward the redaction
+  // there. Response semantics follow the #58 retryability doctrine:
+  //   backend reached + handled (2xx, incl. merchant-unknown no-op) → 200
+  //   endpoint missing (404: backend not deployed yet)              → 200 + loud log
+  //   transient failure (5xx / network)                             → 500 so Shopify redelivers
+  const p = payload as any;
+  const customerId = p?.customer?.id ?? null;
+  const customerEmail = p?.customer?.email ?? null;
+  const orderIds: Array<string | number> = Array.isArray(p?.orders_to_redact)
+    ? p.orders_to_redact
+    : [];
+
+  if (customerId == null && !customerEmail && orderIds.length === 0) {
+    console.warn(
+      `[customers/redact] ${shop}: payload carried no customer id/email/orders — nothing to forward.`,
+    );
+    return new Response("OK", { status: 200 });
+  }
+
+  const result = await redactCustomerInInk({
+    shopDomain: shop,
+    customerId,
+    customerEmail,
+    orderIds,
+  });
+
+  if (result.ok) {
+    console.log(
+      `[customers/redact] ${shop}: ink-backend scrubbed —`,
+      JSON.stringify(result.body?.counts ?? result.body ?? {}),
+    );
+    return new Response("OK", { status: 200 });
+  }
+  if (result.status === 404) {
+    // Endpoint not live yet (backend deploys are local + Sam-gated). Ack the
+    // webhook — retrying against a missing route helps nobody — but log at
+    // ERROR with the non-PII identifiers needed to run the redaction manually.
+    console.error(
+      `[customers/redact] ${shop}: ink-backend endpoint NOT DEPLOYED — run manual redaction for customer_id=${customerId ?? "n/a"} (${orderIds.length} orders).`,
+    );
+    return new Response("OK", { status: 200 });
+  }
+
+  console.error(
+    `[customers/redact] ${shop}: forward failed (status ${result.status}) —`,
+    JSON.stringify(result.body ?? {}),
+  );
+  return new Response("Redaction forward failed — will retry", { status: 500 });
 };

--- a/app/services/ink-api.server.ts
+++ b/app/services/ink-api.server.ts
@@ -562,3 +562,37 @@ export const verifyProofSignature = async (proof: any): Promise<boolean> => {
         return false;
     }
 };
+
+// GDPR: forward a Shopify customers/redact to the ink-backend, which scrubs
+// the buyer's PII from proofs + return docs and deletes their raw tap/click
+// event rows (backend route: POST /admin/redact-customer, admin-secret
+// guarded). Never throws — callers get {ok,status,body} and decide the
+// webhook's retry semantics.
+export const redactCustomerInInk = async (params: {
+  shopDomain: string;
+  customerId?: string | number | null;
+  customerEmail?: string | null;
+  orderIds?: Array<string | number> | null;
+}): Promise<{ ok: boolean; status: number; body: any }> => {
+  const url = getAlanUrl("/admin/redact-customer");
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Admin-Secret": INK_ADMIN_SECRET as string,
+      },
+      body: JSON.stringify({
+        shop_domain: params.shopDomain,
+        customer_id: params.customerId ?? null,
+        customer_email: params.customerEmail ?? null,
+        order_ids: Array.isArray(params.orderIds) ? params.orderIds : [],
+        source: "shopify_customers_redact",
+      }),
+    });
+    const body = await response.json().catch(() => null);
+    return { ok: response.ok, status: response.status, body };
+  } catch (e) {
+    return { ok: false, status: 0, body: { error: String(e) } };
+  }
+};


### PR DESCRIPTION
Closes the Phase-5 TODO in `webhooks.customers.redact.tsx`: forwards the redaction to ink-backend `POST /admin/redact-customer` (built + staged in ink-backend; deploy Sam-gated) keyed on `customer.id` / `customer.email` / `orders_to_redact`.

**Retry semantics (#58 doctrine):** backend 2xx (incl. merchant-unknown no-op) → 200 · endpoint 404 (backend not yet deployed) → 200 + ERROR log with non-PII identifiers for a manual run · 5xx/network → 500 so Shopify redelivers.

**Merge-order safe:** before the backend deploy the forward 404s and the handler acks + logs loudly — no retry storm, nothing breaks. Once Sam's next backend deploy ships the superset, forwarding goes live with zero further embed work.

`react-router build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)