### PR TITLE
Align billing copy with Shopify free plan

### DIFF
--- a/app/components/billing/PlanCard.tsx
+++ b/app/components/billing/PlanCard.tsx
@@ -1,6 +1,6 @@
-// This app is FREE at App Store submission — no plans are configured in the
-// Partner Dashboard, so there is no plan to choose, no charge to approve, and
-// no invoice. This card must not imply otherwise: plan language rendered here
+// This app is FREE at App Store submission. The Partner Dashboard exposes one
+// public Free plan, so there is no charge to approve and no invoice. This card
+// must not imply otherwise: paid plan language rendered here
 // while the listing's pricing field reads "Free" is exactly the inconsistency
 // that got the app rejected (requirement 1.2.1).
 //
@@ -20,23 +20,18 @@ const PlanCard = () => {
         <p className="text-sm font-medium text-foreground">Cost</p>
       </div>
       <p className="text-sm font-medium text-foreground mb-1">
-        You&rsquo;re a founding merchant.
+        Your Shopify plan is Free.
       </p>
       {/* PROSE, not the mark: parallelreturns #644 is the naming authority —
           "The Ritualist" sentence-initial, "the Ritualist" mid-sentence, bare
           "Ritualist" adjectival. Only the app-name field and the wordmark are
           lowercase `the ritualist`. The two cases are both correct and must
           not be flattened into each other. */}
-      {/* "The Ritualist is free" was the wrong sentence and Sam killed it: it
-          makes the PRODUCT the subject of "is free", which is a claim about
-          what it's worth. The arrangement is what costs nothing, so selection
-          leads and cost is subordinate — and "aren't billed" is a status the
-          merchant holds, not a property of the software. */}
       <p className="text-sm text-muted-foreground">
-        We&rsquo;re building this with a small group of brands, and you&rsquo;re
-        one of them. Founding merchants aren&rsquo;t billed. If we introduce
-        paid plans later, you&rsquo;ll choose and approve one inside Shopify
-        &mdash; nothing will ever start on its own.
+        There is no subscription charge, trial, usage fee, or off-platform
+        invoice. Installing the app creates no charge. If paid plans are
+        introduced later, you&rsquo;ll choose and approve one inside Shopify
+        &mdash; nothing will start on its own.
       </p>
     </div>
   );

--- a/app/components/settings/AccountSettings.tsx
+++ b/app/components/settings/AccountSettings.tsx
@@ -68,14 +68,13 @@ const AccountSettings = () => {
           <Card>
             <BlockStack gap="300">
               <Text as="p" variant="bodyMd" fontWeight="semibold">
-                You&rsquo;re a founding merchant.
+                Your Shopify plan is Free.
               </Text>
               <Text as="p" variant="bodyMd">
-                We&rsquo;re building this with a small group of brands, and
-                you&rsquo;re one of them. Founding merchants aren&rsquo;t
-                billed. If we introduce paid plans later, you&rsquo;ll choose
-                and approve one inside Shopify &mdash; nothing will ever start
-                on its own.
+                There is no subscription charge, trial, usage fee, or
+                off-platform invoice. Installing the app creates no charge. If
+                paid plans are introduced later, you&rsquo;ll choose and approve
+                one inside Shopify &mdash; nothing will start on its own.
               </Text>
               <div>
                 <Button onClick={() => navigate("/app/billing")}>View details</Button>

--- a/app/routes/app.billing.tsx
+++ b/app/routes/app.billing.tsx
@@ -11,8 +11,8 @@ import PlanCard from "../components/billing/PlanCard";
 // ledger of orders that never existed) — all tabled unreferenced in
 // components/billing/.
 //
-// The app is FREE at App Store submission: no plans exist in the Partner
-// Dashboard, so nothing can be charged. This page says that in as many words.
+// The app is FREE at App Store submission: the Partner Dashboard exposes one
+// public Free plan, so nothing can be charged. This page says that plainly.
 // It is deliberately kept (rather than deleted) because /app/payment and
 // /app/payment/callback redirect here, and because an explicit "there is
 // nothing to pay" screen is the cheapest possible proof of requirement 1.2.1
@@ -35,13 +35,14 @@ export default function BillingPage() {
           <Card>
             <BlockStack gap="200">
               <Text as="h2" variant="headingSm">
-                If that ever changes
+                Billing stays in Shopify
               </Text>
               <Text as="p" tone="subdued">
-                Any future plan would be offered, approved, and invoiced by
-                Shopify itself — on your regular Shopify invoice, only after
-                you approve it there. There is no card on file, nothing to
-                cancel outside Shopify, and no billing of any kind today.
+                Your current Shopify plan is Free. There is no subscription
+                charge, trial, usage fee, card on file, or off-platform
+                invoice. If paid plans are introduced later, Shopify will
+                present them for approval and add approved charges to your
+                regular Shopify invoice.
               </Text>
             </BlockStack>
           </Card>

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -76,8 +76,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     console.error("[App] INK self-provision error (non-blocking):", err)
   );
 
-  // No pricingUrl: the app is free and the Partner Dashboard has no plans, so
-  // there is nothing for a plan picker to show. The previous version built
+  // No pricingUrl: the Partner Dashboard exposes one public Free plan, so
+  // there is no paid charge or approval flow to launch. The previous version built
   // `…/charges/${SHOPIFY_APP_HANDLE || "ink-verified-delivery"}/pricing_plans`
   // — but SHOPIFY_APP_HANDLE is set in NO environment (verified against Cloud
   // Run 2026-08-01), so that fallback was always what shipped, and it is not

--- a/m.txt
+++ b/m.txt
@@ -21,7 +21,7 @@ Priority: blocks proof lifecycle. Required before billing is accurate.
 •	Proof transitions to ACTIVE after COOLDOWN expires
 
 M3 — Billing: Usage & Billing
-Billing model: $2.99 per enrollment + $2.99 per verification (Active). All charges via Shopify Billing API only — never Stripe.
+Billing model: Free at App Store submission. Any future paid pricing must use Shopify App Pricing — never Stripe.
 •	Wire current billing cycle — date range, Enrolled line item with count and amount, Active line item with count and amount, cycle total
 •	Wire Usage Cap — display cap amount, amount used, percentage used, progress bar
 •	Wire Usage History — per-order list showing order number, Enrolled or Active badge, timestamp, and charge amount


### PR DESCRIPTION
## Summary
- align every merchant-facing billing surface with the single public Free plan configured in Shopify App Pricing
- state explicitly that install creates no subscription charge, trial, usage fee, or off-platform invoice
- remove the stale internal $2.99/event billing note

## Verification
- `npm run typecheck`
- `npm run build`

## Safety
- `shopify.app.toml` unchanged
- no scope, credential, or backend changes