### PR TITLE
[FROZEN — DO NOT MERGE IN REVIEW] M3 redemption capture on orders/create

### DIFF
--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -1,7 +1,7 @@
 import type { ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
-import { enrollOrder, createMerchant } from "../services/ink-api.server";
+import { enrollOrder, createMerchant, reportCampaignRedemption } from "../services/ink-api.server";
 
 /**
  * Look up the merchant's verified-delivery mode preference.
@@ -160,6 +160,35 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   console.log(`\n📦 [orders/create] Processing order ${orderName} (${shop})`);
+
+  // ─── M3 redemption capture (RUNBOOK_CAMPAIGNS §6.3) ──────────────────
+  // Position is load-bearing: AFTER the no-admin/malformed-payload skips,
+  // BEFORE the addon-mode eligibility return below — a buyer who saw a
+  // campaign code on a previous order's page can redeem it on an order
+  // WITHOUT ink shipping, and counting only inside the enroll block would
+  // make the denominator lie. Independent of the proof_reference
+  // idempotency skip for the same reason (the backend doc-set is the
+  // idempotency for redemptions). Fire-and-forget: never fails the webhook.
+  const discountCodes = Array.isArray(data?.discount_codes) ? data.discount_codes : [];
+  if (discountCodes.length > 0) {
+    try {
+      const redemptionApiKey = await getMerchantApiKey(shop);
+      if (redemptionApiKey) {
+        await reportCampaignRedemption(redemptionApiKey, {
+          order_id: data?.id ?? orderGid,
+          order_number: String(orderName),
+          discount_codes: discountCodes,
+          order_total: data?.total_price,
+          currency: data?.currency,
+          order_created_at: data?.created_at,
+        });
+      } else {
+        console.log(`[redemptions] no ink_api_key for ${shop} — codes on ${orderName} not reported`);
+      }
+    } catch (error) {
+      console.warn(`[redemptions] capture failed for ${orderName} — ignored:`, error);
+    }
+  }
 
   // Phone selection (ship → order → customer fallback chain)
   const shippingPhone = data?.shipping_address?.phone;

--- a/app/services/ink-api.server.ts
+++ b/app/services/ink-api.server.ts
@@ -624,3 +624,42 @@ export const purgeShopInInk = async (
     return { ok: false, status: 0, body: { error: String(e) } };
   }
 };
+
+// ─── M3 redemptions (RUNBOOK_CAMPAIGNS §6.3) ────────────────────────────
+// A campaign's code coming back inside orders/create is the first dollar-
+// number in the funnel. This reporter is deliberately dumb: it forwards the
+// order's discount codes to the backend and lets ATTRIBUTION live there
+// (exact-match against book.campaigns, one doc per order, idempotent set) —
+// the embed never decides which campaign earned it. Fire-and-forget: a
+// failure logs and the webhook proceeds; counting revenue must NEVER break
+// the enroll heart.
+export const reportCampaignRedemption = async (
+  apiKey: string,
+  redemption: {
+    order_id: string | number;
+    order_number?: string;
+    /** Raw REST-payload discount codes, shape-preserved: [{code, amount, type}]. */
+    discount_codes: Array<{ code?: string; amount?: string; type?: string }>;
+    order_total?: string;
+    currency?: string;
+    order_created_at?: string;
+  },
+): Promise<void> => {
+  try {
+    const res = await fetch(getAlanUrl("/api/redemptions"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(redemption),
+    });
+    if (!res.ok) {
+      console.warn(`[redemptions] backend said ${res.status} for order ${redemption.order_id} — ignored`);
+    } else {
+      console.log(`[redemptions] reported order ${redemption.order_id} (${redemption.discount_codes.length} code(s))`);
+    }
+  } catch (error) {
+    console.warn(`[redemptions] report failed for order ${redemption.order_id} — ignored:`, error);
+  }
+};


### PR DESCRIPTION
**⚠️ App Store review freeze: this repo auto-deploys on merge — merging this is a prod deploy. It stays a DRAFT until the review closes** (unfreeze order: RUNBOOK_CAMPAIGNS §3.5 / parallelreturns runbook).

The embed half of M3 (RUNBOOK_CAMPAIGNS §6.3): orders carrying `discount_codes` report them to `POST /api/redemptions` (new `reportCampaignRedemption` in ink-api.server) under the merchant's ink api_key. Placement per spec: after the no-admin/malformed skips, **before** the addon-mode eligibility return (buyers can redeem on orders without ink shipping), independent of the proof_reference idempotency skip. Fire-and-forget — a backend failure logs and the webhook proceeds; the enroll heart is untouchable.

Pairs with the backend attribution route (ink-backend branch `claude/campaign-redemptions`) — the backend does ALL attribution (exact-match, one doc per order, idempotent set); this reporter never decides.

Gates: `react-router build` green. `tsc --noEmit` carries only the 7 pre-existing `verifyProxyToken` errors (§17.5 debt, untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)