### PR TITLE
The outbox canary — and the first test gate this repo has ever had

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,59 @@
+# Types and tests, on every PR and every push to main.
+#
+# THIS REPO HAD NO TEST GATE AT ALL. Its only automated checks were the deploy
+# workflow (which runs after main already moved) and the merge-gate comment.
+# `typecheck` and `build` cannot tell whether the Shopify outbox actually
+# rewrites a tracking link — so the promise that a buyer's shipping email
+# carries the brand's page had nothing watching it. The sibling repo learned
+# what that costs on 2026-07-20: a correct change turned the product off for
+# seventeen days, green the whole way, because every gate asked about code
+# shape and none asked whether the product still worked.
+#
+# So this runs the canary (app/services/branded-tracking-link.canary.test.ts)
+# on the commit that would break it.
+#
+# LINT IS DELIBERATELY NOT HERE YET. It reports ~397 pre-existing problems on
+# main by house convention; adding it now would make this workflow red on day
+# one and train everyone to ignore it. Land it as its own PR once the baseline
+# is driven to zero — the same order the sibling repo used.
+name: Checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  # A newer commit supersedes an in-flight check of an older one, but never
+  # cancels a deploy (that workflow owns its own group).
+  group: checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show the commit under test
+        run: echo "Testing ${{ github.sha }}"
+
+      # package.json engines allows >=20.19 <22 || >=22.12. Node 22 satisfies
+      # the upper branch and matches the sibling repo, so both CIs sit on the
+      # same side of the WebSocket/global line.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      # From the committed lockfile, never a resolved-fresh tree: a canary that
+      # passes against different dependencies than production ships is not a
+      # canary.
+      - run: npm ci
+
+      - name: Types
+        run: npm run typecheck
+
+      - name: Tests
+        run: npm test

--- a/app/services/branded-tracking-link.canary.test.ts
+++ b/app/services/branded-tracking-link.canary.test.ts
@@ -1,0 +1,214 @@
+// THE OUTBOX CANARY — the promise that Shopify's own emails carry the brand.
+//
+// WHY THIS FILE IS THE FIRST TEST IN THE REPO. Until now this repo had NO
+// test runner: typecheck, build and lint were the only gates. All three can
+// be green while `fulfillmentTrackingInfoUpdate` is never called, called with
+// a malformed input Shopify rejects, or called on a fulfillment whose carrier
+// feed is dead — and the only way anyone would find out is a buyer clicking
+// "track your shipment" and landing somewhere wrong. The sibling repo learned
+// this the expensive way on 2026-07-20: a correct change turned the product
+// off for seventeen days behind green gates, because every gate asked about
+// code shape and none asked whether the promise still held.
+//
+// WHAT IT GUARDS. `assertBrandedTrackingUrl` is the whole auto-link decision:
+// four refusals that are each load-bearing, plus one mutation whose shape
+// Shopify's schema is strict about. Every branch is exercised here against an
+// injected `admin.graphql`, so this runs with no Shopify login, no network and
+// no store — which is exactly why it can run on every push.
+//
+// WHAT IT CANNOT GUARD, stated plainly so nobody mistakes green for proof:
+// this tests that we ASK Shopify correctly. It cannot tell you the URL landed
+// in a real buyer's inbox — that needs a real fulfillment on a real store
+// (Clare V / Steve Madden, `SHIPPO_TRANSIT` in test mode). Unit-green plus a
+// live staged fulfillment is the pair; neither alone is the promise.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { assertBrandedTrackingUrl, isBrandedTrackingUrl } from "./branded-tracking-link.server";
+
+vi.mock("./brand-page-url.server", () => ({
+  resolveBrandPageUrl: vi.fn(async () => ({
+    pageUrl: "https://clarev.in.ink/r/nfc_test_token",
+    nfcToken: "nfc_test_token",
+    brandSlug: "clarev",
+  })),
+}));
+
+/** A fake Shopify admin that records what we asked it, and answers how the
+ *  real one does. The recording IS the assertion for the mutation shape. */
+function fakeAdmin(response: unknown = { data: { fulfillmentTrackingInfoUpdate: { userErrors: [] } } }) {
+  const calls: Array<{ query: string; variables: Record<string, unknown> }> = [];
+  return {
+    calls,
+    graphql: vi.fn(async (query: string, opts?: { variables?: Record<string, unknown> }) => {
+      calls.push({ query, variables: opts?.variables ?? {} });
+      return { json: async () => response } as unknown as Response;
+    }),
+  };
+}
+
+const FULFILLMENT = {
+  id: 998877,
+  tracking_company: "UPS",
+  tracking_number: "1Z999AA10123456784",
+};
+
+const base = () => ({
+  shop: "clarev-test.myshopify.com",
+  payload: { ...FULFILLMENT },
+  proofId: "proof_abc",
+  merchantApiKey: "key",
+  merchantData: {} as Record<string, unknown>,
+  shippoRegistered: true,
+});
+
+let logs: string[] = [];
+beforeEach(() => {
+  logs = [];
+  vi.spyOn(console, "log").mockImplementation((...a) => void logs.push(a.join(" ")));
+  vi.spyOn(console, "warn").mockImplementation((...a) => void logs.push(a.join(" ")));
+  vi.spyOn(console, "error").mockImplementation((...a) => void logs.push(a.join(" ")));
+  delete process.env.BRANDED_TRACKING_LINK_DISABLED;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.BRANDED_TRACKING_LINK_DISABLED;
+});
+
+describe("the outbox canary — the happy path actually rewrites the link", () => {
+  it("points Shopify's tracking URL at the brand page and says so", async () => {
+    const admin = fakeAdmin();
+    const result = await assertBrandedTrackingUrl({ admin, ...base() });
+
+    expect(result.outcome).toBe("updated");
+    expect(result.url).toBe("https://clarev.in.ink/r/nfc_test_token");
+    expect(admin.graphql).toHaveBeenCalledOnce();
+  });
+
+  it("sends the exact input shape Shopify's schema demands", async () => {
+    const admin = fakeAdmin();
+    await assertBrandedTrackingUrl({ admin, ...base() });
+    const { variables } = admin.calls[0];
+
+    // The gid form — a bare numeric id is rejected by the mutation.
+    expect(variables.fulfillmentId).toBe("gid://shopify/Fulfillment/998877");
+
+    const input = variables.trackingInfoInput as Record<string, unknown>;
+    // THE SCHEMA'S OWN RULE: `url` pairs with `number`, `urls` with `numbers`,
+    // and the two forms are never mixed. Mixing them is a malformed write.
+    expect(input.number).toBe("1Z999AA10123456784");
+    expect(input.url).toBe("https://clarev.in.ink/r/nfc_test_token");
+    expect(input.numbers).toBeUndefined();
+    expect(input.urls).toBeUndefined();
+    // THE CARRIER IS PRESERVED. We are not hiding the carrier, we are
+    // answering its question better — the number and company stay visible.
+    expect(input.company).toBe("UPS");
+
+    // NO SILENT NOTIFICATION: rewriting a link must never re-send a shipping
+    // email to a buyer who already got one.
+    expect(variables.notifyCustomer).toBe(false);
+  });
+
+  it("a multi-parcel fulfillment uses the plural form, one page per number", async () => {
+    const admin = fakeAdmin();
+    await assertBrandedTrackingUrl({
+      admin,
+      ...base(),
+      payload: { ...FULFILLMENT, tracking_number: undefined, tracking_numbers: ["A1", "B2"] },
+    });
+    const input = admin.calls[0].variables.trackingInfoInput as Record<string, unknown>;
+
+    expect(input.numbers).toEqual(["A1", "B2"]);
+    expect(input.urls).toEqual([
+      "https://clarev.in.ink/r/nfc_test_token",
+      "https://clarev.in.ink/r/nfc_test_token",
+    ]);
+    expect(input.number).toBeUndefined();
+    expect(input.url).toBeUndefined();
+  });
+});
+
+describe("the outbox canary — every refusal holds, and none of them writes", () => {
+  const refuses = async (over: Record<string, unknown>, expected: string) => {
+    const admin = fakeAdmin();
+    const result = await assertBrandedTrackingUrl({ admin, ...base(), ...over });
+    expect(result.outcome).toBe(expected);
+    // The whole point of a refusal is that Shopify is left alone.
+    expect(admin.graphql).not.toHaveBeenCalled();
+    return result;
+  };
+
+  it("the env kill switch turns it off everywhere", async () => {
+    process.env.BRANDED_TRACKING_LINK_DISABLED = "1";
+    await refuses({}, "skipped_disabled_env");
+  });
+
+  it("a merchant who switched it off keeps Shopify's link", async () => {
+    await refuses({ merchantData: { branded_tracking_link: false } }, "skipped_disabled_merchant");
+  });
+
+  it("THE LOOP GUARD: our own mutation's echo is a no-op", async () => {
+    // Our rewrite re-fires FULFILLMENTS_UPDATE. Without this the webhook
+    // would rewrite its own rewrite, forever.
+    await refuses(
+      { payload: { ...FULFILLMENT, tracking_url: "https://clarev.in.ink/r/nfc_test_token" } },
+      "skipped_already_branded",
+    );
+  });
+
+  it("A DEAD FEED KEEPS THE CARRIER'S LINK — and names the carrier it skipped", async () => {
+    // A branded page that says "on its way" forever is WORSE than the carrier
+    // link: it burns the one impression this exists to win.
+    const result = await refuses({ shippoRegistered: false }, "skipped_feed_unregistered");
+    expect(result.detail).toBe("UPS");
+    // The skip log is the expansion list for shippoCarriers.js — a silent
+    // skip would make the real carrier mix invisible.
+    expect(logs.join("\n")).toContain("UPS");
+  });
+
+  it("no tracking number means no rewrite — a url without a number is malformed", async () => {
+    await refuses(
+      { payload: { id: 998877, tracking_company: "UPS" } },
+      "skipped_no_page_url",
+    );
+  });
+
+  it("no fulfillment id means there is nothing to address", async () => {
+    await refuses({ payload: { tracking_number: "A1", tracking_company: "UPS" } }, "skipped_no_fulfillment_id");
+  });
+});
+
+describe("the outbox canary — Shopify's own failures never break the webhook", () => {
+  it("userErrors are reported, not thrown", async () => {
+    const admin = fakeAdmin({
+      data: { fulfillmentTrackingInfoUpdate: { userErrors: [{ field: ["trackingInfoInput"], message: "invalid" }] } },
+    });
+    const result = await assertBrandedTrackingUrl({ admin, ...base() });
+    expect(result.outcome).toBe("failed");
+    expect(result.detail).toContain("invalid");
+  });
+
+  it("a thrown request is non-fatal — the webhook must still return 200", async () => {
+    const admin = {
+      graphql: vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    };
+    const result = await assertBrandedTrackingUrl({ admin, ...base() });
+    expect(result.outcome).toBe("failed");
+    expect(result.detail).toContain("network down");
+  });
+});
+
+describe("isBrandedTrackingUrl — the loop guard's own edges", () => {
+  it("recognises our hosts and only ours", () => {
+    expect(isBrandedTrackingUrl("https://clarev.in.ink/r/tok")).toBe(true);
+    expect(isBrandedTrackingUrl("https://www.in.ink/r/tok")).toBe(true);
+    expect(isBrandedTrackingUrl("https://in.ink")).toBe(true);
+    expect(isBrandedTrackingUrl("https://ups.com/track?n=1")).toBe(false);
+    expect(isBrandedTrackingUrl("")).toBe(false);
+    expect(isBrandedTrackingUrl(null)).toBe(false);
+    // A lookalike domain must NOT read as ours, or a hostile link would
+    // silently disable the rewrite for that fulfillment.
+    expect(isBrandedTrackingUrl("https://not-in.ink.example.com/x")).toBe(false);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,8 @@
         "tailwindcss": "^3.4.19",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.9.3",
-        "vite": "^6.3.6"
+        "vite": "^6.3.6",
+        "vitest": "^3.2.7"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
@@ -5929,10 +5930,28 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/eslint": {
@@ -6584,6 +6603,135 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@web3-storage/multipart-parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
@@ -7062,6 +7210,16 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
@@ -7598,6 +7756,23 @@
         "upper-case-first": "^2.0.2"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7661,6 +7836,16 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -8193,6 +8378,16 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -9259,6 +9454,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -9297,6 +9502,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -11872,6 +12087,13 @@
       "integrity": "sha512-SqD/Bg3ZfltBJ2Z14hJ/BihnvtV553WO4g9/ePtlp4lrnl9jF3AdIJt53A/Wkg/0Li+LMfxaBqgx1MiFZdQlpQ==",
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -11936,6 +12158,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/map-cache": {
@@ -12917,6 +13149,16 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -14261,6 +14503,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -14412,6 +14661,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -14420,6 +14676,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -14676,6 +14939,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strnum": {
       "version": "2.1.2",
@@ -15039,6 +15322,20 @@
         "node": ">=16"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -15082,6 +15379,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/title-case": {
@@ -15873,6 +16200,99 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -16060,6 +16480,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "shopify": "shopify",
     "graphql-codegen": "graphql-codegen",
     "vite": "vite",
-    "typecheck": "react-router typegen && tsc --noEmit"
+    "typecheck": "react-router typegen && tsc --noEmit",
+    "test": "vitest run"
   },
   "type": "module",
   "engines": {
@@ -86,7 +87,8 @@
     "tailwindcss": "^3.4.19",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.9.3",
-    "vite": "^6.3.6"
+    "vite": "^6.3.6",
+    "vitest": "^3.2.7"
   },
   "workspaces": [
     "extensions/*"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+// Vitest for the embed. This repo shipped with NO test runner at all — its
+// only gates were typecheck, build and lint, none of which can tell whether
+// the Shopify outbox actually rewrites a tracking link. See
+// app/services/branded-tracking-link.canary.test.ts for why that mattered.
+//
+// Deliberately NOT wired through vite.config.ts: that config exists to serve
+// the Shopify app (HMR hosts, tunnel URLs, the react-router plugin) and
+// loading it under test drags the whole app pipeline in. Tests here are pure
+// server-module tests, so they get a plain node environment and nothing else.
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["app/**/*.{test,canary.test}.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
## Why

Sam: *"that repo has no test runner at all."* It didn't. `typecheck`, `build` and `lint` were the only gates — and none of them can tell whether `fulfillmentTrackingInfoUpdate` is ever called, called with an input Shopify rejects, or called on a fulfillment whose carrier feed is dead. The only way anyone finds out is a buyer clicking "track your shipment" and landing somewhere wrong.

The sibling repo learned what that costs on 2026-07-20: a correct, careful change turned matching off for **seventeen days**, green the whole way, because every gate asked about *code shape* and none asked whether the promise still held.

## What lands

- **vitest** — Vite 6 was already a dependency, so it drops in. Its own `vitest.config.ts`, deliberately not `vite.config.ts`, which exists to serve the Shopify app (HMR hosts, tunnel URLs, the react-router plugin) and would drag that whole pipeline into a pure server-module test.
- **`npm test`**.
- **`.github/workflows/checks.yml`** — typecheck + tests on every PR and every push to main, `npm ci` from the committed lockfile, echoing the SHA under test, `cancel-in-progress` scoped so it never touches the deploy workflow's group.

## What the canary covers

`assertBrandedTrackingUrl`, end to end, against an injected `admin.graphql` — no login, no network, no store, so it runs on every push:

- the rewrite happens and returns the brand page URL;
- **the mutation shape Shopify's schema is strict about** — `gid://` form; `url` pairs with `number`, `urls` with `numbers`, never mixed; carrier company and number preserved verbatim;
- **`notifyCustomer` stays `false`** — a rewrite must never re-send a shipping email to a buyer who already got one;
- multi-parcel takes the plural form, one page per number;
- **all six refusals hold *and* leave Shopify untouched**: env kill switch, per-merchant switch, the loop guard against our own mutation's echo, the dead-feed skip (which must also *name* the carrier — that log is the expansion list for `shippoCarriers.js`), no tracking number, no fulfillment id;
- `userErrors` and thrown requests are non-fatal, so the webhook still returns 200.

## Proven to catch its bugs

The standard the sibling canaries set — verify it fails before letting it pass:

| injected regression | result |
|---|---|
| `notifyCustomer: true` (would re-spam buyers) | **red** |
| dead-feed gate removed (would point at a silent page) | **red** |

## What it cannot prove

Stated in the file so nobody mistakes green for done: this tests that we **ask Shopify correctly**. It cannot show the URL reached a real buyer's inbox. That needs a staged fulfillment on a real test store (Clare V / Steve Madden, tracking number `SHIPPO_TRANSIT` in test mode) — Sam's to run. The pair is unit-green **plus** that live walk.

## Lint

Deliberately not in the workflow: ~397 pre-existing problems on main by house convention. Landing it now would be red on day one and train everyone to ignore the gate. Its own PR, once the baseline is zero — the same order the sibling repo used.

## Gate

`npm run typecheck` · `npm test` (12 passing) · `npm run build` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)