### PR TITLE
Money that looks like money, and columns that don't collide

### DIFF
--- a/app/components/RecentActivity.tsx
+++ b/app/components/RecentActivity.tsx
@@ -88,7 +88,13 @@ const RecentActivity = () => {
             </div>
 
             {/* Desktop Layout */}
-            <div className="hidden sm:flex items-center justify-between">
+            {/* gap-4 on the ROW, not just inside each group. `flex-1` on the
+                left group makes it grow to fill, which defeats
+                justify-between — so with a wide amount the date and the money
+                collided into "Jul 6, 1:06 AMUSD 5010.0". Seen on the live
+                dashboard 2026-08-02; it only shows once an order is big
+                enough, which is why it survived. */}
+            <div className="hidden sm:flex items-center justify-between gap-4">
               {/* Order & Customer Info */}
               <div className="flex items-center gap-6 flex-1 min-w-0">
                 <span className="font-semibold text-foreground whitespace-nowrap">

--- a/app/routes/app.api.dashboard.recent-activity.tsx
+++ b/app/routes/app.api.dashboard.recent-activity.tsx
@@ -7,6 +7,26 @@ const json = (data: any, init?: ResponseInit) =>
     ...init,
   });
 
+/** Shopify money → something a merchant recognises as money.
+ *
+ *  `shopMoney.amount` arrives as a raw decimal STRING ("5010.0", "175.0"), so
+ *  interpolating it produced "USD 5010.0" on the dashboard's first screen.
+ *  Falls back to the plain concatenation if the currency code is one Intl
+ *  doesn't know — a wrong-looking price beats a thrown loader. */
+export function formatMoney(amount: string | number, currencyCode: string): string {
+  const value = typeof amount === "number" ? amount : Number.parseFloat(amount);
+  if (!Number.isFinite(value)) return `${currencyCode} ${amount}`;
+  try {
+    return new Intl.NumberFormat("en", {
+      style: "currency",
+      currency: currencyCode,
+      currencyDisplay: "narrowSymbol",
+    }).format(value);
+  } catch {
+    return `${currencyCode} ${value.toFixed(2)}`;
+  }
+}
+
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { admin } = await authenticate.admin(request);
 
@@ -114,7 +134,15 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
           hour: "numeric",
           minute: "2-digit",
         }),
-        amount: `${order.totalPriceSet.shopMoney.currencyCode} ${order.totalPriceSet.shopMoney.amount}`,
+        // MONEY IS FORMATTED, NOT CONCATENATED. Shopify returns `amount` as a
+        // raw decimal string — "5010.0", "175.0" — so the old template put
+        // "USD 5010.0" on the merchant's first screen, which reads as broken
+        // data rather than as money. Intl gives two decimals, thousands
+        // separators, and the shop's own currency symbol.
+        amount: formatMoney(
+          order.totalPriceSet.shopMoney.amount,
+          order.totalPriceSet.shopMoney.currencyCode,
+        ),
         status: verificationStatus === "active" ? "enrolled" : verificationStatus,
       };
     }).filter(Boolean);


### PR DESCRIPTION
Both found by opening the live dashboard on Corvara Cicli and **looking at it**, not by reading code.

**1 — `USD 5010.0`.** Shopify returns `shopMoney.amount` as a raw decimal *string*, and the row did `${currencyCode} ${amount}`. The merchant’s first screen read `USD 175.0`, `USD 5010.0`, `USD 3600.0` — one decimal, no separators. That is not a price, it is a float that escaped. Now formatted through `Intl`, with a plain-concat fallback so an unknown currency code can never throw the loader.

**2 — `Jul 6, 1:06 AMUSD 5010.0`.** The desktop row is `justify-between`, but the left group carries `flex-1`, which makes it grow to fill and defeats the justify — so the groups touch. With a short amount there was slack and it looked fine: **#1006 at `USD 175.0` rendered correctly on the very same screen where #1005 at `USD 5010.0` collided.** That is why it survived — it only appears once an order is big enough.

Swept the class, not the instance: `tagged-shipments` (the "View All" destination a reviewer clicks next) already formats via `toLocaleString`, and nothing else concatenates a currency code onto a raw amount.

`tsc` 0 errors · production build green.