### PR TITLE
An empty account should not look like a broken one

### DIFF
--- a/app/components/settings/AccountSettings.tsx
+++ b/app/components/settings/AccountSettings.tsx
@@ -18,9 +18,13 @@ const AccountSettings = () => {
   // Dynamic data from the `app.settings` route loader
   const shopData = useRouteLoaderData("routes/app.settings") as any;
 
-  const storeEmail = shopData?.contactEmail || "Not available";
-  const installedDate = shopData?.installedDate || "Not available";
-  const displayDomain = shopData?.primaryDomain || shopData?.shopDomain || currentShop?.domain || "Not available";
+  // A ROW WE CANNOT FILL IS HIDDEN, NOT LABELLED "Not available". Printing
+  // that beside a field name reads as a broken page; omitting the row reads as
+  // a page with nothing to say. (The install date was un-fillable by
+  // construction until the merchant record started stamping createdAt.)
+  const storeEmail = shopData?.contactEmail || "";
+  const installedDate = shopData?.installedDate || "";
+  const displayDomain = shopData?.primaryDomain || shopData?.shopDomain || currentShop?.domain || "";
 
   if (loading) {
     return (
@@ -44,14 +48,18 @@ const AccountSettings = () => {
               <Text as="p" variant="bodyMd" fontWeight="semibold">
                 {displayDomain}
               </Text>
+              {storeEmail && (
               <InlineStack gap="200">
                 <Text as="span" tone="subdued" variant="bodySm">Contact:</Text>
                 <Text as="span" variant="bodySm">{storeEmail}</Text>
               </InlineStack>
+              )}
+              {installedDate && (
               <InlineStack gap="200">
                 <Text as="span" tone="subdued" variant="bodySm">Installed:</Text>
                 <Text as="span" variant="bodySm">{installedDate}</Text>
               </InlineStack>
+              )}
             </BlockStack>
           </Card>
         </Layout.AnnotatedSection>

--- a/app/routes/app.help.tsx
+++ b/app/routes/app.help.tsx
@@ -157,16 +157,29 @@ const Help = () => {
               <Text as="h2" variant="headingSm">
                 Frequently Asked Questions
               </Text>
+              {/* THE SECTION TITLE WAS ONLY EVER A REACT KEY. Every section
+                  carried a heading — "Getting started", "The delivery record",
+                  "Returns", "Cost" — and none of them reached the page, so the
+                  FAQ rendered as five unlabelled boxes and "How much does it
+                  cost?" floated with nothing saying it was about cost. A field
+                  that reaches the data and not the page is invisible to tsc
+                  and to the suite (TECH_BIBLE law 9); only an eye on the
+                  rendered screen catches it. */}
               {faqSections.map((section) => (
-                <Card key={section.title} padding="0">
-                  {section.items.map((item, i) => (
-                    <FAQItem
-                      key={i}
-                      question={item.question}
-                      answer={item.answer}
-                    />
-                  ))}
-                </Card>
+                <BlockStack key={section.title} gap="200">
+                  <Text as="h3" variant="headingSm">
+                    {section.title}
+                  </Text>
+                  <Card padding="0">
+                    {section.items.map((item, i) => (
+                      <FAQItem
+                        key={i}
+                        question={item.question}
+                        answer={item.answer}
+                      />
+                    ))}
+                  </Card>
+                </BlockStack>
               ))}
             </BlockStack>
           </Layout.Section>

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -26,18 +26,33 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const shop = shopData.data?.shop;
   
   // 2. Get Merchant details from Firestore to get accurate install date and api_key
-  let installedDate = "Not available";
+  // Empty, not "Not available" — the component hides the row when there is no
+  // date, and a field reading "Not available" looks like a failure rather than
+  // an absence.
+  let installedDate = "";
   let inventoryStr = "0";
   let usedStr = "0";
 
   try {
-    const merchantDocs = await firestore.collection("merchants").where("shopDomain", "==", session.shop).limit(1).get();
-    if (!merchantDocs.empty) {
-        const data = merchantDocs.docs[0].data();
-        if (data.createdAt) {
-            const date = data.createdAt.toDate ? data.createdAt.toDate() : new Date(data.createdAt);
-            installedDate = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(date);
-        }
+    // BY DOCUMENT ID FIRST. The embedded app provisions with
+    // `merchants.doc(shop).set({ shop, … })`, so `where("shopDomain", …)` never
+    // matched it — which is why this read "Not available" for every merchant,
+    // permanently, no matter how long ago they installed. The query is kept as
+    // a fallback: the standalone auth path creates docs with random ids and a
+    // `shopDomain` field.
+    let data: Record<string, any> | undefined;
+    const byId = await firestore.collection("merchants").doc(session.shop).get();
+    if (byId.exists) {
+      data = byId.data();
+    } else {
+      const merchantDocs = await firestore.collection("merchants").where("shopDomain", "==", session.shop).limit(1).get();
+      if (!merchantDocs.empty) data = merchantDocs.docs[0].data();
+    }
+    if (data?.createdAt) {
+      const date = data.createdAt.toDate ? data.createdAt.toDate() : new Date(data.createdAt);
+      if (!Number.isNaN(date.getTime())) {
+        installedDate = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(date);
+      }
     }
 
     // 3. Fetch real inventory — use admin-level Firestore lookup (no API key needed)

--- a/app/routes/app.tagged-shipments._index.tsx
+++ b/app/routes/app.tagged-shipments._index.tsx
@@ -438,6 +438,26 @@ export default function ShipmentsIndex() {
               <IndexTable
                 resourceName={resourceName}
                 itemCount={sortedOrders.length}
+                // A FRESH INSTALL HAS NO SHIPMENTS, AND THAT IS ONE OF THE
+                // FIRST SCREENS A REVIEWER SEES. Without this, Polaris renders
+                // the column headings over blank space — "Order · Customer ·
+                // Date" and nothing beneath — which reads as a page that
+                // failed to load, not as an account with no orders yet.
+                // Observed on the live app 2026-08-02.
+                emptyState={
+                  <div style={{ padding: "40px 20px", textAlign: "center" }}>
+                    <BlockStack gap="200" inlineAlign="center">
+                      <Text as="h3" variant="headingSm">
+                        No shipments yet
+                      </Text>
+                      <Text as="p" tone="subdued">
+                        Orders enroll automatically as they come in. When your
+                        next one ships, it appears here with its page and its
+                        delivery status.
+                      </Text>
+                    </BlockStack>
+                  </div>
+                }
                 headings={[
                   { title: "Order" },
                   { title: "Customer" },

--- a/app/services/merchant.server.ts
+++ b/app/services/merchant.server.ts
@@ -7,6 +7,9 @@ export interface MerchantData {
   ink_api_key?: string;
   verified_delivery_mode?: "addon" | "background";
   updatedAt?: string;
+  /** First provision. Settings renders this as the install date — it was
+   *  never written, so that row read "Not available" forever. */
+  createdAt?: string;
 }
 
 export const getMerchant = async (shop: string): Promise<MerchantData | null> => {
@@ -22,8 +25,26 @@ export const getMerchant = async (shop: string): Promise<MerchantData | null> =>
 
 export const updateMerchant = async (shop: string, data: Partial<MerchantData>) => {
   try {
-    await firestore.collection(COLLECTION).doc(shop).set(
-      { ...data, shop, updatedAt: new Date().toISOString() }, 
+    const ref = firestore.collection(COLLECTION).doc(shop);
+    const now = new Date().toISOString();
+
+    // STAMP THE INSTALL ONCE. Settings shows this as "Installed:", and nothing
+    // ever wrote it — so that row read "Not available" for every merchant who
+    // had ever installed, permanently. Only set on the first write, so an
+    // existing merchant's date is never rewritten by a later update.
+    //
+    // `shopDomain` is written alongside `shop` on purpose: the standalone auth
+    // path writes `shopDomain` and queries by it, this path writes `shop` and
+    // keys by document id, and the Settings lookup was searching for a field
+    // this writer never set. Writing both ends the mismatch without migrating
+    // either shape.
+    const existing = await ref.get();
+    const stamp = existing.exists && (existing.data() as MerchantData)?.createdAt
+      ? {}
+      : { createdAt: now };
+
+    await ref.set(
+      { ...data, shop, shopDomain: shop, ...stamp, updatedAt: now },
       { merge: true }
     );
   } catch (error) {


### PR DESCRIPTION
Found by opening each screen of the live app on Corvara Cicli — which is the state a reviewer installs into: **nothing has happened yet.**

**1 — Shipments rendered bare column headings.** Polaris `IndexTable` had no `emptyState`, so a store with no shipments got `Order · Customer · Date` floating over blank space. That reads as a page that failed to load. A reviewer installs into exactly this state; it is one of the first screens they see.

**2 — `Installed: Not available` was unfillable by construction**, for every merchant, forever. Two independent bugs stacked:

- `updateMerchant` wrote `shop` and `updatedAt` and **never `createdAt`** — the field Settings formats as the install date.
- Settings looked the merchant up with `where("shopDomain", "==", shop)`, but the embedded app provisions with `merchants.doc(shop).set({ shop, … })` — a field that writer never set. **The query could not match its own document.**

Now the install is stamped once on first provision (never rewritten), the lookup goes by document id with the old query kept as a fallback for the standalone auth path’s random-id docs, and `shopDomain` is written alongside `shop` so the two shapes stop disagreeing.

**3 — A row we cannot fill is hidden, not labelled.** "Not available" beside a field name reads as breakage; an absent row reads as nothing to say. Applies to Contact and Installed alike.

The two remaining `Not available` strings live inside `{FEATURE_NFC && …}` with `FEATURE_NFC = false` — they ship in the bundle but never render.

`tsc` 0 errors · production build green.