### PR TITLE
One unauthorized field stopped every order enrolling, and said it worked

### DIFF
--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -2,7 +2,7 @@ import type { ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
 import { enrollOrder, createMerchant } from "../services/ink-api.server";
-import { productDetailFromLineItem } from "../services/order-line-item";
+import { attachProductUrls, productDetailFromLineItem } from "../services/order-line-item";
 
 /**
  * Look up the merchant's verified-delivery mode preference.
@@ -63,6 +63,44 @@ function genNfcToken(): string {
   return `nfc_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
 }
 
+/** Ask for the line items' storefront URLs, and never let the answer matter.
+ *
+ *  Returns an index-aligned array, or `null` when the fetch failed for ANY
+ *  reason — most importantly a missing `read_products` scope, which is the
+ *  state of every install until the scope change ships and re-consent lands.
+ *
+ *  The refusal is LOGGED, not swallowed: a fallback that hides a failure makes
+ *  the outage permanent and silent (TECH_BIBLE law 32). One line, naming the
+ *  order and the reason, so "the product link is missing" is answerable from
+ *  the logs instead of from a rebuild.
+ */
+async function fetchProductUrls(
+  admin: any,
+  orderGid: string,
+  orderName: string,
+): Promise<(string | null)[] | null> {
+  try {
+    const res = await admin.graphql(PRODUCT_URLS_QUERY, {
+      variables: { id: orderGid },
+    });
+    const json = await res.json();
+    const edges = json?.data?.order?.lineItems?.edges;
+    if (!Array.isArray(edges)) {
+      console.warn(
+        `[orders/create] product URLs unavailable for ${orderName} — enroll continues without them (no lineItems in response)`,
+      );
+      return null;
+    }
+    return edges.map((e: any) => e?.node?.product?.onlineStoreUrl ?? null);
+  } catch (err: any) {
+    console.warn(
+      `[orders/create] product URLs unavailable for ${orderName} — enroll continues without them:`,
+      err?.message || err,
+    );
+    return null;
+  }
+}
+
 const TAG_MUTATION = `
 mutation AddOrderTag($id: ID!, $tags: [String!]!) {
   tagsAdd(id: $id, tags: $tags) {
@@ -82,7 +120,24 @@ mutation SetInkMetafields($metafields: [MetafieldsSetInput!]!) {
 // Order detail fetch for auto-enroll — line items (incl. product image),
 // customer, shipping address, total, and the existing proof_reference metafield
 // (for idempotency).
-const ORDER_DETAIL_QUERY = `
+//
+// NOTHING OPTIONAL MAY RIDE THIS QUERY. It is the enroll-critical fetch: order
+// name, customer, ship-to, line items, the idempotency metafield and the
+// fulfillments all come from here, and a proof cannot be created without them.
+//
+// Shopify does not drop a field it cannot authorize — it fails the WHOLE
+// query. So one selection the app lacks a scope for takes down enrollment for
+// every order on every install, silently. That is not theory: #82 added
+// `product { onlineStoreUrl }` here on 2026-08-09, the app has never held
+// `read_products`, and real order #1019 came back
+//     "Access denied for product field. Required access: `read_products`"
+// — no proof, no metafields, no tracking-link rewrite, and the handler still
+// logged ✅ and returned 200.
+//
+// Enrichment therefore lives in PRODUCT_URLS_QUERY below, fetched separately
+// and fail-open. Adding a field to THIS query is a scope decision; treat it as
+// one. (ENGINEERING_BIBLE §17; TECH_BIBLE laws 32 + 35.)
+export const ORDER_DETAIL_QUERY = `
   query AutoEnrollOrder($id: ID!) {
     order(id: $id) {
       id
@@ -98,16 +153,33 @@ const ORDER_DETAIL_QUERY = `
             sku
             originalUnitPriceSet { shopMoney { amount } }
             image { url }
-            # The product's public storefront page. onlineStoreUrl is null for
-            # a product not published to the Online Store channel, which is the
-            # honest answer — the tap page hides the link rather than sending a
-            # buyer somewhere that 404s.
-            product { onlineStoreUrl }
           }
         }
       }
       metafield(namespace: "ink", key: "proof_reference") { value }
       fulfillments { trackingInfo { company number } }
+    }
+  }
+`;
+
+// THE ENRICHMENT, ON ITS OWN WIRE. The product's public storefront page —
+// `onlineStoreUrl` is null for a product not published to the Online Store
+// channel, which is the honest answer; the tap page hides the link rather than
+// sending a buyer somewhere that 404s.
+//
+// Requires the `read_products` scope. It is asked for separately and its
+// failure is swallowed by design, so a missing or revoked scope costs exactly
+// this link and never the enrollment.
+export const PRODUCT_URLS_QUERY = `
+  query AutoEnrollProductUrls($id: ID!) {
+    order(id: $id) {
+      lineItems(first: 20) {
+        edges {
+          node {
+            product { onlineStoreUrl }
+          }
+        }
+      }
     }
   }
 `;
@@ -181,6 +253,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   const hasPremiumDelivery = hasInkPremiumShipping(shippingLines);
 
+  // Set by the enroll catch. Non-null ⇒ suppress the success line and return
+  // 500 so Shopify retries. Declared out here because the success line lives
+  // outside the processing try/catch.
+  let enrollFailure: string | null = null;
+
   // Background enrollment: INK is hidden from checkout and never appears as a
   // customer-paid shipping option, so every order on this shop is eligible.
   const deliveryMode = await getMerchantDeliveryMode(shop);
@@ -250,7 +327,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
             String(data?.id ?? "").replace(/\D/g, "") ||
             String(order.name ?? "").replace(/\D/g, "");
           const lineItems = (order.lineItems?.edges || []).map((e: any) => e.node);
-          const product_details = lineItems.map(productDetailFromLineItem);
+          // The enrichment, on its own wire and fail-open: a scope the app does
+          // not hold costs the product link and nothing else. See
+          // PRODUCT_URLS_QUERY.
+          const product_details = attachProductUrls(
+            lineItems.map(productDetailFromLineItem),
+            await fetchProductUrls(admin, orderGid, orderName),
+          );
           const addr = order.shippingAddress;
           // Recipient/customer name — Alan's order mapper reads
           // shipping_address.name as the customer name fallback, so carry it
@@ -369,9 +452,21 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         }
       }
     } catch (enrollErr: any) {
-      console.warn(
-        `[orders/create] Auto-enroll soft-failed for ${orderName} (order still tagged):`,
-        enrollErr?.message || enrollErr
+      // NAME THE REFUSAL, AND MAKE IT COUNT. This branch used to warn and fall
+      // through to a `✅ Successfully processed` + 200, so a total enrollment
+      // failure was indistinguishable from success in the logs AND told
+      // Shopify never to retry. Order #1019 (2026-08-09) died exactly here:
+      // the order was tagged, the ✅ printed, and no proof has ever existed.
+      //
+      // `enrollFailure` is read below: it suppresses the success line and
+      // returns 500 so Shopify's at-least-once retry can land the enroll once
+      // the cause is fixed. Retry is safe — the backend dedupes on
+      // (shop_id, order_id) (ink-backend #23), and tagsAdd / metafieldsSet are
+      // both idempotent.
+      enrollFailure = enrollErr?.message || String(enrollErr);
+      console.error(
+        `❌ [orders/create] Auto-enroll FAILED for ${orderName} (order still tagged):`,
+        enrollFailure
       );
     }
 
@@ -439,6 +534,19 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       error?.message || error
     );
     return new Response("Error processing order", { status: 500 });
+  }
+
+  // A FAILED ENROLL IS NOT A PROCESSED ORDER. Saying so out loud, and asking
+  // for the retry, is the whole point: the order is tagged but has no proof,
+  // so the tap page, the receipt links and the branded tracking-link rewrite
+  // (which gates on the ink.proof_reference metafield) all have nothing to
+  // work with. 500 ⇒ Shopify redelivers; the backend's (shop_id, order_id)
+  // dedupe makes that safe.
+  if (enrollFailure) {
+    console.error(
+      `❌ [orders/create] ${orderName} NOT enrolled (mode=${deliveryMode}) — returning 500 so Shopify retries. Cause: ${enrollFailure}\n`
+    );
+    return new Response("enroll failed", { status: 500 });
   }
 
   console.log(

--- a/app/services/enroll-survives-enrichment.test.ts
+++ b/app/services/enroll-survives-enrichment.test.ts
@@ -1,0 +1,157 @@
+// NOTHING OPTIONAL RIDES THE ENROLL-CRITICAL QUERY.
+//
+// Real order #1019, 2026-08-09. PR #82 added `product { onlineStoreUrl }` to
+// ORDER_DETAIL_QUERY — the single query that feeds auto-enrollment. The app
+// has never held `read_products`, and Shopify does not omit a field it cannot
+// authorize: it fails the entire query. So the order came back
+//
+//     Access denied for product field. Required access: `read_products`
+//
+// and with it went the order name, the customer, the ship-to, the line items,
+// the idempotency metafield and the fulfillments — everything a proof is made
+// of. No proof was created. Because the failure was caught and warned, the
+// handler then printed `✅ Successfully processed` and returned 200, which
+// also told Shopify never to retry. Every new order on every install failed
+// this way, silently, for the two hours it took a human to notice the order
+// was missing from the app.
+//
+// Two independent guards, because two independent things went wrong:
+//   1. the enrichment must not be able to take enrollment down again, ever
+//      (even once the scope lands — the NEXT optional field is the risk)
+//   2. a failed enroll must say so and ask for the retry
+//
+// Both were watched failing against the pre-change source before being
+// trusted (§0.0 rule 5): guard 1 reports the `product {` selection inside
+// ORDER_DETAIL_QUERY, guard 2's attachProductUrls import does not exist.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { attachProductUrls, productDetailFromLineItem } from "./order-line-item";
+
+const ROUTE_SRC = readFileSync(
+  fileURLToPath(new URL("../routes/webhooks.orders_create.ts", import.meta.url)),
+  "utf8",
+);
+
+/** The text of one `const NAME = \`…\`;` template literal in the route. */
+function templateLiteral(name: string): string {
+  const start = ROUTE_SRC.indexOf(`${name} = \``);
+  if (start === -1) throw new Error(`${name} not found in webhooks.orders_create.ts`);
+  const open = ROUTE_SRC.indexOf("`", start);
+  const close = ROUTE_SRC.indexOf("`", open + 1);
+  if (close === -1) throw new Error(`${name} literal is unterminated`);
+  return ROUTE_SRC.slice(open + 1, close);
+}
+
+describe("the enroll-critical query carries nothing optional", () => {
+  it("does not select any product field — that needs read_products, and an unauthorized field fails the WHOLE query", () => {
+    const critical = templateLiteral("ORDER_DETAIL_QUERY");
+    expect(critical).not.toMatch(/\bproduct\s*\{/);
+    expect(critical).not.toContain("onlineStoreUrl");
+  });
+
+  it("still selects everything a proof is actually made of", () => {
+    const critical = templateLiteral("ORDER_DETAIL_QUERY");
+    for (const required of [
+      "name",
+      "customer",
+      "shippingAddress",
+      "totalPriceSet",
+      "lineItems",
+      "sku",
+      "image",
+      "metafield",
+      "fulfillments",
+    ]) {
+      expect(critical).toContain(required);
+    }
+  });
+
+  it("asks for the product URLs on a separate wire", () => {
+    const enrichment = templateLiteral("PRODUCT_URLS_QUERY");
+    expect(enrichment).toMatch(/\bproduct\s*\{/);
+    expect(enrichment).toContain("onlineStoreUrl");
+    // Its own operation — not a fragment spliced back into the critical one.
+    expect(enrichment).toContain("query AutoEnrollProductUrls");
+  });
+
+  it("fetches those URLs fail-open, and logs the refusal rather than hiding it", () => {
+    // The fetch helper swallows the error (so enroll survives) but must warn
+    // (so the outage cannot be permanent and silent — TECH_BIBLE law 32).
+    const helper = ROUTE_SRC.slice(
+      ROUTE_SRC.indexOf("async function fetchProductUrls"),
+      ROUTE_SRC.indexOf("const TAG_MUTATION"),
+    );
+    expect(helper).toContain("catch");
+    expect(helper).toContain("return null");
+    expect(helper).toMatch(/console\.warn/);
+  });
+});
+
+describe("a failed enroll is reported, and retried", () => {
+  it("returns 500 on enroll failure so Shopify redelivers", () => {
+    expect(ROUTE_SRC).toContain("enrollFailure");
+    const tail = ROUTE_SRC.slice(ROUTE_SRC.indexOf("if (enrollFailure)"));
+    expect(tail).toMatch(/status:\s*500/);
+  });
+
+  it("prints the success line only when the enroll did not fail", () => {
+    const successIdx = ROUTE_SRC.indexOf("Successfully processed order");
+    const guardIdx = ROUTE_SRC.indexOf("if (enrollFailure)");
+    expect(guardIdx).toBeGreaterThan(-1);
+    // The guard returns before the success line can be reached.
+    expect(guardIdx).toBeLessThan(successIdx);
+  });
+
+  it("logs the failure as an error naming the order, not a warn that reads like noise", () => {
+    expect(ROUTE_SRC).toMatch(/Auto-enroll FAILED for \$\{orderName\}/);
+  });
+});
+
+describe("attachProductUrls folds the enrichment in without ever damaging a detail", () => {
+  const details = () => [
+    productDetailFromLineItem({
+      title: "Bevelyn Pump",
+      sku: "BEV-1",
+      quantity: 1,
+      originalUnitPriceSet: { shopMoney: { amount: "109.95" } },
+      image: { url: "https://cdn.shopify.com/bevelyn.jpg" },
+    }),
+    productDetailFromLineItem({ title: "Carrson Sandal", quantity: 2 }),
+  ];
+
+  it("attaches each URL by index", () => {
+    const out = attachProductUrls(details(), [
+      "https://www.stevemadden.com/products/bevelyn",
+      "https://www.stevemadden.com/products/carrson",
+    ]);
+    expect(out[0].product_url).toBe("https://www.stevemadden.com/products/bevelyn");
+    expect(out[1].product_url).toBe("https://www.stevemadden.com/products/carrson");
+  });
+
+  it("leaves details BYTE-IDENTICAL when the fetch was refused (null)", () => {
+    const before = details();
+    const out = attachProductUrls(before, null);
+    expect(out).toEqual(before);
+    expect(out.every((d) => !("product_url" in d))).toBe(true);
+  });
+
+  it("omits rather than writing an empty product_url when a product has no storefront page", () => {
+    const out = attachProductUrls(details(), [null, "https://www.stevemadden.com/products/carrson"]);
+    expect("product_url" in out[0]).toBe(false);
+    expect(out[1].product_url).toBe("https://www.stevemadden.com/products/carrson");
+  });
+
+  it("leaves the tail unenriched when the two calls disagree on length", () => {
+    const out = attachProductUrls(details(), ["https://www.stevemadden.com/products/bevelyn"]);
+    expect(out[0].product_url).toBe("https://www.stevemadden.com/products/bevelyn");
+    expect("product_url" in out[1]).toBe(false);
+  });
+
+  it("never mutates the input array", () => {
+    const before = details();
+    attachProductUrls(before, ["https://www.stevemadden.com/products/bevelyn", null]);
+    expect("product_url" in before[0]).toBe(false);
+  });
+});

--- a/app/services/order-line-item.ts
+++ b/app/services/order-line-item.ts
@@ -29,3 +29,32 @@ export function productDetailFromLineItem(n: any) {
     ...(n?.product?.onlineStoreUrl ? { product_url: n.product.onlineStoreUrl } : {}),
   };
 }
+
+/** Fold separately-fetched product URLs onto already-built line-item details.
+ *
+ *  WHY THIS EXISTS AS A SECOND STEP. `product { onlineStoreUrl }` needs the
+ *  `read_products` scope, and Shopify fails the ENTIRE query when a selection
+ *  is unauthorized — it does not omit the field. Riding the enroll-critical
+ *  query, that one selection took enrollment down for every order on every
+ *  install and reported success while doing it (real order #1019,
+ *  2026-08-09). So the URLs are fetched on their own wire and folded in here;
+ *  `urls` is `null` whenever that fetch failed or was refused.
+ *
+ *  ABSENT MEANS ABSENT. A null/blank entry leaves the detail byte-identical
+ *  rather than writing `product_url: ""` — the tap page hides the link on
+ *  absence (law 7), and an empty string would render a dead door.
+ *
+ *  Index-aligned: both come from the same `lineItems(first: 20)` selection on
+ *  the same order, so position is the join. A length mismatch (a line item
+ *  added between the two calls) simply leaves the unmatched tail unenriched.
+ */
+export function attachProductUrls<T extends Record<string, unknown>>(
+  details: T[],
+  urls: (string | null)[] | null,
+): T[] {
+  if (!urls) return details;
+  return details.map((detail, i) => {
+    const url = urls[i];
+    return url ? ({ ...detail, product_url: url } as T) : detail;
+  });
+}

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -103,7 +103,19 @@ api_version = "2025-10"
 # ADDING THESE COSTS MERCHANT RE-CONSENT. Shopify re-prompts every installed
 # store on a scope change. Doing it now, with two test stores installed, costs
 # nothing; doing it after real merchants install costs each of them a prompt.
-scopes = "read_assigned_fulfillment_orders,write_assigned_fulfillment_orders,read_merchant_managed_fulfillment_orders,write_merchant_managed_fulfillment_orders,read_third_party_fulfillment_orders,write_third_party_fulfillment_orders,read_customers,read_files,write_files,read_fulfillments,write_fulfillments,read_metaobjects,write_metaobjects,read_online_store_pages,write_online_store_pages,read_orders,write_orders,write_shipping,write_themes"
+#
+# `read_products` — the product's public storefront page (`onlineStoreUrl`),
+# which is what makes "view this product" on the buyer's page possible. Added
+# 2026-08-09, after real order #1019 proved the cost of asking without it:
+# Shopify does not omit an unauthorized field, it FAILS THE WHOLE QUERY, so
+# one selection took auto-enrollment down for every order on every install
+# while the handler logged ✅ and returned 200.
+#
+# The handler no longer DEPENDS on this scope — product URLs are fetched
+# separately and fail open (webhooks.orders_create.ts, PRODUCT_URLS_QUERY), so
+# a store that has not re-consented still enrolls normally and simply carries
+# no product link. This scope is what turns that link on.
+scopes = "read_assigned_fulfillment_orders,write_assigned_fulfillment_orders,read_merchant_managed_fulfillment_orders,write_merchant_managed_fulfillment_orders,read_third_party_fulfillment_orders,write_third_party_fulfillment_orders,read_customers,read_files,write_files,read_fulfillments,write_fulfillments,read_metaobjects,write_metaobjects,read_online_store_pages,write_online_store_pages,read_orders,write_orders,read_products,write_shipping,write_themes"
 optional_scopes = [ ]
 use_legacy_install_flow = false
 


### PR DESCRIPTION
Sam ordered Steve Madden #1019 at 20:32Z. It appeared in the Ritualist,
tagged and metafielded, and never reached in.ink. Cloud Run says why:

  [orders/create] Auto-enroll soft-failed for #1019 (order still tagged):
  Access denied for product field. Required access: `read_products`
  ✅ [orders/create] Successfully processed order #1019 (mode=background)
  POST /webhooks/orders_create 200

#82 added `product { onlineStoreUrl }` to ORDER_DETAIL_QUERY four hours
earlier. That is the enroll-critical fetch, and the app has never held
`read_products` — the scope is absent from both tomls and appears nowhere in
the repo. Shopify does not omit a field it cannot authorize; it fails the
WHOLE query. So the throw landed before odJson was ever read, and enrollment
lost the order name, the customer, the ship-to, the line items, the
idempotency metafield and the fulfillments. Everything a proof is made of, for
one optional link.

It was not the rig. Every store on this app version lacks the scope, so every
new order on every install had been failing this way since 18:17Z, reporting
success.

THE ENRICHMENT MOVES OFF THE CRITICAL PATH. PRODUCT_URLS_QUERY is its own
operation, fetched by fetchProductUrls and folded in by attachProductUrls,
returning null on any refusal. A missing scope now costs exactly the product
link. This is the durable half: the scope below fixes today's field, and this
fixes the class — the next optional field cannot reach enrollment either.

THE REFUSAL IS NAMED AND RETRIED. The catch warned and fell through to ✅ and
200, which also told Shopify never to redeliver — the failure was invisible in
the logs AND unrecoverable. It now logs ❌ with the cause and returns 500.
Retry is safe: the backend dedupes on (shop_id, order_id) (ink-backend #23),
and tagsAdd/metafieldsSet are both idempotent. Third occurrence of the law
that a function which declines must return the decline and its caller must
render it (TECH_BIBLE law 14; law 32 for the counted fallback).

read_products IS added to shopify.app.toml — the 8da1 app only, never the
smusic config. It COSTS MERCHANT RE-CONSENT on every installed store, which is
why it is Sam's call and why it goes now, with two test stores installed,
rather than after real merchants arrive. Until each store re-consents the new
fetch simply fails open, so nothing regresses in the meantime.

Not fixed here, named so it is a decision: the no-ink_api_key path still warns
and prints the success line. That order genuinely was processed (tagged,
metafielded) and a 500 there would make Shopify retry an unprovisioned
merchant forever.

Verified: 12 new guards watched FAILING against the pre-change source before
being trusted (the `product {` selection is reported inside
ORDER_DETAIL_QUERY; attachProductUrls does not exist) — 11 failed, 1 passed,
that one being the regression guard that should hold on both. Then the full
suite, 54 tests across 7 files, and the real react-router build.

Still unproven end to end, and it cannot be from here: a fresh order must walk
the webhook. #1020 settles it — exactly one delivery, no soft-fail, then
order_status_url + shop_domain + product_url on the public wire, then the
fulfilment with SHIPPO_TRANSIT for the branded tracking link the failed enroll
also took down (it gates on the ink.proof_reference metafield this never
wrote).

---

**Merge this FIRST and alone.** Enroll is broken in production right now; this is what revives it.

**New surface:** none.

**Needs a gated `shopify app deploy` after merge** — `read_products` is added to `shopify.app.toml` (the 8da1 app only). Until each store re-consents, the new product-URL fetch simply fails open and enrollment works normally, so merging alone is safe and non-regressive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)