### PR TITLE
The app name is "The Ritualist"

### DIFF
--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -1,16 +1,26 @@
 # Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "8da1addef3dcd4251db5057cda3c85fa"
-# The MARK, which is lowercase and carries the article: `the ritualist`.
-# Settled by Sam 2026-08-01; `ritualist` (no article) and
-# `ritualist - order page media` are both bad memory from the handoff pack.
-# Prose is cased differently on purpose — parallelreturns #644: "The Ritualist"
-# sentence-initial, "the Ritualist" mid-sentence. A listing whose name field
-# reads `the ritualist` while its Details paragraph opens "The Ritualist
-# turns each…" is CORRECT.
+# THE APP NAME, as Sam settled it 2026-08-02: "The Ritualist", capitalised.
+# He has now asserted this casing three times across two sessions and been
+# right each time; the lowercase `the ritualist` that briefly lived here came
+# off MY framing, not his. `ritualist` (no article) and `ritualist - order page
+# media` are both bad memory from the 08-01 handoff pack.
+#
+# THIS MUST MATCH THE PARTNER DASHBOARD. The Dashboard name is edited by hand;
+# this file overwrites it on the next `shopify app deploy`. Leaving them
+# different means a deploy silently reverts the Dashboard, which is how a name
+# change gets undone weeks later by someone shipping an unrelated config.
+#
+# The wordmark is a separate asset and stays lowercase with its period —
+# `the ritualist.` — per parallelreturns #644. Prose follows #644 too:
+# "The Ritualist" sentence-initial, "the Ritualist" mid-sentence, bare
+# "Ritualist" adjectival. A name field reading "The Ritualist" beside a
+# lowercase wordmark is CORRECT, not drift.
+#
 # Inert until the next gated `shopify app deploy`; never regenerate this
 # app's credentials.
-name = "the ritualist"
+name = "The Ritualist"
 # app.in.ink = the Worker front door (parallelreturns #359, VERIFIED live +
 # byte-identical to Cloud Run 2026-07-05). The App Store checker rejects app
 # URLs whose DOMAIN contains "shopify" — shopify-app-…run.app does. Goes live


### PR DESCRIPTION
Sam settled the casing directly: **"make my name The Ritualist"**.

The lowercase `the ritualist` briefly in this file came off my framing — I read the 08-01 handoff pack (wrong on naming twice over) instead of parallelreturns #644, then offered a lowercase option he picked off that bad framing.

**Why the file and not just the Dashboard:** the Partner Dashboard name is edited by hand, and `shopify.app.toml` overwrites it on the next `shopify app deploy`. Leaving them different is how a rename gets silently reverted weeks later by an unrelated config ship.

The **wordmark** stays lowercase with its period — `the ritualist.` — per #644, as does the prose rule ("The Ritualist" sentence-initial, "the Ritualist" mid-sentence, bare "Ritualist" adjectival). A name field reading "The Ritualist" beside a lowercase wordmark is correct, not drift.

Name only — `access_scopes`, `client_id`, `redirect_urls`, `application_url` byte-identical. Inert until a gated `shopify app deploy`.