### PR TITLE
Shopify's own outbox becomes the brand's distribution

### DIFF
--- a/app/components/settings/DeliveryModeSettings.tsx
+++ b/app/components/settings/DeliveryModeSettings.tsx
@@ -6,11 +6,16 @@ import {
   Text,
   Banner,
   Spinner,
+  Checkbox,
 } from "@shopify/polaris";
 import { toast } from "../../hooks/use-toast";
 
 const DeliveryModeSettings = () => {
   const [loading, setLoading] = useState(true);
+  // The branded tracking link. ON for every merchant unless they turn it off
+  // here — so this starts true and only a loaded `false` moves it.
+  const [trackingLink, setTrackingLink] = useState(true);
+  const [trackingLinkSaving, setTrackingLinkSaving] = useState(false);
 
   // App-Bridge-aware fetch (mirrors the pattern used in BrandingSettings).
   const fetchSecure = async (path: string, options: RequestInit = {}) => {
@@ -58,12 +63,46 @@ const DeliveryModeSettings = () => {
           variant: "destructive",
           duration: 3000,
         });
-      } finally {
-        setLoading(false);
       }
+      // Separate try: a tracking-link read that fails must not blank the
+      // delivery panel, and vice versa.
+      try {
+        const res = await fetchSecure("/app/api/settings/branded-tracking-link");
+        if (res && typeof res.enabled === "boolean") setTrackingLink(res.enabled);
+      } catch (err: any) {
+        console.error("Failed to load tracking link setting:", err);
+      }
+      setLoading(false);
     };
     load();
   }, []);
+
+  const saveTrackingLink = async (enabled: boolean) => {
+    const previous = trackingLink;
+    setTrackingLink(enabled); // optimistic — a toggle that lags feels broken
+    setTrackingLinkSaving(true);
+    try {
+      await fetchSecure("/app/api/settings/branded-tracking-link", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled }),
+      });
+      toast({
+        title: enabled ? "Tracking links point to your page" : "Tracking links point to the carrier",
+        duration: 2500,
+      });
+    } catch (err: any) {
+      setTrackingLink(previous); // say so, don't keep a lie on screen
+      toast({
+        title: "Couldn't save that",
+        description: err.message,
+        variant: "destructive",
+        duration: 3000,
+      });
+    } finally {
+      setTrackingLinkSaving(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -102,6 +141,32 @@ const DeliveryModeSettings = () => {
                 runs in background mode.
               </Text>
             </Banner>
+          </BlockStack>
+        </Card>
+      </Layout.AnnotatedSection>
+
+      <Layout.AnnotatedSection
+        title="Tracking link"
+        description="Where your customer lands when they click “Track your shipment”."
+      >
+        <Card>
+          <BlockStack gap="400">
+            <Checkbox
+              label="Send tracking clicks to your order page"
+              helpText={
+                "Your order page answers when the package is arriving, and it stays yours. " +
+                "The carrier name and tracking number are still shown, and still link to the carrier."
+              }
+              checked={trackingLink}
+              disabled={trackingLinkSaving}
+              onChange={saveTrackingLink}
+            />
+            <Text as="p" tone="subdued" variant="bodySm">
+              This applies to the tracking link on the order page in your admin, in the
+              shipping-confirmation email, and on your customer’s order-status page. Orders shipped
+              with a carrier we can’t follow keep Shopify’s own tracking link, so no customer is
+              ever sent to a page that can’t tell them anything.
+            </Text>
           </BlockStack>
         </Card>
       </Layout.AnnotatedSection>

--- a/app/routes/app.api.settings.branded-tracking-link.tsx
+++ b/app/routes/app.api.settings.branded-tracking-link.tsx
@@ -1,0 +1,104 @@
+/**
+ * Branded tracking link — merchant preference endpoint.
+ *
+ * GET   → { enabled: boolean }
+ * PATCH → { enabled: boolean } persisted to
+ *         merchants/{shopDomain}.branded_tracking_link
+ *
+ * DEFAULT ON (Sam, 2026-08-06): an absent field reads as enabled, so every
+ * merchant gets the branded tracking link without touching this screen. The
+ * field exists to turn it OFF for one shop; env BRANDED_TRACKING_LINK_DISABLED
+ * turns it off everywhere. Both are emergency exits, not opt-ins — which is
+ * why `false` is stored explicitly and absence is never treated as a refusal.
+ *
+ * Reads/writes are gated by `authenticate.admin(request)` from Shopify. Follows
+ * the app.api.settings.delivery-mode.tsx precedent exactly.
+ */
+import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
+import firestore from "../firestore.server";
+import { authenticate } from "../shopify.server";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, PATCH, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+const json = (data: any, init?: ResponseInit) =>
+  new Response(JSON.stringify(data), {
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+    ...init,
+  });
+
+async function getMerchantDoc(shopDomain: string) {
+  const direct = await firestore.collection("merchants").doc(shopDomain).get();
+  if (direct.exists) return direct;
+  for (const field of ["shop", "shopDomain", "shop_domain"]) {
+    const snapshot = await firestore
+      .collection("merchants")
+      .where(field, "==", shopDomain)
+      .limit(1)
+      .get();
+    if (!snapshot.empty) return snapshot.docs[0];
+  }
+  return null;
+}
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  const { session } = await authenticate.admin(request);
+  const shopDomain = session.shop;
+
+  try {
+    const doc = await getMerchantDoc(shopDomain);
+    // Absent → ON. Only an explicit false turns it off.
+    const enabled = doc?.data()?.branded_tracking_link !== false;
+    return json({ enabled, killedGlobally: Boolean(process.env.BRANDED_TRACKING_LINK_DISABLED) });
+  } catch (err: any) {
+    console.error("[settings/branded-tracking-link] GET error:", err.message);
+    return json({ error: "Failed to fetch tracking link setting" }, { status: 500 });
+  }
+};
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  if (request.method !== "PATCH") {
+    return json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const { session } = await authenticate.admin(request);
+  const shopDomain = session.shop;
+
+  try {
+    const body = await request.json();
+    const enabled = body?.enabled;
+    if (typeof enabled !== "boolean") {
+      return json({ error: "Invalid body. Expected { enabled: boolean }" }, { status: 400 });
+    }
+
+    const doc = await getMerchantDoc(shopDomain);
+    if (!doc) {
+      console.warn(
+        `[settings/branded-tracking-link] Merchant doc not found for ${shopDomain}; cannot persist`,
+      );
+      return json(
+        { error: "Merchant not registered with the Ritualist backend yet" },
+        { status: 404 },
+      );
+    }
+
+    await doc.ref.update({ branded_tracking_link: enabled, updatedAt: new Date() });
+    console.log(`[settings/branded-tracking-link] ${shopDomain} → enabled=${enabled}`);
+
+    return json({ enabled });
+  } catch (err: any) {
+    console.error("[settings/branded-tracking-link] PATCH error:", err.message);
+    return json({ error: "Failed to update tracking link setting" }, { status: 500 });
+  }
+};

--- a/app/routes/webhooks.fulfillments_create.tsx
+++ b/app/routes/webhooks.fulfillments_create.tsx
@@ -78,12 +78,33 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       return new Response("OK", { status: 200 });
     }
 
-    await NFSService.updateTracking(proofId, merchantApiKey, {
+    const patched = await NFSService.updateTracking(proofId, merchantApiKey, {
       carrier_name: trackingCompany || undefined,
       tracking_number: trackingNumber,
       tracking_url: trackingUrl || undefined,
     });
     console.log(`✅ [${topic}] Tracking forwarded for ${orderName}: ${trackingCompany ?? "?"} ${trackingNumber} → ${proofId}`);
+
+    // THE AUTO-LINK. The backend has just told us whether the Shippo feed
+    // registered for this carrier (`shippo_registered`), which is the only
+    // honest gate on taking Shopify's tracking link over: a branded page that
+    // can never update is worse than the carrier's own. Gated, logged, and
+    // never fatal — see branded-tracking-link.server.ts.
+    try {
+      const { assertBrandedTrackingUrl } = await import("../services/branded-tracking-link.server");
+      await assertBrandedTrackingUrl({
+        admin,
+        shop,
+        payload,
+        proofId,
+        merchantApiKey,
+        merchantData: merchantHit?.data ?? {},
+        shippoRegistered: patched?.shippo_registered === true,
+        label: `[${topic}] branded-tracking-link`,
+      });
+    } catch (e: any) {
+      console.error(`❌ branded tracking link failed (non-fatal):`, e?.message);
+    }
 
     // The SHIPPED email belongs to this moment — tracking just landed on
     // the proof, so the page is live as a tracker. "On its way — track it",

--- a/app/routes/webhooks.fulfillments_update.tsx
+++ b/app/routes/webhooks.fulfillments_update.tsx
@@ -28,14 +28,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     console.log(`📦 Order ID: ${orderId}`);
     console.log(`📦 Shipment Status: ${shipmentStatus || "None/Unknown"}`);
 
-    // If it's not one of our targeted statuses, we ignore it.
-    if (shipmentStatus !== "out_for_delivery" && shipmentStatus !== "delivered") {
-      console.log(`📦 Status is not actionable for notifications. Exiting.`);
-      console.log("📦 ================================================\n");
-      return new Response("OK", { status: 200 });
-    }
-
-    // 1. Fetch the Order to check if it's an INK order and get customer info
+    // 1. Fetch the Order to check if it's an INK order and get customer info.
+    //    Memoized: this handler now has TWO jobs (the tracking hop below and
+    //    the delivery notifications after it) and they must not each spend an
+    //    API call on the same order.
     const orderQuery = `#graphql
       query GetOrderForFulfillmentEvent($id: ID!) {
         order(id: $id) {
@@ -51,10 +47,96 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       }
     `;
 
-    console.log(`📦 Querying Shopify for Order details...`);
-    const orderData = await admin.graphql(orderQuery, { variables: { id: orderGid } });
-    const orderJson = await orderData.json();
-    const order = orderJson.data?.order;
+    let orderPromise: Promise<any> | null = null;
+    const loadOrder = () => {
+      if (!orderPromise) {
+        console.log(`📦 Querying Shopify for Order details...`);
+        orderPromise = admin
+          .graphql(orderQuery, { variables: { id: orderGid } })
+          .then((r) => r.json())
+          .then((j: any) => j.data?.order ?? null);
+      }
+      return orderPromise;
+    };
+
+    // 2. Fetch Merchant Notification Settings — convention-proof resolver.
+    //    The old shopDomain-only query silently exited here on shop/shop_domain
+    //    docs, which meant REAL CARRIER DELIVERIES never marked proofs
+    //    delivered on those shops (Phase-1 rehearsal finding, 2026-07-02).
+    let merchantPromise: ReturnType<typeof findMerchantDoc> | null = null;
+    const loadMerchant = () => {
+      if (!merchantPromise) {
+        console.log(`📦 Fetching Merchant Settings for ${shop}...`);
+        merchantPromise = findMerchantDoc(firestore, shop);
+      }
+      return merchantPromise;
+    };
+
+    // ── THE TRACKING-ADDED-LATER HOP (the 3PL gap) ──────────────────────────
+    // This handler used to ignore everything except out_for_delivery/delivered,
+    // which meant a fulfillment created EMPTY and given tracking a moment later
+    // — the normal 3PL and ShipStation shape — never reached the backend at
+    // all. fulfillments/create had already fired with nothing to forward, and
+    // nothing fired afterwards. Those orders' pages could never answer "where
+    // is it", however healthy the rest of the pipe was.
+    //
+    // Runs BEFORE the status gate, and only when there is tracking to forward.
+    // The backend PATCH is idempotent, so re-forwarding an unchanged number is
+    // harmless; our own branded-link mutation re-fires this webhook exactly
+    // once, and the loop guard inside assertBrandedTrackingUrl ends it there.
+    const trackingNumber =
+      (Array.isArray(fulfillment.tracking_numbers) && fulfillment.tracking_numbers[0]) ||
+      fulfillment.tracking_number ||
+      null;
+    if (trackingNumber) {
+      try {
+        const trackingOrder = await loadOrder();
+        const trackingProofId = trackingOrder?.proofMetafield?.value;
+        if (trackingProofId) {
+          const hit = await loadMerchant();
+          const apiKey = hit?.apiKey ?? hit?.data?.ink_api_key ?? null;
+          if (apiKey) {
+            const patched = await NFSService.updateTracking(trackingProofId, apiKey, {
+              carrier_name: fulfillment.tracking_company || undefined,
+              tracking_number: String(trackingNumber),
+              tracking_url:
+                (Array.isArray(fulfillment.tracking_urls) && fulfillment.tracking_urls[0]) ||
+                fulfillment.tracking_url ||
+                undefined,
+            });
+            console.log(
+              `✅ Tracking forwarded on UPDATE for ${trackingOrder?.name ?? orderId}: ` +
+                `${fulfillment.tracking_company ?? "?"} ${trackingNumber} → ${trackingProofId}`,
+            );
+
+            const { assertBrandedTrackingUrl } = await import("../services/branded-tracking-link.server");
+            await assertBrandedTrackingUrl({
+              admin,
+              shop,
+              payload: fulfillment,
+              proofId: trackingProofId,
+              merchantApiKey: apiKey,
+              merchantData: hit?.data ?? {},
+              shippoRegistered: patched?.shippo_registered === true,
+              label: `[${topic}] branded-tracking-link`,
+            });
+          } else {
+            console.log(`⚠️ No ink_api_key for ${shop}; cannot forward tracking added on update.`);
+          }
+        }
+      } catch (e: any) {
+        console.error(`❌ tracking hop on update failed (non-fatal):`, e?.message ?? e);
+      }
+    }
+
+    // If it's not one of our targeted statuses, we ignore the rest.
+    if (shipmentStatus !== "out_for_delivery" && shipmentStatus !== "delivered") {
+      console.log(`📦 Status is not actionable for notifications. Exiting.`);
+      console.log("📦 ================================================\n");
+      return new Response("OK", { status: 200 });
+    }
+
+    const order = await loadOrder();
 
     if (!order) {
       console.log(`❌ Order not found in Shopify. Exiting.`);
@@ -71,12 +153,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       return new Response("OK", { status: 200 });
     }
 
-    // 2. Fetch Merchant Notification Settings — convention-proof resolver.
-    //    The old shopDomain-only query silently exited here on shop/shop_domain
-    //    docs, which meant REAL CARRIER DELIVERIES never marked proofs
-    //    delivered on those shops (Phase-1 rehearsal finding, 2026-07-02).
-    console.log(`📦 Fetching Merchant Settings for ${shop}...`);
-    const merchantHit = await findMerchantDoc(firestore, shop);
+    const merchantHit = await loadMerchant();
 
     if (!merchantHit) {
       console.log(`⚠️ No merchant document found for ${shop}. Exiting.`);

--- a/app/services/brand-page-url.server.ts
+++ b/app/services/brand-page-url.server.ts
@@ -1,0 +1,99 @@
+// THE BUYER'S PAGE URL — one author, because two would drift.
+//
+// `https://{brand}.in.ink/r/{nfc_token}` is the address of the thing this
+// whole product is. It was resolved inline in state-email.server.ts, and the
+// branded tracking link needs the SAME address on the same order — a second
+// copy of this resolution is a guarantee that one day an email and a tracking
+// button send the same buyer to two different pages.
+//
+// Two facts the resolution has to get right, both learned the hard way:
+//
+//  · THE BRAND LIVES ON THE BACKEND DOC. brand_slug / shop_name / support_email
+//    are written to merchants/{shop_id} by the backend; the embed's own doc
+//    (keyed by myshopify domain) carries the api key and not the brand. #1016's
+//    shipped email went out as sm-test-hhawzn52@in.ink for exactly this reason.
+//    So the backend doc is MERGED OVER the embed doc before reading brand.
+//  · THE TOKEN IS THE PAGE. Only an nfc_token addresses a real buyer page.
+//    `/r/{proof_id}` resolves for nobody without merchant auth, so it is
+//    offered ONLY as email's pre-existing fallback and NEVER as an address we
+//    hand to Shopify to point customers at.
+
+import { brandSlugFromDomain } from "./email.server";
+import { getProof } from "./ink-api.server";
+
+export interface BrandPageResolution {
+  /** The real buyer page. Non-null ONLY when a proof carries an nfc_token —
+   *  the one URL safe to publish anywhere a customer will click. */
+  pageUrl: string | null;
+  /** What email has always linked to: the page, or a www fallback that at
+   *  least lands somewhere. Kept for byte-identical email behaviour. */
+  emailUrl: string;
+  nfcToken: string | null;
+  brandSlug: string;
+  /** The proof's shop_id — the backend's merchant identity, not the domain. */
+  proofShopId: string;
+  /** Backend merchant doc merged over the embed's, for brand fields. */
+  brandDoc: Record<string, any>;
+  customerTier: string | null;
+}
+
+/** Resolve the buyer page for one proof.
+ *
+ *  Fail-soft throughout: a proof fetch or merchant-doc read that fails leaves
+ *  `pageUrl` null and the caller decides. Nothing here may throw into a
+ *  webhook — this runs on the fulfillment path, where the only unforgivable
+ *  outcome is a non-200. */
+export async function resolveBrandPageUrl({
+  merchantApiKey,
+  proofId,
+  shop,
+  merchantData,
+  label = "brand-page-url",
+}: {
+  merchantApiKey?: string | null;
+  proofId: string;
+  /** The myshopify domain — the last-resort brand source. */
+  shop: string;
+  /** The embed's own merchant doc (findMerchantDoc().data). */
+  merchantData: Record<string, any>;
+  label?: string;
+}): Promise<BrandPageResolution> {
+  let nfcToken: string | null = null;
+  let customerTier: string | null = null;
+  let proofShopId = "";
+
+  if (merchantApiKey) {
+    try {
+      const proof = await getProof(merchantApiKey, proofId);
+      nfcToken = (proof?.nfc_token as string | undefined) || null;
+      customerTier = (proof?.customer_tier as string | undefined) || null;
+      proofShopId = String(proof?.shop_id || "");
+    } catch (e: any) {
+      console.warn(`🔗 ${label}: proof fetch failed (${e?.message}) — no branded page URL.`);
+    }
+  }
+
+  let brandDoc: Record<string, any> = merchantData;
+  if (proofShopId) {
+    try {
+      const { default: firestore } = await import("../firestore.server");
+      const d = await firestore.collection("merchants").doc(proofShopId).get();
+      if (d.exists) brandDoc = { ...merchantData, ...(d.data() || {}) };
+    } catch (e: any) {
+      console.warn(`🔗 ${label}: backend merchant doc fetch failed (${e?.message}) — using embed doc for branding.`);
+    }
+  }
+
+  const brandDomain =
+    (brandDoc.shop_domain as string | undefined) ||
+    (brandDoc.shopDomain as string | undefined) ||
+    shop;
+  const brandSlug =
+    brandSlugFromDomain(brandDoc.brand_slug as string | undefined) ||
+    brandSlugFromDomain(brandDomain);
+
+  const pageUrl = brandSlug && nfcToken ? `https://${brandSlug}.in.ink/r/${nfcToken}` : null;
+  const emailUrl = pageUrl ?? `https://www.in.ink/r/${nfcToken || proofId}`;
+
+  return { pageUrl, emailUrl, nfcToken, brandSlug, proofShopId, brandDoc, customerTier };
+}

--- a/app/services/branded-tracking-link.server.ts
+++ b/app/services/branded-tracking-link.server.ts
@@ -1,0 +1,201 @@
+// THE AUTO-LINK — Shopify's own outbox becomes the brand's distribution.
+//
+// `fulfillmentTrackingInfoUpdate` accepts a custom tracking URL, and that URL
+// is what Shopify renders on the admin order page, in the shipping-confirmation
+// email, and on the customer's order-status page. So on every fulfillment that
+// carries tracking we can point the store's OWN surfaces at the brand's page —
+// no template paste, no merchant work, no sends of our own. Every "track your
+// shipment" click the store already generates lands on the brand instead of on
+// the carrier.
+//
+// The carrier name and tracking number stay intact and visible, here and on
+// our page's meta line. We are not hiding the carrier; we are answering the
+// question better than it does.
+//
+// FOUR REFUSALS, and each one is load-bearing:
+//
+//  1. THE FEED MUST BE PROVABLY ALIVE. A branded page that says "on its way"
+//     forever is WORSE than the carrier link — it burns the one impression
+//     this exists to win. We only take the link over when the backend confirms
+//     Shippo registration (`shippo_registered` off PATCH /proofs/:id/tracking).
+//     Every skip LOGS its tracking_company, so live merchants' real carrier mix
+//     writes our expansion list instead of us guessing at it. The gate is an
+//     instrument, not a ceiling.
+//  2. THE LOOP GUARD. Our own mutation re-fires FULFILLMENTS_UPDATE. A tracking
+//     URL already pointing at .in.ink is a no-op, so the echo dies here.
+//  3. THE KILL SWITCHES. Env `BRANDED_TRACKING_LINK_DISABLED` turns it off
+//     everywhere; `merchants/{shop}.branded_tracking_link === false` turns it
+//     off for one merchant. Rollout is default-ON for every merchant (Sam,
+//     2026-08-06) — these are the emergency exits, not the opt-in.
+//  4. NO SILENT NOTIFICATION. notifyCustomer:false — rewriting a link must
+//     never re-send a shipping email to a buyer who already got one.
+
+import { resolveBrandPageUrl } from "./brand-page-url.server";
+
+/** Every way this can end, so callers log the truth rather than a guess. */
+export type BrandedTrackingOutcome =
+  | "updated"
+  | "skipped_disabled_env"
+  | "skipped_disabled_merchant"
+  | "skipped_already_branded"
+  | "skipped_feed_unregistered"
+  | "skipped_no_page_url"
+  | "skipped_no_fulfillment_id"
+  | "failed";
+
+export interface BrandedTrackingResult {
+  outcome: BrandedTrackingOutcome;
+  url?: string;
+  detail?: string;
+}
+
+const MUTATION = `#graphql
+  mutation InkBrandedTrackingUrl(
+    $fulfillmentId: ID!
+    $trackingInfoInput: FulfillmentTrackingInput!
+    $notifyCustomer: Boolean
+  ) {
+    fulfillmentTrackingInfoUpdate(
+      fulfillmentId: $fulfillmentId
+      trackingInfoInput: $trackingInfoInput
+      notifyCustomer: $notifyCustomer
+    ) {
+      fulfillment { id trackingInfo { company number url } }
+      userErrors { field message }
+    }
+  }
+`;
+
+/** Is this URL already ours? Guards the echo our own mutation causes. */
+export function isBrandedTrackingUrl(url?: string | null): boolean {
+  return /(^|\/\/|\.)in\.ink(\/|$)/i.test(String(url || ""));
+}
+
+/** Every tracking URL Shopify currently holds for this fulfillment. */
+function currentTrackingUrls(payload: any): string[] {
+  const urls: string[] = [];
+  if (Array.isArray(payload?.tracking_urls)) urls.push(...payload.tracking_urls.map(String));
+  if (payload?.tracking_url) urls.push(String(payload.tracking_url));
+  return urls.filter(Boolean);
+}
+
+function trackingNumbers(payload: any): string[] {
+  const nums: string[] = [];
+  if (Array.isArray(payload?.tracking_numbers)) nums.push(...payload.tracking_numbers.map(String));
+  else if (payload?.tracking_number) nums.push(String(payload.tracking_number));
+  return nums.filter(Boolean);
+}
+
+export async function assertBrandedTrackingUrl({
+  admin,
+  shop,
+  payload,
+  proofId,
+  merchantApiKey,
+  merchantData,
+  shippoRegistered,
+  label = "branded-tracking-link",
+}: {
+  admin: { graphql: (query: string, opts?: any) => Promise<Response> };
+  shop: string;
+  /** The Fulfillment webhook payload. */
+  payload: any;
+  proofId: string;
+  merchantApiKey?: string | null;
+  merchantData: Record<string, any>;
+  /** From the backend's PATCH /proofs/:id/tracking response. Only `true`
+   *  means the Shippo feed is registered and our page can actually speak. */
+  shippoRegistered: boolean;
+  label?: string;
+}): Promise<BrandedTrackingResult> {
+  const carrier = String(payload?.tracking_company || "").trim() || "(no carrier name)";
+
+  if (process.env.BRANDED_TRACKING_LINK_DISABLED) {
+    console.log(`🔗 ${label}: OFF by env — leaving Shopify's carrier link in place.`);
+    return { outcome: "skipped_disabled_env" };
+  }
+  if (merchantData?.branded_tracking_link === false) {
+    console.log(`🔗 ${label}: OFF for ${shop} — leaving Shopify's carrier link in place.`);
+    return { outcome: "skipped_disabled_merchant" };
+  }
+
+  const existing = currentTrackingUrls(payload);
+  if (existing.length > 0 && existing.every(isBrandedTrackingUrl)) {
+    console.log(`🔗 ${label}: already ours — no-op (this is the echo of our own mutation).`);
+    return { outcome: "skipped_already_branded" };
+  }
+
+  // NO SILENT CAPS: a skipped carrier is the measurement, so it says its own
+  // name. This log is the expansion list for utils/shippoCarriers.js.
+  if (shippoRegistered !== true) {
+    console.log(
+      `🔗 ${label}: SKIPPED — the carrier feed is not registered for "${carrier}" (shop ${shop}, proof ${proofId}). ` +
+        `Shopify's own tracking link stays. Add this carrier to shippoCarriers.js if it keeps appearing.`,
+    );
+    return { outcome: "skipped_feed_unregistered", detail: carrier };
+  }
+
+  const fulfillmentRawId = payload?.id;
+  if (!fulfillmentRawId) {
+    console.warn(`🔗 ${label}: fulfillment payload carries no id — cannot address the mutation.`);
+    return { outcome: "skipped_no_fulfillment_id" };
+  }
+
+  const resolved = await resolveBrandPageUrl({ merchantApiKey, proofId, shop, merchantData, label });
+  if (!resolved.pageUrl) {
+    console.warn(
+      `🔗 ${label}: no buyer page URL for proof ${proofId} (nfc_token=${resolved.nfcToken ?? "none"}, ` +
+        `brand=${resolved.brandSlug || "none"}) — leaving Shopify's carrier link in place.`,
+    );
+    return { outcome: "skipped_no_page_url" };
+  }
+
+  // Carrier and number are PRESERVED verbatim; only the destination moves.
+  // The schema's own rule (FulfillmentTrackingInput): url pairs with number,
+  // urls pairs with numbers, and you never mix the two forms. A url with no
+  // number would be a malformed write, so no number means no rewrite — the
+  // carrier link stays and the buyer keeps whatever Shopify had.
+  const numbers = trackingNumbers(payload);
+  if (numbers.length === 0) {
+    console.log(`🔗 ${label}: fulfillment carries no tracking number — nothing to rewrite.`);
+    return { outcome: "skipped_no_page_url", detail: "no tracking number" };
+  }
+  const trackingInfoInput: Record<string, unknown> = {
+    ...(payload?.tracking_company ? { company: String(payload.tracking_company) } : {}),
+    // Shopify pairs numbers with urls by index, so a multi-parcel fulfillment
+    // gets the same page once per number — every parcel belongs to one order,
+    // and the page shows the order.
+    ...(numbers.length > 1
+      ? { numbers, urls: numbers.map(() => resolved.pageUrl as string) }
+      : { number: numbers[0], url: resolved.pageUrl }),
+  };
+
+  try {
+    const res = await admin.graphql(MUTATION, {
+      variables: {
+        fulfillmentId: `gid://shopify/Fulfillment/${fulfillmentRawId}`,
+        trackingInfoInput,
+        notifyCustomer: false,
+      },
+    });
+    const json: any = await res.json();
+    const userErrors = json?.data?.fulfillmentTrackingInfoUpdate?.userErrors ?? [];
+    if (userErrors.length > 0) {
+      const detail = userErrors.map((e: any) => `${(e.field || []).join(".")}: ${e.message}`).join("; ");
+      console.error(`🔗 ${label}: Shopify refused the rewrite — ${detail}`);
+      return { outcome: "failed", detail };
+    }
+    if (json?.errors?.length) {
+      const detail = json.errors.map((e: any) => e.message).join("; ");
+      console.error(`🔗 ${label}: GraphQL error — ${detail}`);
+      return { outcome: "failed", detail };
+    }
+    console.log(`✅ ${label}: ${carrier} tracking for proof ${proofId} now points at ${resolved.pageUrl}`);
+    return { outcome: "updated", url: resolved.pageUrl };
+  } catch (e: any) {
+    // Webhook discipline: a failed rewrite is a link that stays as Shopify's.
+    // It is never a non-200.
+    console.error(`🔗 ${label}: rewrite threw (non-fatal) — ${e?.message ?? e}`);
+    return { outcome: "failed", detail: String(e?.message ?? e) };
+  }
+}

--- a/app/services/state-email.server.ts
+++ b/app/services/state-email.server.ts
@@ -18,9 +18,9 @@
 // ink.shipped_email_sent / ink.arrival_email_sent order metafields (Shopify
 // redelivers webhooks and carriers repeat scans; the customer gets ONE of each).
 
-import { EmailService, brandSlugFromDomain } from "./email.server";
+import { EmailService } from "./email.server";
 import { fetchBrandEmailKit, selectEmailCampaign } from "./brand-email.server";
-import { getProof } from "./ink-api.server";
+import { resolveBrandPageUrl } from "./brand-page-url.server";
 import { CUSTOMER_CONSENT_FRAGMENT, mayIncludeMarketing } from "./consent.server";
 
 const INK_NAMESPACE = "ink";
@@ -118,46 +118,30 @@ export async function sendStateEmailOnce(args: StateEmailArgs): Promise<void> {
   const buyerEmailConsent = checkJson.data?.order?.customer?.emailMarketingConsent ?? null;
   const aimedSectionAllowed = mayIncludeMarketing("aimed_section", "email", buyerEmailConsent);
 
-  // ── Proof (authoritative): nfc_token for the page link, tier for aiming ──
+  // ── Proof + branded sender + the same live link the physical tag resolves
+  // to. All of it resolved by ONE author (brand-page-url.server.ts), because
+  // the branded TRACKING link now needs the identical address on the identical
+  // order — and two copies of this resolution would eventually send the same
+  // buyer to two different pages from one email and one tracking button.
+  //
+  // What that author gets right, and why: brand identity (brand_slug,
+  // shop_name, support_email) lives on the BACKEND merchant doc
+  // (merchants/{shop_id}); the embed's own doc carries the api key but not the
+  // brand. #1016's shipped email went out as sm-test-hhawzn52@in.ink for
+  // exactly that reason, so the backend doc is merged OVER the embed doc.
   const merchantApiKey: string | undefined = merchantData.ink_api_key;
-  let nfcToken: string | undefined;
-  let customerTier: string | null = null;
-  let proofShopId = "";
-  if (merchantApiKey) {
-    try {
-      const proof = await getProof(merchantApiKey, proofId);
-      nfcToken = proof?.nfc_token || undefined;
-      customerTier = (proof?.customer_tier as string | undefined) || null;
-      proofShopId = String(proof?.shop_id || "");
-    } catch (e: any) {
-      console.warn(`📧 ${label}: proof fetch failed (${e?.message}) — sending with fallback link.`);
-    }
-  }
-
-  // ── Branded sender + the same live link the physical tag resolves to ──
-  // Brand identity fields (brand_slug, shop_name, support_email) live on the
-  // BACKEND-provisioned merchant doc (merchants/{shop_id}); the embed's own
-  // doc (keyed by the myshopify domain) carries the api key but not the
-  // brand. Caught live on #1016's shipped email: it went out as
-  // sm-test-hhawzn52@in.ink instead of stevemadden@in.ink. Merge the backend
-  // doc over the embed doc for brand resolution, same as api.verify does.
-  let brandDoc: Record<string, any> = merchantData;
-  if (proofShopId) {
-    try {
-      const { default: firestore } = await import("../firestore.server");
-      const d = await firestore.collection("merchants").doc(proofShopId).get();
-      if (d.exists) brandDoc = { ...merchantData, ...(d.data() || {}) };
-    } catch (e: any) {
-      console.warn(`📧 ${label}: backend merchant doc fetch failed (${e?.message}) — using embed doc for branding.`);
-    }
-  }
-  const brandDomain =
-    (brandDoc.shop_domain as string | undefined) ||
-    (brandDoc.shopDomain as string | undefined) ||
-    shop;
-  const brandSlug =
-    brandSlugFromDomain(brandDoc.brand_slug as string | undefined) ||
-    brandSlugFromDomain(brandDomain);
+  const brandPage = await resolveBrandPageUrl({
+    merchantApiKey,
+    proofId,
+    shop,
+    merchantData,
+    label,
+  });
+  const nfcToken = brandPage.nfcToken ?? undefined;
+  const customerTier = brandPage.customerTier;
+  const proofShopId = brandPage.proofShopId;
+  const brandDoc = brandPage.brandDoc;
+  const brandSlug = brandPage.brandSlug;
   const senderFromEmail = brandSlug && brandSlug.length >= 2 ? `${brandSlug}@in.ink` : undefined;
   const senderFromName =
     (brandDoc.shop_name as string | undefined) ||
@@ -187,10 +171,7 @@ export async function sendStateEmailOnce(args: StateEmailArgs): Promise<void> {
     console.log(`📧 SKIP ${label} (test-mode merchant, backend doc): refusing real customer send for ${customerEmail}.`);
     return;
   }
-  const proofUrl =
-    brandSlug && nfcToken
-      ? `https://${brandSlug}.in.ink/r/${nfcToken}`
-      : `https://www.in.ink/r/${nfcToken || proofId}`;
+  const proofUrl = brandPage.emailUrl;
 
   // ── Email-as-tap-page: brand kit + the buyer's aimed section (fail-soft) ──
   const brandKit = await fetchBrandEmailKit(proofShopId);


### PR DESCRIPTION
Wave 2 of the rev-1 tracking plan. Merging auto-deploys, and the deployed code writes tracking URLs into whichever Shopify stores have the app installed — today that is the two test rigs (Steve Madden, Clare V.), not anyone's customers. So this needs Sam's OK because it deploys, not because a wrong rewrite reaches a buyer.

Gated on Wave 1 ([parallelreturns #796](https://github.com/ssmusic/parallelreturns/pull/796), merged): never point a store's tracking button at a page that can't answer "when."

## The move

On every fulfillment carrying tracking, `fulfillmentTrackingInfoUpdate` sets the tracking URL to `https://{brand}.in.ink/r/{nfc_token}`. Shopify's schema states in its own words where that URL is rendered:

> The tracking URL is displayed in the merchant's admin on the order page. The tracking URL is displayed in the shipping confirmation email… When accounts are enabled, it's also displayed in the customer's order history.

Carrier name and tracking number are preserved verbatim in Shopify and shown on our page's meta line, still linking to the carrier. We aren't hiding the carrier — we're answering its question better than it does.

## Four refusals, each load-bearing

| refusal | why |
|---|---|
| **The feed must be provably alive** — rewrite only when the backend confirms Shippo registration | A branded page stuck on "on its way" forever is *worse* than the carrier link. **The gate needed no invention:** `PATCH /proofs/:id/tracking` already returns `shippo_registered`. |
| **Loop guard** — a URL already on `.in.ink` is a no-op | Our own mutation re-fires `FULFILLMENTS_UPDATE`; the echo dies in one hop. |
| **Kill switches** — env `BRANDED_TRACKING_LINK_DISABLED`, per-merchant `branded_tracking_link` | Default **ON** for every merchant per your ruling. Absence reads as ON; only an explicit `false` refuses. |
| **`notifyCustomer: false`** | Rewriting a link must never re-send a shipping email to a buyer who already got one. |

**No silent caps:** every skipped carrier logs its `tracking_company` string, so the expansion list for `shippoCarriers.js` gets written by observation rather than guesswork. **Stated plainly: that instrument currently measures nothing.** Both installs are test rigs shipping Shippo test tokens, so there is no real carrier mix to learn yet. The log is built now because it is nearly free to build now and impossible to backfill later — the gate itself earns its place today by refusing to point a buyer at a page that cannot update.

## The 3PL gap, fixed on the way past

`fulfillments/update` ignored everything except `out_for_delivery`/`delivered`. So a fulfillment created **empty** and given tracking a moment later — the normal 3PL and ShipStation shape — never reached the backend at all: `fulfillments/create` had already fired with nothing to forward, and nothing fired after. Those orders' pages could never answer "where is it," however healthy the rest of the pipe was. The tracking hop now runs *before* the status gate, with the order query and merchant read memoized so two jobs don't spend two API calls on one order.

## One author for the buyer URL

`brand-page-url.server.ts` is **extracted** from `state-email.server.ts`, not copied — an email and a tracking button resolving the same order must not be able to drift to two different pages. state-email now consumes it, so the backend-doc merge that fixed #1016's sender has exactly one implementation.

## Merchant control

Settings → Delivery → **Tracking link**: "Send tracking clicks to your order page." Default on. Endpoint follows the `app.api.settings.delivery-mode.tsx` precedent exactly.

## Verification — what is proven, and what isn't

**Proven here:** `npm run typecheck` ✅ · `npm run build` (real react-router build) ✅ · lint delta is only the repo's existing house style (`any` in catch blocks, firestore default-import), no new rule classes · **the mutation validated against the live Shopify Admin 2025-10 schema** — well-formed, not deprecated, and matching the schema's own `number`↔`url` / `numbers`↔`urls` pairing rule (a rewrite with no tracking number is now refused rather than sent malformed).

**Not proven, and can't be before merge:** the webhook path only runs on a deployed app, and merging *is* the deploy. So the Steve Madden run (`sm-test-hhawzn52`, real login, never the gate demo's mock token) is the **post-merge** gate, not a claim made here. Since that store is a test rig, this is a cheap thing to do and an easy thing to undo — deploy, fulfill one order, look — fulfill with tracking → admin order page link and order-status "Track shipment" both land on `{brand}.in.ink/r/{token}`, no notification email fired, webhook logs show the loop guard no-op on the echo. Happy to drive that with you the moment it's live, and to revert on the spot if any of it disagrees.

## Known, accepted limitation

The shipping-confirmation email is composed at fulfillment-creation moment. When a merchant's flow attaches tracking and notifies in one shot, that first email's inline tracking link may carry the carrier URL — our rewrite lands seconds later. The default template's main CTA is the order-status page, which reads the *current* URL → ours.

## Not in this PR

The `shippoCarriers.js` expansion (4 of 68 tokens mapped) stays its own backend PR per your ruling — different repo, needs your deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
