### PR TITLE
GDPR: forward shop/redact to the ink-backend whole-shop purge

### DIFF
--- a/app/routes/webhooks.shop.redact.tsx
+++ b/app/routes/webhooks.shop.redact.tsx
@@ -1,21 +1,50 @@
 import { type ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
+import { purgeShopInInk } from "../services/ink-api.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-  const { topic, shop, payload, webhookId } = await authenticate.webhook(request);
+  const { topic, shop } = await authenticate.webhook(request);
 
   console.log(`Received ${topic} webhook for ${shop}`);
 
-  // SHOP/REDACT: 48 hours after uninstall, or when a store requests deletion.
-  // We should delete the merchant record from Firestore.
+  // SHOP/REDACT: ~48 hours after uninstall, or when a store requests
+  // deletion. Two sides to erase:
+  //   1. this app's own merchant doc (embed Firestore) — below;
+  //   2. the system of record (ink-backend): the shop's proofs, per-proof
+  //      event/return rows, and backend merchant docs — forwarded to
+  //      POST /admin/purge-shop (staged; deploy Sam-gated).
+  // Response semantics per the #58 retryability doctrine: backend 2xx (incl.
+  // merchant-unknown no-op) → 200 · endpoint 404 (backend not deployed yet)
+  // → 200 + loud ERROR log · transient 5xx/network → 500 so Shopify
+  // redelivers (the embed-doc delete below is idempotent on retry).
+  let embedDocDeleted = false;
   try {
-      console.log(`[GDPR] Deleting merchant data for ${shop}`);
-      await firestore.collection("merchants").doc(shop).delete();
+    console.log(`[GDPR] Deleting merchant data for ${shop}`);
+    await firestore.collection("merchants").doc(shop).delete();
+    embedDocDeleted = true;
   } catch (error) {
-      console.error(`[GDPR] Failed to delete merchant data for ${shop}:`, error);
-      // We still return 200 to acknowledge receipt
+    console.error(`[GDPR] Failed to delete embed merchant doc for ${shop}:`, error);
   }
 
-  return new Response("OK", { status: 200 });
+  const result = await purgeShopInInk(shop);
+  if (result.ok) {
+    console.log(
+      `[shop/redact] ${shop}: ink-backend purged —`,
+      JSON.stringify(result.body?.counts ?? result.body ?? {}),
+    );
+    return new Response("OK", { status: 200 });
+  }
+  if (result.status === 404) {
+    console.error(
+      `[shop/redact] ${shop}: ink-backend purge endpoint NOT DEPLOYED — run manual purge (POST /admin/purge-shop, shop_domain=${shop}).`,
+    );
+    return new Response("OK", { status: 200 });
+  }
+
+  console.error(
+    `[shop/redact] ${shop}: backend purge failed (status ${result.status}, embed doc deleted=${embedDocDeleted}) —`,
+    JSON.stringify(result.body ?? {}),
+  );
+  return new Response("Shop purge forward failed — will retry", { status: 500 });
 };

--- a/app/services/ink-api.server.ts
+++ b/app/services/ink-api.server.ts
@@ -596,3 +596,31 @@ export const redactCustomerInInk = async (params: {
     return { ok: false, status: 0, body: { error: String(e) } };
   }
 };
+
+// GDPR: forward a Shopify shop/redact to the ink-backend whole-shop purge
+// (POST /admin/purge-shop) — deletes the shop's proofs, per-proof event/
+// return rows, enroll locks, and backend merchant docs. `confirm` echoes the
+// shop domain (the endpoint's fat-finger guard). Never throws.
+export const purgeShopInInk = async (
+  shopDomain: string,
+): Promise<{ ok: boolean; status: number; body: any }> => {
+  const url = getAlanUrl("/admin/purge-shop");
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Admin-Secret": INK_ADMIN_SECRET as string,
+      },
+      body: JSON.stringify({
+        shop_domain: shopDomain,
+        confirm: shopDomain,
+        source: "shopify_shop_redact",
+      }),
+    });
+    const body = await response.json().catch(() => null);
+    return { ok: response.ok, status: response.status, body };
+  } catch (e) {
+    return { ok: false, status: 0, body: { error: String(e) } };
+  }
+};


### PR DESCRIPTION
Completes the GDPR webhook pair (sibling of #60): `shop/redact` now erases BOTH sides — the embed merchant doc (as before) AND, via forward to ink-backend `POST /admin/purge-shop` (#31, staged, Sam-gated deploy), the system of record: the shop's proofs, per-proof return/tap/click/custody rows, enroll locks, and backend merchant docs.

**Retry semantics (#58 doctrine):** backend 2xx (incl. merchant-unknown no-op) → 200 · endpoint 404 (backend not deployed yet) → 200 + ERROR log with the manual command · transient → 500 so Shopify redelivers (embed-doc delete idempotent on retry). **Merge-order safe** — activates automatically when Sam's backend deploy ships the superset.

`react-router build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)