### PR TITLE
The auto-link asks for the fulfillments merchants actually make

### DIFF
--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -81,7 +81,29 @@ api_version = "2025-10"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "read_assigned_fulfillment_orders,write_assigned_fulfillment_orders,read_customers,read_files,write_files,read_fulfillments,write_fulfillments,read_metaobjects,write_metaobjects,read_online_store_pages,write_online_store_pages,read_orders,write_orders,write_shipping,write_themes"
+#
+# THE THREE FULFILLMENT-ORDER SCOPES ARE NOT INTERCHANGEABLE, and holding only
+# the first one is why the branded tracking link had never rewritten a single
+# real fulfillment. They partition by WHO FULFILLS:
+#
+#   · assigned         — fulfillment orders routed to US as a fulfillment
+#                        service. We are not one, so this covers nothing that
+#                        actually happens.
+#   · merchant_managed — the merchant fulfilling at their OWN location. This
+#                        is the ordinary case and it is most of Shopify.
+#   · third_party      — a 3PL / external service (ShipStation and friends).
+#
+# `fulfillmentTrackingInfoUpdate` accepts ANY ONE of the three, so with only
+# `assigned` every real rewrite came back:
+#     "The api_client does not have access to the fulfillment."
+# Measured live on Steve Madden order #1018, 2026-08-07, fulfilled by hand from
+# Shop location — the most ordinary fulfillment there is. Wave 2 shipped,
+# deployed green, and could not have worked for anyone.
+#
+# ADDING THESE COSTS MERCHANT RE-CONSENT. Shopify re-prompts every installed
+# store on a scope change. Doing it now, with two test stores installed, costs
+# nothing; doing it after real merchants install costs each of them a prompt.
+scopes = "read_assigned_fulfillment_orders,write_assigned_fulfillment_orders,read_merchant_managed_fulfillment_orders,write_merchant_managed_fulfillment_orders,read_third_party_fulfillment_orders,write_third_party_fulfillment_orders,read_customers,read_files,write_files,read_fulfillments,write_fulfillments,read_metaobjects,write_metaobjects,read_online_store_pages,write_online_store_pages,read_orders,write_orders,write_shipping,write_themes"
 optional_scopes = [ ]
 use_legacy_install_flow = false
 


### PR DESCRIPTION
## Wave 2 shipped, deployed green, and could not have worked for anyone

Measured live tonight on Steve Madden order **#1018** — fulfilled by hand from **Shop location**, the most ordinary fulfillment there is. From Cloud Run:

```
🔗 branded-tracking-link: Shopify refused the rewrite —
   trackingInfoInput: The api_client does not have access to the fulfillment.
```

**It is not an ownership rule.** Shopify's docs say nothing about needing to have *created* the fulfillment. `fulfillmentTrackingInfoUpdate` accepts any **one** of three scopes, and they partition by *who fulfills*:

| scope | covers | held before |
|---|---|---|
| `write_assigned_fulfillment_orders` | orders routed to **us** as a fulfillment service — we aren't one, so nothing real | ✅ |
| `write_merchant_managed_fulfillment_orders` | the merchant fulfilling at **their own location** — the ordinary case, most of Shopify | ❌ |
| `write_third_party_fulfillment_orders` | a **3PL / external service** | ❌ |

We held only the first. Every rewrite against a real fulfillment was refused.

**Why nobody caught it:** the carrier-feed bug (fixed in the backend earlier tonight) refused *first*, so the mutation was never reached and this error never surfaced. Two bugs stacked, the outer hiding the inner — the same shape as the matching regression.

This adds `merchant_managed` and `third_party`, read and write. It also settles the ShipStation question: a 3PL route needs `third_party`, so **neither missing scope is optional** if this is to work for real merchants.

## Not pushed to Shopify — this one is Sam's

A scope change **re-prompts every installed store for consent** (CLAUDE.md law 2: merchant re-consent). Pushing app config is `shopify app config push` from this toml, and that's Sam's call and Sam's hands.

Timing is in our favour: **two test stores are installed today**, so re-consent costs nothing now and one prompt per merchant later.

## Verification

`npm run typecheck` clean · `npm test` 12 passing (the outbox canary — which, note, could never have caught this: it proves we *ask Shopify correctly*, and the ask was correct; the app just wasn't allowed to make it. The gap is named in that file's own "what it cannot guard" section).

## New surfaces

**None.** Configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)