### PR TITLE
Harden delivery mode for App Store review

### DIFF
--- a/app/components/settings/DeliveryModeSettings.tsx
+++ b/app/components/settings/DeliveryModeSettings.tsx
@@ -3,19 +3,14 @@ import {
   Layout,
   Card,
   BlockStack,
-  RadioButton,
   Text,
   Banner,
   Spinner,
 } from "@shopify/polaris";
 import { toast } from "../../hooks/use-toast";
 
-type DeliveryMode = "addon" | "background";
-
 const DeliveryModeSettings = () => {
-  const [mode, setMode] = useState<DeliveryMode>("addon");
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
 
   // App-Bridge-aware fetch (mirrors the pattern used in BrandingSettings).
   const fetchSecure = async (path: string, options: RequestInit = {}) => {
@@ -54,10 +49,7 @@ const DeliveryModeSettings = () => {
   useEffect(() => {
     const load = async () => {
       try {
-        const data = await fetchSecure("/app/api/settings/delivery-mode");
-        if (data?.mode === "addon" || data?.mode === "background") {
-          setMode(data.mode);
-        }
+        await fetchSecure("/app/api/settings/delivery-mode");
       } catch (err: any) {
         console.error("Failed to load delivery mode:", err);
         toast({
@@ -72,36 +64,6 @@ const DeliveryModeSettings = () => {
     };
     load();
   }, []);
-
-  const handleChange = async (next: DeliveryMode) => {
-    if (next === mode || saving) return;
-
-    const previous = mode;
-    setMode(next); // optimistic
-    setSaving(true);
-
-    try {
-      await fetchSecure("/app/api/settings/delivery-mode", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ mode: next }),
-      });
-      toast({
-        description: `Delivery mode set to ${next === "addon" ? "Optional add-on" : "Automatic (background)"}`,
-        duration: 2000,
-      });
-    } catch (err: any) {
-      setMode(previous); // revert
-      toast({
-        title: "Couldn't save delivery mode",
-        description: err.message,
-        variant: "destructive",
-        duration: 3000,
-      });
-    } finally {
-      setSaving(false);
-    }
-  };
 
   if (loading) {
     return (
@@ -124,39 +86,22 @@ const DeliveryModeSettings = () => {
     <Layout>
       <Layout.AnnotatedSection
         title="Delivery mode"
-        description="Choose how ink. appears in the buyer delivery flow."
+        description="ink. works behind your existing Shopify delivery methods."
       >
         <Card>
           <BlockStack gap="400">
-            <RadioButton
-              label="Optional add-on"
-              helpText="Customers see an ink. delivery option alongside their other shipping methods. They choose whether to opt in."
-              checked={mode === "addon"}
-              id="delivery-mode-addon"
-              name="delivery-mode"
-              onChange={() => handleChange("addon")}
-              disabled={saving}
-            />
-            <RadioButton
-              label="Automatic (background)"
-              helpText="Customers see only your standard shipping methods. ink. is applied to eligible orders in the background."
-              checked={mode === "background"}
-              id="delivery-mode-background"
-              name="delivery-mode"
-              onChange={() => handleChange("background")}
-              disabled={saving}
-            />
-
-            {mode === "background" && (
-              <Banner tone="info">
-                <Text as="p" variant="bodySm">
-                  Background mode hides ink. from your checkout the next time
-                  Shopify polls our carrier service (usually within a few
-                  minutes). Existing in-flight checkouts may still show the
-                  option until then.
-                </Text>
-              </Banner>
-            )}
+            <Text as="p" variant="bodyMd">
+              Automatic background mode is active. Buyers see only your standard
+              Shopify shipping methods, and ink. creates order pages for
+              eligible orders after purchase.
+            </Text>
+            <Banner tone="info">
+              <Text as="p" variant="bodySm">
+                INK does not add a customer-paid checkout delivery option. Any
+                legacy carrier-service callback returns no rates while the app
+                runs in background mode.
+              </Text>
+            </Banner>
           </BlockStack>
         </Card>
       </Layout.AnnotatedSection>

--- a/app/routes/api.shipping-rates.ts
+++ b/app/routes/api.shipping-rates.ts
@@ -1,8 +1,12 @@
 /**
  * Shipping Rates Callback Endpoint
  * 
- * Shopify POSTs to this URL at checkout to get available shipping rates.
- * This is called by the Carrier Service API — NOT through Shopify auth.
+ * Legacy Carrier Service callback.
+ *
+ * App Store review posture: INK does not expose a customer-paid checkout
+ * delivery add-on. Keep the endpoint healthy for any stale Shopify callback,
+ * but return no rates so Shopify falls back to the merchant's own shipping
+ * methods.
  * 
  * Shopify sends: { rate: { origin, destination, items, currency, locale } }
  * We respond with: { rates: [...] }
@@ -26,43 +30,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       });
     }
 
-    const currency = rate.currency || "USD";
-
-    // Calculate delivery dates (2-day for premium, 5-7 for standard)
-    const now = new Date();
-    const premiumMin = new Date(now);
-    premiumMin.setDate(premiumMin.getDate() + 1);
-    const premiumMax = new Date(now);
-    premiumMax.setDate(premiumMax.getDate() + 2);
-    const standardMin = new Date(now);
-    standardMin.setDate(standardMin.getDate() + 5);
-    const standardMax = new Date(now);
-    standardMax.setDate(standardMax.getDate() + 7);
-
-    const formatDate = (d: Date) => d.toISOString().split("T")[0];
-
-    const rates = [
-      {
-        service_name: "ink. Verified Delivery",
-        service_code: "INK_VERIFIED",
-        total_price: "1000", // $10.00 in cents
-        description: "2-day delivery with verification, Priority handling and Delivery confirmation",
-        currency,
-        min_delivery_date: formatDate(premiumMin),
-        max_delivery_date: formatDate(premiumMax),
-      },
-      {
-        service_name: "Standard Free Delivery",
-        service_code: "STANDARD_FREE",
-        total_price: "0", // Free
-        description: "5-7 business days",
-        currency,
-        min_delivery_date: formatDate(standardMin),
-        max_delivery_date: formatDate(standardMax),
-      },
-    ];
-
-    console.log(`[ShippingRates] Returning ${rates.length} rates for ${rate.destination?.city || "unknown"}, ${rate.destination?.province || ""}`);
+    const rates: any[] = [];
+    console.log(`[ShippingRates] Background mode: returning no INK rates for ${rate.destination?.city || "unknown"}, ${rate.destination?.province || ""}`);
 
     return new Response(JSON.stringify({ rates }), {
       status: 200,

--- a/app/routes/app.api.settings.delivery-mode.tsx
+++ b/app/routes/app.api.settings.delivery-mode.tsx
@@ -1,16 +1,14 @@
 /**
  * Verified Delivery Mode — merchant preference endpoint.
  *
- * GET   → returns { mode: "addon" | "background" }
- * PATCH → accepts { mode } and persists to merchants/{shopDomain}.verified_delivery_mode
+ * GET   → returns { mode: "background" }
+ * PATCH → accepts { mode: "background" } and persists to
+ * merchants/{shopDomain}.verified_delivery_mode
  *
  * Mode meaning:
- *   - "addon"      (default): INK shows as a customer-facing checkout option,
- *                  the customer chooses + pays. Current behavior.
  *   - "background":            INK is hidden from checkout. Every order on
  *                  this shop is silently tagged for INK enrollment regardless
- *                  of which shipping method the customer picked. Merchant
- *                  absorbs the cost.
+ *                  of which shipping method the customer picked.
  *
  * Reads/writes are gated by `authenticate.admin(request)` from Shopify.
  */
@@ -19,7 +17,7 @@ import firestore from "../firestore.server";
 import { authenticate } from "../shopify.server";
 import { setCarrierServiceActive } from "../services/carrier-service.server";
 
-const VALID_MODES = ["addon", "background"] as const;
+const VALID_MODES = ["background"] as const;
 type DeliveryMode = (typeof VALID_MODES)[number];
 
 const corsHeaders = {
@@ -57,7 +55,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
   try {
     const doc = await getMerchantDoc(shopDomain);
-    const mode: DeliveryMode = doc?.data()?.verified_delivery_mode || "addon";
+    const mode: DeliveryMode = "background";
     return json({ mode });
   } catch (err: any) {
     console.error("[settings/delivery-mode] GET error:", err.message);
@@ -104,17 +102,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       updatedAt: new Date(),
     });
 
-    // Propagate to Shopify: when mode is "addon", Shopify should call our
-    // shipping-rates callback at checkout (active=true). When "background",
-    // we want Shopify to stop calling it so the customer no longer sees INK
-    // among their shipping options (active=false). Failure to propagate is
-    // logged but doesn't fail the save — the mode persists in Firestore and
-    // can be re-synced on next app load.
-    const carrierActive = mode === "addon";
-    await setCarrierServiceActive(admin, carrierActive);
+    // Propagate to Shopify: INK should not appear as a customer-paid checkout
+    // carrier option during App Store review. Failure is logged by the helper
+    // but doesn't fail the save.
+    await setCarrierServiceActive(admin, false);
 
     console.log(
-      `[settings/delivery-mode] ${shopDomain} → mode=${mode}, carrier active=${carrierActive}`
+      `[settings/delivery-mode] ${shopDomain} → mode=${mode}, carrier active=false`
     );
 
     return json({ mode });

--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -5,8 +5,8 @@ import { enrollOrder, createMerchant } from "../services/ink-api.server";
 
 /**
  * Look up the merchant's verified-delivery mode preference.
- * Defaults to "addon" (current behavior — only INK-shipped orders are tagged)
- * if no preference is stored yet.
+ * Defaults to "background" so a missing preference never implies a
+ * customer-paid checkout add-on.
  */
 async function getMerchantDeliveryMode(
   shopDomain: string
@@ -23,14 +23,14 @@ async function getMerchantDeliveryMode(
       if (direct.exists) docData = direct.data() ?? null;
     }
     const mode = docData?.verified_delivery_mode;
-    if (mode === "addon" || mode === "background") return mode;
-    return "addon";
+    if (mode === "background") return mode;
+    return "background";
   } catch (e) {
     console.warn(
-      `[orders/create] Failed to read delivery mode for ${shopDomain}, defaulting to addon:`,
+      `[orders/create] Failed to read delivery mode for ${shopDomain}, defaulting to background:`,
       e
     );
-    return "addon";
+    return "background";
   }
 }
 

--- a/app/services/carrier-service.server.ts
+++ b/app/services/carrier-service.server.ts
@@ -4,10 +4,9 @@
  * Registers the app as a Carrier Service so Shopify calls our
  * /api/shipping-rates endpoint at checkout to provide shipping options.
  *
- * The carrier service can be toggled active/inactive per-shop via
- * `setCarrierServiceActive`. When a merchant switches to "background"
- * delivery mode, we set active=false so Shopify stops calling our
- * callback and the customer no longer sees INK at checkout.
+ * App Store review posture: INK runs in background mode. The carrier service
+ * remains registered only so legacy installs can be deactivated; it must not
+ * expose a customer-paid checkout option.
  */
 
 const CARRIER_SERVICE_NAME = "ink. Verified Delivery";
@@ -131,10 +130,11 @@ export async function ensureCarrierServiceRegistered(admin: any, appUrl: string)
     );
 
     if (existingInk) {
-      // Already registered — check if callback URL needs updating
+      // Already registered — check if callback URL needs updating and force
+      // inactive so no customer-paid INK delivery option appears at checkout.
       const currentCallbackUrl = `${appUrl}/api/shipping-rates`;
-      if (existingInk.node.callbackUrl !== currentCallbackUrl) {
-        console.log(`[CarrierService] Updating callback URL to ${currentCallbackUrl}`);
+      if (existingInk.node.callbackUrl !== currentCallbackUrl || existingInk.node.active) {
+        console.log(`[CarrierService] Updating callback URL to ${currentCallbackUrl} and deactivating`);
         await admin.graphql(`
           mutation carrierServiceUpdate($input: DeliveryCarrierServiceUpdateInput!) {
             carrierServiceUpdate(input: $input) {
@@ -142,6 +142,7 @@ export async function ensureCarrierServiceRegistered(admin: any, appUrl: string)
                 id
                 name
                 callbackUrl
+                active
               }
               userErrors {
                 field
@@ -154,6 +155,7 @@ export async function ensureCarrierServiceRegistered(admin: any, appUrl: string)
             input: {
               id: existingInk.node.id,
               callbackUrl: currentCallbackUrl,
+              active: false,
             }
           }
         });
@@ -187,7 +189,7 @@ export async function ensureCarrierServiceRegistered(admin: any, appUrl: string)
           name: CARRIER_SERVICE_NAME,
           callbackUrl,
           supportsServiceDiscovery: true,
-          active: true,
+          active: false,
         }
       }
     });


### PR DESCRIPTION
## Summary
- force INK delivery mode to background-only for App Store review
- deactivate any legacy carrier service registration and keep new registrations inactive
- make the legacy shipping-rates callback return no checkout rates

## Why
Shopify review asked us to make sure the app meets all requirements. The existing optional checkout delivery add-on could be read as a customer-paid checkout charge surface. This PR removes that surface from the embedded app and keeps stale carrier callbacks healthy without adding rates.

## Verification
- npm run build
- git diff --check for the changed files

No app config or scope changes.