### PR TITLE
Gate debug route during App Store review

### DIFF
--- a/app/routes/app.debug.tsx
+++ b/app/routes/app.debug.tsx
@@ -1,8 +1,7 @@
 import { type LoaderFunctionArgs, type ActionFunctionArgs } from "react-router";
 import { useLoaderData, useFetcher } from "react-router";
-import { redirect } from "react-router";
 import { authenticate } from "../shopify.server";
-import { ENABLE_DEV_ROUTES } from "../flags.server";
+import { assertDevRoutesEnabled } from "../flags.server";
 import { 
   Card, 
   Page, 
@@ -15,7 +14,7 @@ import {
 import { ensureCarrierServiceRegistered } from "../services/carrier-service.server";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-  if (!ENABLE_DEV_ROUTES) return redirect("/app/dashboard");
+  assertDevRoutesEnabled();
   const { admin } = await authenticate.admin(request);
   
   try {
@@ -52,6 +51,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 };
 
 export const action = async ({ request }: ActionFunctionArgs) => {
+  assertDevRoutesEnabled();
   const { admin } = await authenticate.admin(request);
   const appUrl = process.env.SHOPIFY_APP_URL;
 

--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -10,7 +10,7 @@ import { enrollOrder, createMerchant } from "../services/ink-api.server";
  */
 async function getMerchantDeliveryMode(
   shopDomain: string
-): Promise<"addon" | "background"> {
+): Promise<"background"> {
   try {
     const snapshot = await firestore
       .collection("merchants")
@@ -175,18 +175,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   const hasPremiumDelivery = hasInkPremiumShipping(shippingLines);
 
-  // Mode-aware enrollment decision:
-  //   • addon mode: only enroll if the customer chose the INK shipping option
-  //   • background mode: enroll every order on this shop regardless of
-  //     shipping (INK is hidden from checkout in this mode anyway).
+  // Background enrollment: INK is hidden from checkout and never appears as a
+  // customer-paid shipping option, so every order on this shop is eligible.
   const deliveryMode = await getMerchantDeliveryMode(shop);
   const shouldEnroll = hasPremiumDelivery || deliveryMode === "background";
 
   if (!shouldEnroll) {
-    console.log(
-      `📦 [orders/create] Order ${orderName} skipped — addon mode, no INK shipping selected`
-    );
-    return new Response("ok - addon mode, not INK");
+    console.log(`[orders/create] Order ${orderName} skipped — not eligible`);
+    return new Response("ok - not eligible");
   }
 
   if (deliveryMode === "background") {


### PR DESCRIPTION
## Summary
- return 404 for `/app/debug` loader/action unless dev routes are explicitly enabled
- remove obsolete addon-mode wording from the orders/create webhook comments/logs

## Why
App Review can direct-probe non-navigation routes. The debug route exposed carrier-service internals and had an action path that could re-run registration. This keeps ops tooling unavailable in production review while leaving normal app behavior unchanged.

## Verification
- npm run build
- git diff --check for changed files

No app config or scope changes.