### PR TITLE
Expiring offline access tokens

### DIFF
--- a/app/shopify.server.ts
+++ b/app/shopify.server.ts
@@ -59,6 +59,24 @@ const shopify = shopifyApp({
   ...(process.env.SHOP_CUSTOM_DOMAIN
     ? { customShopDomains: [process.env.SHOP_CUSTOM_DOMAIN] }
     : {}),
+
+  // EXPIRING OFFLINE ACCESS TOKENS. Shopify requires these of every public app
+  // from 2027-01-01; after that date a non-expiring token gets authentication
+  // errors instead of data. The app's API health report flagged us with "Calls
+  // made with deprecated offline tokens detected in the last 14 days".
+  //
+  // The point is blast radius: a non-expiring token that leaks is valid
+  // forever, an expiring one for sixty minutes, and it rotates itself. This
+  // codebase has already leaked one token into a transcript, so that is not a
+  // hypothetical.
+  //
+  // Merchants do NOT reinstall — the library exchanges existing tokens in
+  // place and refreshes them before expiry. FirestoreSessionStorage already
+  // persists and rehydrates `expires` as a Date (it was written for the
+  // framework's refresh path), so the storage half needed no change.
+  future: {
+    expiringOfflineAccessTokens: true,
+  },
 });
 
 export default shopify;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@shopify/app-bridge-react": "^4.2.7",
         "@shopify/app-bridge-utils": "^3.5.1",
         "@shopify/polaris": "^13.9.5",
-        "@shopify/shopify-app-react-router": "^1.0.2",
+        "@shopify/shopify-app-react-router": "^1.2.1",
         "@tanstack/react-query": "^5.90.21",
         "@types/bcryptjs": "^2.4.6",
         "bcryptjs": "^3.0.3",
@@ -5636,12 +5636,12 @@
       }
     },
     "node_modules/@shopify/admin-api-client": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@shopify/admin-api-client/-/admin-api-client-1.1.1.tgz",
-      "integrity": "sha512-J/cdodM7jmk9yKxHnkrnVHP2Gm70w2dFA4O3ehPvIBsXvK0PwXmiRjQOCCPfyLo442awON5soQ/XuWVSUmZL/g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@shopify/admin-api-client/-/admin-api-client-1.1.2.tgz",
+      "integrity": "sha512-sV5gS8x4kj0KLULlOJkoBzm+tu6tn+1PCK9a6inySv5qtzmf/JxDWtLgaW9vRXeXHo/Sl/p3mBWhY3//fKA8iw==",
       "license": "MIT",
       "dependencies": {
-        "@shopify/graphql-client": "^1.4.1"
+        "@shopify/graphql-client": "^1.4.2"
       }
     },
     "node_modules/@shopify/api-codegen-preset": {
@@ -5709,9 +5709,9 @@
       }
     },
     "node_modules/@shopify/graphql-client": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@shopify/graphql-client/-/graphql-client-1.4.1.tgz",
-      "integrity": "sha512-/w4Uchx8ueI8gwmJd1ZbbIGndsjfMEFlzmay3P7rya5zj7K308xne/ggIvWDweueIut2qf1A8lI58xQl9Pu22w==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@shopify/graphql-client/-/graphql-client-1.4.2.tgz",
+      "integrity": "sha512-C/fEyx6BZmTGeJv0HSsduhfn5ZbkXk0nePkyo0+xXxorP1I+uvx9pobdFxTfiPnOrh+P6QiKzBgIviksnSo4YA==",
       "license": "MIT"
     },
     "node_modules/@shopify/graphql-codegen": {
@@ -5786,18 +5786,18 @@
       "dev": true
     },
     "node_modules/@shopify/shopify-api": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@shopify/shopify-api/-/shopify-api-12.1.1.tgz",
-      "integrity": "sha512-YDx+3cqKZYveBVqkls80yZ8eL0MVj2+nlHK3b59Z931GsuMrPEg1dLwuoAKZiDdByYGxEnoR7GZfb+KIn63P/A==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@shopify/shopify-api/-/shopify-api-13.1.0.tgz",
+      "integrity": "sha512-TwYL9kPxOgQwwlc9tmnAmSDs79Gdg9QLaIMCfkaCJxkhWxIHVkPWa74GvbBwnmTtB8jkg61Ja4/Qxrk9bCBUiA==",
       "license": "MIT",
       "dependencies": {
-        "@shopify/admin-api-client": "^1.1.1",
-        "@shopify/graphql-client": "^1.4.1",
-        "@shopify/storefront-api-client": "^1.0.9",
+        "@shopify/admin-api-client": "^1.1.2",
+        "@shopify/graphql-client": "^1.4.2",
+        "@shopify/storefront-api-client": "^1.0.10",
         "compare-versions": "^6.1.1",
-        "isbot": "^5.1.26",
+        "isbot": "^5.1.40",
         "jose": "^5.9.6",
-        "lossless-json": "^4.2.0",
+        "lossless-json": "^4.3.0",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -5805,17 +5805,17 @@
       }
     },
     "node_modules/@shopify/shopify-app-react-router": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@shopify/shopify-app-react-router/-/shopify-app-react-router-1.0.2.tgz",
-      "integrity": "sha512-bAwFkHNqYWlrDGY1km4CxS1q3xSO8O3a4oxuSPzIEXBcEK1YEjQOxBrby1MmliiDDOUpFOIxRKQkJ/3Byhn5+g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@shopify/shopify-app-react-router/-/shopify-app-react-router-1.2.1.tgz",
+      "integrity": "sha512-37FtkGoHkvXFUsBU/ibhTrlAGoogfq0VodyEckkggi35lrjZfOGX7xKzMWW13QyD6q8bGg/wCBNOW4WANvewEA==",
       "license": "MIT",
       "dependencies": {
-        "@shopify/admin-api-client": "^1.1.1",
-        "@shopify/shopify-api": "^12.1.1",
-        "@shopify/shopify-app-session-storage": "^4.0.2",
-        "@shopify/storefront-api-client": "^1.0.9",
+        "@shopify/admin-api-client": "^1.1.2",
+        "@shopify/shopify-api": "^13.1.0",
+        "@shopify/shopify-app-session-storage": "^5.0.1",
+        "@shopify/storefront-api-client": "^1.0.10",
         "compare-versions": "^6.1.1",
-        "isbot": "^5.1.26"
+        "isbot": "^5.1.40"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5827,21 +5827,21 @@
       }
     },
     "node_modules/@shopify/shopify-app-session-storage": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shopify/shopify-app-session-storage/-/shopify-app-session-storage-4.0.2.tgz",
-      "integrity": "sha512-ii6X6DDMhcClouZHgX9F10sWi62pqm46MSZ/L9SAzWwQI1TUGkHHohc8o0Pi370aEmtYmbPG3nUhK12BdRFguw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@shopify/shopify-app-session-storage/-/shopify-app-session-storage-5.0.1.tgz",
+      "integrity": "sha512-VL66qkz2w1x5hH14v+swFZAnN36VrFuVi/Lc6FkLTJxCSvSu4fPNYn04kjIxGykgsRb7trLBXC7mF3j8yDUFeA==",
       "license": "MIT",
       "peerDependencies": {
-        "@shopify/shopify-api": "^12.0.0"
+        "@shopify/shopify-api": "^13.0.0"
       }
     },
     "node_modules/@shopify/storefront-api-client": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@shopify/storefront-api-client/-/storefront-api-client-1.0.9.tgz",
-      "integrity": "sha512-vgc0ZczMvrbsQQFYcIIONnIiqiafpcMyq5osI8X6PB65DhnmCQEp3kSlXKOjBPzyAWYvp28nLHS0+r4xsp4yQA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@shopify/storefront-api-client/-/storefront-api-client-1.0.10.tgz",
+      "integrity": "sha512-A0ItFW58L5+y/jnnJDEsmt2YcQSt2BG+pNoQOYRpPBJaOLpTj7A13q1QVrE5XYVGZCA6ZQ6FqAtgosHHrkut0Q==",
       "license": "MIT",
       "dependencies": {
-        "@shopify/graphql-client": "^1.4.1"
+        "@shopify/graphql-client": "^1.4.2"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -11315,9 +11315,9 @@
       "license": "MIT"
     },
     "node_modules/isbot": {
-      "version": "5.1.32",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.32.tgz",
-      "integrity": "sha512-VNfjM73zz2IBZmdShMfAUg10prm6t7HFUQmNAEOAVS4YH92ZrZcvkMcGX6cIgBJAzWDzPent/EeAtYEHNPNPBQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.2.1.tgz",
+      "integrity": "sha512-dJ+LpKyClQZ7NG+j3OensC/mAZkGpukE9YUrgPYvAZj2doVL0edfDgywTUh5CXa0o+nW9a1V9e5+CJTX8+SxRw==",
       "license": "Unlicense",
       "engines": {
         "node": ">=18"
@@ -11867,9 +11867,9 @@
       }
     },
     "node_modules/lossless-json": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.3.0.tgz",
-      "integrity": "sha512-ToxOC+SsduRmdSuoLZLYAr5zy1Qu7l5XhmPWM3zefCZ5IcrzW/h108qbJUKfOlDlhvhjUK84+8PSVX0kxnit0g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.3.1.tgz",
+      "integrity": "sha512-SqD/Bg3ZfltBJ2Z14hJ/BihnvtV553WO4g9/ePtlp4lrnl9jF3AdIJt53A/Wkg/0Li+LMfxaBqgx1MiFZdQlpQ==",
       "license": "MIT"
     },
     "node_modules/lower-case": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@shopify/app-bridge-react": "^4.2.7",
     "@shopify/app-bridge-utils": "^3.5.1",
     "@shopify/polaris": "^13.9.5",
-    "@shopify/shopify-app-react-router": "^1.0.2",
+    "@shopify/shopify-app-react-router": "^1.2.1",
     "@tanstack/react-query": "^5.90.21",
     "@types/bcryptjs": "^2.4.6",
     "bcryptjs": "^3.0.3",


### PR DESCRIPTION
API health flagged us: **"Calls made with deprecated offline tokens detected in the last 14 days · Fix by Jan 1"**. Shopify requires expiring offline access tokens of every public app from **2027-01-01**; after that, non-expiring tokens receive authentication errors instead of data.

The reason is blast radius. A non-expiring token that leaks is valid forever; an expiring one dies in sixty minutes and rotates itself. This codebase has already leaked a token into a transcript once, so that is not hypothetical.

```
@shopify/shopify-app-react-router  1.0.2 -> 1.2.1
@shopify/shopify-api               12.x  -> 13.1.0
future.expiringOfflineAccessTokens = true
```

**Merchants do not reinstall.** The library exchanges existing tokens in place and refreshes them before expiry. `FirestoreSessionStorage` already persisted and rehydrated `expires` as a `Date` — it was written for the framework refresh path — which is why a major bump of the auth library lands as a single flag.

`tsc` 0 errors · react-router production build green.

⚠️ **This is the auth path on a live app with 3 installs.** Merging auto-deploys. A green build does not prove a token exchange — the check that matters is opening the embedded app on a real store the moment the Cloud Run revision flips.