### PR TITLE
Send the two URLs that were already sitting there

### DIFF
--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -2,6 +2,7 @@ import type { ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
 import { enrollOrder, createMerchant } from "../services/ink-api.server";
+import { productDetailFromLineItem } from "../services/order-line-item";
 
 /**
  * Look up the merchant's verified-delivery mode preference.
@@ -97,6 +98,11 @@ const ORDER_DETAIL_QUERY = `
             sku
             originalUnitPriceSet { shopMoney { amount } }
             image { url }
+            # The product's public storefront page. onlineStoreUrl is null for
+            # a product not published to the Online Store channel, which is the
+            # honest answer — the tap page hides the link rather than sending a
+            # buyer somewhere that 404s.
+            product { onlineStoreUrl }
           }
         }
       }
@@ -244,13 +250,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
             String(data?.id ?? "").replace(/\D/g, "") ||
             String(order.name ?? "").replace(/\D/g, "");
           const lineItems = (order.lineItems?.edges || []).map((e: any) => e.node);
-          const product_details = lineItems.map((n: any) => ({
-            name: n.title,
-            sku: n.sku || "",
-            quantity: n.quantity ?? 1,
-            price: n.originalUnitPriceSet?.shopMoney?.amount ?? "0",
-            image_url: n.image?.url || null,
-          }));
+          const product_details = lineItems.map(productDetailFromLineItem);
           const addr = order.shippingAddress;
           // Recipient/customer name — Alan's order mapper reads
           // shipping_address.name as the customer name fallback, so carry it
@@ -303,7 +303,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
               undefined, // photo_hashes
               carrier_name,
               tracking_number,
-              finalPhone || order.customer?.phone || null
+              finalPhone || order.customer?.phone || null,
+              // The buyer's own order-status page on the merchant's site.
+              // Shopify has always sent it in this body; we never read it.
+              { orderStatusUrl: data?.order_status_url || null, shopDomain: shop || null }
             );
 
           let inkData: any;

--- a/app/services/enroll-order-status-url.test.ts
+++ b/app/services/enroll-order-status-url.test.ts
@@ -1,0 +1,124 @@
+// SHOPIFY HAS BEEN SENDING US THIS THE WHOLE TIME.
+//
+// The orders/create webhook body carries `order_status_url` — the buyer's own
+// order-status page on the merchant's site, no login required. We never read
+// it, so no proof has ever held one, and the tap page has had no honest way to
+// offer "view your order".
+//
+// Nothing downstream needed changing to accept it: the backend's validation
+// spreads unknown keys and the serializer emits the whole order_details object,
+// so a field added here reaches the customer wire for free.
+//
+// What this file guards is the ABSENCE rule. The tap page hides the link when
+// the field is missing (law 7 — the Clare-V law), and it can only do that if
+// missing means MISSING. An empty string would render a dead door, and the
+// entire existing order base — including both live rigs — will never have this
+// field, so the absent case is the common one, not the edge one.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn();
+
+function lastPayload(): any {
+  const [, init] = fetchMock.mock.calls.at(-1) as [string, RequestInit];
+  return JSON.parse(String(init.body));
+}
+
+beforeEach(() => {
+  // The module throws at import time without this (ink-api.server.ts:5).
+  vi.stubEnv("INK_ADMIN_SECRET", "test-secret");
+  vi.stubEnv("INK_API_URL", "https://api.test");
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify({ proof_id: "proof_1" }),
+    json: async () => ({ proof_id: "proof_1" }),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+async function enroll(orderContext?: {
+  orderStatusUrl?: string | null;
+  shopDomain?: string | null;
+}) {
+  const { enrollOrder } = await import("./ink-api.server");
+  await enrollOrder(
+    "key_1",
+    "1018",
+    "nfc_tok_1",
+    "#1018",
+    "dana@example.com",
+    { name: "Dana Ruiz", city: "Austin" },
+    [{ title: "Lanyard Tote", qty: 1 }],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    "UPS",
+    "1Z999",
+    null,
+    orderContext,
+  );
+}
+
+describe("what enroll tells the backend about the order", () => {
+  it("carries the buyer's order-status page when Shopify sent one", async () => {
+    await enroll({
+      orderStatusUrl: "https://sm-test-hhawzn52.myshopify.com/orders/abc123",
+      shopDomain: "sm-test-hhawzn52.myshopify.com",
+    });
+
+    expect(lastPayload().order_details.order_status_url).toBe(
+      "https://sm-test-hhawzn52.myshopify.com/orders/abc123",
+    );
+  });
+
+  it("carries the real shop domain alongside it", async () => {
+    // proof.merchant and proof.shop_id are BOTH the merchant_id — despite the
+    // comment on the former saying `shop_domain` — so nothing on the wire has
+    // ever held the actual host.
+    await enroll({ orderStatusUrl: "https://x.test/o/1", shopDomain: "sm-test-hhawzn52.myshopify.com" });
+
+    expect(lastPayload().order_details.shop_domain).toBe("sm-test-hhawzn52.myshopify.com");
+  });
+
+  it("OMITS the field entirely when Shopify sent nothing — never an empty string", async () => {
+    await enroll({ orderStatusUrl: null, shopDomain: null });
+
+    const details = lastPayload().order_details;
+    expect("order_status_url" in details).toBe(false);
+    expect("shop_domain" in details).toBe(false);
+  });
+
+  it("omits it when no context is passed at all", async () => {
+    // The warehouse and tagged-shipments enroll paths don't pass one. They must
+    // keep sending byte-identical payloads.
+    await enroll(undefined);
+
+    const details = lastPayload().order_details;
+    expect("order_status_url" in details).toBe(false);
+    expect("shop_domain" in details).toBe(false);
+  });
+
+  it("leaves the rest of the payload exactly as it was", async () => {
+    await enroll({ orderStatusUrl: "https://x.test/o/1", shopDomain: "x.test" });
+    const payload = lastPayload();
+
+    expect(payload.order_id).toBe("1018");
+    expect(payload.nfc_token).toBe("nfc_tok_1");
+    expect(payload.carrier_name).toBe("UPS");
+    expect(payload.tracking_number).toBe("1Z999");
+    expect(payload.order_details.order_number).toBe("#1018");
+    expect(payload.order_details.customer_name).toBe("Dana Ruiz");
+    expect(payload.order_details.customer_email).toBe("dana@example.com");
+    expect(payload.order_details.product_details).toEqual([
+      { title: "Lanyard Tote", qty: 1 },
+    ]);
+  });
+});

--- a/app/services/ink-api.server.ts
+++ b/app/services/ink-api.server.ts
@@ -254,7 +254,12 @@ export const enrollOrder = async (
     photoHashes?: string[],
     carrierName?: string | null,
     trackingNumber?: string | null,
-    customerPhone?: string | null
+    customerPhone?: string | null,
+    // WHERE THE BUYER CAN SEE THIS ORDER ON THE MERCHANT'S OWN SITE.
+    // An options bag rather than two more positional args — this signature is
+    // already fourteen deep, and the two other enroll call sites (warehouse,
+    // tagged-shipments) simply don't pass it and are unaffected.
+    orderContext?: { orderStatusUrl?: string | null; shopDomain?: string | null }
 ) => {
     // Alan's API was changed to require order details nested in an
     // `order_details` JSON object rather than as separate top-level fields.
@@ -281,6 +286,26 @@ export const enrollOrder = async (
             product_details: productDetails,
         },
     };
+
+    // Shopify's orders/create body has always carried `order_status_url` — the
+    // buyer's own order-status page, no login required. We simply never read
+    // it, so no proof has ever held one and the tap page has had no honest way
+    // to say "view your order". Nothing downstream needs changing to accept it:
+    // the backend's validation spreads unknown keys and the serializer emits
+    // the whole object, so it reaches the customer wire for free.
+    //
+    // Only stamped when present — an absent field must stay absent rather than
+    // become an empty string, because the page hides the link on absence and
+    // "" would render a dead one (law 7).
+    if (orderContext?.orderStatusUrl) {
+        payload.order_details.order_status_url = orderContext.orderStatusUrl;
+    }
+    // The real shop domain, alongside it. `proof.merchant` and `proof.shop_id`
+    // are BOTH the merchant_id despite the comment on the former saying
+    // shop_domain, so nothing on the wire has ever carried the actual host.
+    if (orderContext?.shopDomain) {
+        payload.order_details.shop_domain = orderContext.shopDomain;
+    }
 
     if (warehouseLocation) payload.warehouse_location = warehouseLocation;
     if (nfcUid) payload.nfc_uid = nfcUid;

--- a/app/services/order-line-item.ts
+++ b/app/services/order-line-item.ts
@@ -1,0 +1,31 @@
+/** One Shopify line item, in the shape the enroll payload wants.
+ *
+ *  A pure mapper, and it lives here rather than in the webhook route so it can
+ *  be tested without standing up Shopify's app config — importing the route
+ *  pulls in shopify.server.ts, which throws on an empty appUrl.
+ *
+ *  `product_url` is the addition (2026-08-08). The customer wire has carried a
+ *  `product_url` field on line items for a long time — the adapter already
+ *  forwards it, `LineItem` declares it, the tap page can read it — and this
+ *  mapping never filled it. So it has been null on EVERY Shopify-enrolled
+ *  order, and "view this product" was unbuildable for a reason nobody could
+ *  see. Measured, not assumed: the 60-proof Taylor Stitch live corpus carries
+ *  zero product_urls.
+ *
+ *  Same shape as the sku/product_type drop (#820): a field that exists at both
+ *  ends and is dropped in the middle is invisible to tsc, the suite and review.
+ */
+export function productDetailFromLineItem(n: any) {
+  return {
+    name: n?.title,
+    sku: n?.sku || "",
+    quantity: n?.quantity ?? 1,
+    price: n?.originalUnitPriceSet?.shopMoney?.amount ?? "0",
+    image_url: n?.image?.url || null,
+    // Omitted, never "", when the product has no storefront page:
+    // onlineStoreUrl is null for a product not published to the Online Store
+    // channel, and that is the honest answer. The tap page hides the link on
+    // absence (law 7), which only works if absent means absent.
+    ...(n?.product?.onlineStoreUrl ? { product_url: n.product.onlineStoreUrl } : {}),
+  };
+}

--- a/app/services/product-url-capture.test.ts
+++ b/app/services/product-url-capture.test.ts
@@ -1,0 +1,74 @@
+// A TYPED FIELD NOBODY SERVED.
+//
+// The customer wire has carried `product_url` on line items for a long time —
+// the adapter forwards it, `LineItem` declares it, the tap page can read it —
+// and this webhook never filled it. So it has been null on every
+// Shopify-enrolled order, and "view this product" was unbuildable for a reason
+// nobody could see. Measured, not assumed: the 60-proof Taylor Stitch live
+// corpus carries ZERO product_urls.
+//
+// Same shape as the sku/product_type drop (#820) and the third instance of it:
+// a field that exists at both ends and is dropped in the middle is invisible to
+// tsc, the suite and review.
+
+import { describe, expect, it } from "vitest";
+import { productDetailFromLineItem } from "./order-line-item";
+
+const node = (over: Record<string, unknown> = {}) => ({
+  title: "Lanyard Tote",
+  sku: "LT-001",
+  quantity: 2,
+  originalUnitPriceSet: { shopMoney: { amount: "128.00" } },
+  image: { url: "https://cdn.shopify.com/tote.jpg" },
+  ...over,
+});
+
+describe("what a line item tells the proof", () => {
+  it("carries the product's own storefront page", () => {
+    const out = productDetailFromLineItem(
+      node({ product: { onlineStoreUrl: "https://stevemadden.com/products/lanyard-tote" } }),
+    );
+
+    expect(out.product_url).toBe("https://stevemadden.com/products/lanyard-tote");
+  });
+
+  it("OMITS it when the product isn't published to the storefront", () => {
+    // onlineStoreUrl is null for a product not on the Online Store channel.
+    // Absent is the honest answer, and the tap page hides the link on absence
+    // (law 7) — which only works if absent means absent, never "".
+    const out = productDetailFromLineItem(node({ product: { onlineStoreUrl: null } }));
+
+    expect("product_url" in out).toBe(false);
+  });
+
+  it("omits it when Shopify sends no product at all", () => {
+    const out = productDetailFromLineItem(node());
+
+    expect("product_url" in out).toBe(false);
+  });
+
+  it("leaves the commerce evidence exactly as it was", () => {
+    // The sku/product_type drop cost a release. Nothing else moves here.
+    const out = productDetailFromLineItem(node());
+
+    expect(out).toEqual({
+      name: "Lanyard Tote",
+      sku: "LT-001",
+      quantity: 2,
+      price: "128.00",
+      image_url: "https://cdn.shopify.com/tote.jpg",
+    });
+  });
+
+  it("keeps its nerve on a half-empty node", () => {
+    const out = productDetailFromLineItem({ title: "Bare" });
+
+    expect(out).toEqual({
+      name: "Bare",
+      sku: "",
+      quantity: 1,
+      price: "0",
+      image_url: null,
+    });
+  });
+});


### PR DESCRIPTION
Two links back to the merchant's own site, neither of which we were capturing.

## Order status
Shopify's `orders/create` body carries **`order_status_url`** — the buyer's own
order-status page, no login required. The handler never read it, so no proof
holds one and the tap page has had no honest way to offer "view your order".

`shop_domain` rides along: `proof.merchant` and `proof.shop_id` are **both** the
merchant_id — despite the comment on the former saying `shop_domain` — so
nothing on the wire has ever held the actual host.

## Product URL — and the plan was wrong about this one

The plan said `LineItem.product_url` *"survives end-to-end"* and a "view this
product" link was buildable today. **It is not.** The adapter forwards the
field, the type declares it, the tap page can read it — and this webhook never
filled it, so it has been `null` on every Shopify-enrolled order.

Measured, not assumed: the 60-proof Taylor Stitch live corpus carries **zero**
product_urls. The GraphQL selection now asks for `product { onlineStoreUrl }`
and the mapper forwards it.

That is the **third** instance of the sku/product_type class (#820): a field
that exists at both ends and is dropped in the middle is invisible to tsc, the
suite and review.

## Why nothing downstream changes
The backend's validation spreads unknown keys and the serializer emits the whole
`order_details` object, so both fields reach the customer wire for free. **Zero
backend change, zero deploy.**

## Absent means absent
Both are stamped only when present, never `""`. The page hides each link on
absence (law 7), which only works if missing is missing — `""` would render a
dead door. This is the common case: the entire existing order base lacks both
fields, both live rigs included, and **#1018 can never have them.**

`onlineStoreUrl` is null for a product not published to the Online Store
channel. That is the honest answer, and the link hides rather than sending a
buyer somewhere that 404s.

## Shape notes
- The line-item mapper moved to `app/services/order-line-item.ts` so it can be
  tested at all — importing the route pulls in `shopify.server.ts`, which throws
  on an empty appUrl.
- `enrollOrder` takes an options bag rather than two more positional args (the
  signature is already fourteen deep). The warehouse and tagged-shipments enroll
  paths don't pass one and their payloads stay byte-identical — asserted.

## NOT verified end-to-end, and cannot be from here
Both fields need a **fresh real order** through the webhook: re-run the REV-1
API loop on the Steve Madden rig and confirm they land in `order_details` on the
public proof wire. **This PR does not claim that.**

What *is* verified: the payloads these build (10 tests — every new-behaviour one
fails against the pre-change source, the absence rules stay green), the full
suite (42), and the real `react-router build`.

Renders the links: [ssmusic/parallelreturns#837](https://github.com/ssmusic/parallelreturns/pull/837).

🤖 Generated with [Claude Code](https://claude.com/claude-code)