### PR TITLE
The email line stops racing the email

### DIFF
--- a/app/components/settings/CommunicationSettings.tsx
+++ b/app/components/settings/CommunicationSettings.tsx
@@ -62,10 +62,19 @@ async function secureFetch(path: string, options: RequestInit = {}) {
 // every "View your order" in that template resolves to the brand's page. Same
 // approach AfterShip and Malomo ship to merchants, because no Shopify API can
 // edit a notification template — verified against Shopify's docs 2026-08-07.
-const LIQUID_SNIPPET =
-  "{% if fulfillment.tracking_url %}{% assign order_status_url = fulfillment.tracking_url %}{% endif %}";
+//
+// IT IS NO LONGER A CONSTANT. The server builds it per brand
+// (`notification-snippet.ts`), because the line needs the merchant's own
+// subdomain and because the old hardcoded version read
+// `fulfillment.tracking_url` — blank on order confirmation forever, and ~600ms
+// behind the shipping email by construction. This fallback is what renders
+// before the fetch lands; it is the neutral www host, never a guessed one.
+import { notificationSnippet } from "../../services/notification-snippet";
+
+const FALLBACK_SNIPPET = notificationSnippet(null);
 
 const TEMPLATE_LABELS: Record<TemplateKey, string> = {
+  order_confirmation: "Order confirmation",
   shipping_confirmation: "Shipping confirmation",
   shipping_update: "Shipping update",
   out_for_delivery: "Out for delivery",
@@ -76,6 +85,9 @@ const CommunicationSettings = ({ shopDomain }: { shopDomain?: string }) => {
   const [settings, setSettings] = useState<NotificationSettings>(
     DEFAULT_NOTIFICATION_SETTINGS,
   );
+  // The brand-specific line, built server-side. Starts on the neutral www
+  // fallback so the card is never blank and never shows a guessed host.
+  const [snippet, setSnippet] = useState<string>(FALLBACK_SNIPPET);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
@@ -87,6 +99,7 @@ const CommunicationSettings = ({ shopDomain }: { shopDomain?: string }) => {
       } else if (data?.settings) {
         setSettings(data.settings);
       }
+      if (data?.snippet) setSnippet(data.snippet);
       setLoaded(true);
     });
     return () => {
@@ -142,7 +155,7 @@ const CommunicationSettings = ({ shopDomain }: { shopDomain?: string }) => {
 
   const copySnippet = async () => {
     try {
-      await navigator.clipboard.writeText(LIQUID_SNIPPET);
+      await navigator.clipboard.writeText(snippet);
       toast({ description: "Copied. Paste it as a new first line.", duration: 2500 });
     } catch {
       toast({ description: "Couldn't copy — select the line and copy it manually.", variant: "destructive" });
@@ -196,7 +209,7 @@ const CommunicationSettings = ({ shopDomain }: { shopDomain?: string }) => {
           <BlockStack gap="400">
             <InlineStack gap="200" blockAlign="center">
               <Text as="p" variant="bodySm" fontWeight="medium">
-                Add one line to four email templates
+                Add one line to five email templates
               </Text>
               <Badge tone={templatesDone === TEMPLATE_KEYS.length ? "success" : "attention"}>
                 {`${templatesDone} of ${TEMPLATE_KEYS.length} done`}
@@ -223,7 +236,7 @@ const CommunicationSettings = ({ shopDomain }: { shopDomain?: string }) => {
                       display: "block",
                     }}
                   >
-                    {LIQUID_SNIPPET}
+                    {snippet}
                   </code>
                 </div>
                 <InlineStack gap="200">

--- a/app/routes/app.api.settings.notifications.tsx
+++ b/app/routes/app.api.settings.notifications.tsx
@@ -7,6 +7,12 @@ import {
   sanitizeNotificationSettings,
   resolveShopFromTokenPayload,
 } from "../services/notification-settings";
+import { brandSlugFromDoc } from "../services/brand-page-url.server";
+import { getShopIdByDomain } from "../services/ink-api.server";
+import {
+  notificationSnippet,
+  SNIPPET_TEMPLATES,
+} from "../services/notification-snippet";
 
 /**
  * Notification Settings endpoint.
@@ -92,7 +98,31 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       await hit.ref.set({ notification_settings: settings }, { merge: true });
     }
 
-    return json({ settings });
+    // THE SNIPPET IS BUILT SERVER-SIDE, from the same brand the tracking
+    // rewrite uses. The card used to hold a hardcoded constant, which is how
+    // it shipped a line that could only ever work after a fulfillment. The
+    // slug has to come from the BACKEND merchant doc (brand_slug) — deriving
+    // it from the myshopify domain yields `sm-test-hhawzn52.in.ink`, a host
+    // that looks right and 404s. Fail-soft: no slug ⇒ the www fallback, which
+    // resolves for every brand.
+    let brandSlug = "";
+    try {
+      const shopId = await getShopIdByDomain(auth.shop);
+      const backend = shopId
+        ? (await firestore.collection("merchants").doc(shopId).get()).data() ?? {}
+        : {};
+      brandSlug = brandSlugFromDoc({ ...hit.data, ...backend }, auth.shop);
+    } catch (e: any) {
+      console.warn(
+        `[settings/notifications] brand slug unresolved (${e?.message}) — snippet falls back to www.in.ink`,
+      );
+    }
+
+    return json({
+      settings,
+      snippet: notificationSnippet(brandSlug),
+      snippetTemplates: SNIPPET_TEMPLATES,
+    });
   } catch (err: any) {
     console.error("[settings/notifications] GET error:", err.message);
     return json({ error: "Failed to fetch notification settings" }, { status: 500 });

--- a/app/services/brand-page-url.server.ts
+++ b/app/services/brand-page-url.server.ts
@@ -37,6 +37,33 @@ export interface BrandPageResolution {
   customerTier: string | null;
 }
 
+/** THE BRAND'S OWN SUBDOMAIN LABEL, from a merchant doc.
+ *
+ *  Split out of `resolveBrandPageUrl` so a caller that has no proof — the
+ *  Notifications snippet card — reads the brand the SAME way the tracking
+ *  rewrite does. It already drifted once: the verify webhook builds
+ *  `sm-test-hhawzn52.in.ink` off the myshopify domain while the rewrite
+ *  correctly builds `stevemadden.in.ink` off the backend doc, so the same
+ *  order carries two different hosts. This file's header calls that out as
+ *  the thing it exists to prevent; a second no-proof copy would have been
+ *  the third.
+ *
+ *  `brand_slug` on the merged doc wins; the shop domain is the last resort
+ *  and is exactly what produces a wrong-but-plausible host. */
+export function brandSlugFromDoc(
+  brandDoc: Record<string, any>,
+  shop: string,
+): string {
+  const brandDomain =
+    (brandDoc.shop_domain as string | undefined) ||
+    (brandDoc.shopDomain as string | undefined) ||
+    shop;
+  return (
+    brandSlugFromDomain(brandDoc.brand_slug as string | undefined) ||
+    brandSlugFromDomain(brandDomain)
+  );
+}
+
 /** Resolve the buyer page for one proof.
  *
  *  Fail-soft throughout: a proof fetch or merchant-doc read that fails leaves
@@ -84,13 +111,7 @@ export async function resolveBrandPageUrl({
     }
   }
 
-  const brandDomain =
-    (brandDoc.shop_domain as string | undefined) ||
-    (brandDoc.shopDomain as string | undefined) ||
-    shop;
-  const brandSlug =
-    brandSlugFromDomain(brandDoc.brand_slug as string | undefined) ||
-    brandSlugFromDomain(brandDomain);
+  const brandSlug = brandSlugFromDoc(brandDoc, shop);
 
   const pageUrl = brandSlug && nfcToken ? `https://${brandSlug}.in.ink/r/${nfcToken}` : null;
   const emailUrl = pageUrl ?? `https://www.in.ink/r/${nfcToken || proofId}`;

--- a/app/services/notification-settings.test.ts
+++ b/app/services/notification-settings.test.ts
@@ -57,7 +57,7 @@ describe("sanitizeNotificationSettings — the API stops writing verbatim", () =
     );
   });
 
-  it("templatesPastedAt keeps only the four known templates, ISO string or null", () => {
+  it("templatesPastedAt keeps only the known templates, ISO string or null", () => {
     const clean = sanitizeNotificationSettings({
       templatesPastedAt: {
         shipping_confirmation: "2026-08-07T23:00:00.000Z",
@@ -84,6 +84,10 @@ describe("sanitizeNotificationSettings — the API stops writing verbatim", () =
     expect(DEFAULT_NOTIFICATION_SETTINGS.channels.sms).toBe(false);
     expect(DEFAULT_NOTIFICATION_SETTINGS).not.toHaveProperty("reminders");
     expect(TEMPLATE_KEYS).toEqual([
+      // order_confirmation joined 2026-08-10 with the metafield snippet —
+      // the token exists at enrollment, so the first email a buyer gets can
+      // finally carry the page.
+      "order_confirmation",
       "shipping_confirmation",
       "shipping_update",
       "out_for_delivery",

--- a/app/services/notification-settings.ts
+++ b/app/services/notification-settings.ts
@@ -13,6 +13,11 @@
 // their next save.
 
 export const TEMPLATE_KEYS = [
+  // Order confirmation joined 2026-08-10: the metafield snippet works there
+  // (the token exists at enrollment), where the old fulfillment-based line
+  // was blank forever. First in the list because it is the first email a
+  // buyer ever gets.
+  "order_confirmation",
   "shipping_confirmation",
   "shipping_update",
   "out_for_delivery",
@@ -42,6 +47,7 @@ export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
   returnReminders: { days7: true, hours48: false },
   returnWindow: "30",
   templatesPastedAt: {
+    order_confirmation: null,
     shipping_confirmation: null,
     shipping_update: null,
     out_for_delivery: null,

--- a/app/services/notification-snippet.test.ts
+++ b/app/services/notification-snippet.test.ts
@@ -1,0 +1,58 @@
+// The snippet's whole job is to survive the two things that broke the old one:
+// a template with no fulfillment, and an enrollment that never happened.
+import { describe, it, expect } from "vitest";
+import { notificationSnippet, SNIPPET_TEMPLATES } from "./notification-snippet";
+
+describe("the pasted Liquid cannot race the email", () => {
+  it("reads the enrollment metafield, never the fulfillment", () => {
+    const s = notificationSnippet("stevemadden");
+    expect(s).toContain("order.metafields.ink.ink_token");
+    // THE REGRESSION THIS FILE EXISTS FOR. `fulfillment.tracking_url` is
+    // written ~600ms after Shopify composes the shipping email (#1020,
+    // measured) and is blank forever on order confirmation.
+    expect(s).not.toContain("fulfillment");
+    expect(s).not.toContain("tracking_url");
+  });
+
+  it("reassigns the variable Shopify's own primary button reads", () => {
+    // If this ever stops assigning `order_status_url`, the paste is decorative:
+    // the button keeps pointing at Shopify and nobody finds out until a
+    // merchant taps it.
+    expect(notificationSnippet("stevemadden")).toContain(
+      "{% assign order_status_url =",
+    );
+  });
+
+  it("guards on a blank token so it can never break a button", () => {
+    const s = notificationSnippet("stevemadden");
+    expect(s).toContain("{% if ink_token != blank %}");
+    expect(s.endsWith("{% endif %}")).toBe(true);
+    // An order that predates the app, or whose enroll failed, must fall
+    // through to whatever Shopify already set — today's behaviour, never a
+    // dead link.
+  });
+
+  it("builds the brand's own host from the resolved slug", () => {
+    expect(notificationSnippet("stevemadden")).toContain(
+      '"https://stevemadden.in.ink/r/" | append: ink_token',
+    );
+  });
+
+  it("falls back to www, never to a guessed host", () => {
+    // The myshopify label (`sm-test-hhawzn52`) is the wrong-but-plausible
+    // host that already shipped in the verify webhook. A neutral www URL
+    // resolves for every brand; a guessed subdomain 404s while looking right.
+    for (const blank of [undefined, null, "", "   "]) {
+      expect(notificationSnippet(blank)).toContain('"https://www.in.ink/r/"');
+    }
+  });
+
+  it("is a single line — it is pasted into a template's first line", () => {
+    expect(notificationSnippet("stevemadden")).not.toContain("\n");
+  });
+
+  it("names order confirmation first, the template the old line could not serve", () => {
+    expect(SNIPPET_TEMPLATES[0]).toBe("Order confirmation");
+    expect(SNIPPET_TEMPLATES).toContain("Shipping confirmation");
+  });
+});

--- a/app/services/notification-snippet.ts
+++ b/app/services/notification-snippet.ts
@@ -1,0 +1,68 @@
+// THE ONE LINE A MERCHANT PASTES — and the reason the old one didn't work.
+//
+// Shopify has no API for editing a notification template, so this snippet is
+// the only way the store's own emails can point at the brand's page. That part
+// is unavoidable (AfterShip and Malomo ship the same instruction). What WAS
+// avoidable is what the line read.
+//
+// THE OLD LINE RACED, AND LOST. It was:
+//
+//     {% if fulfillment.tracking_url %}
+//       {% assign order_status_url = fulfillment.tracking_url %}{% endif %}
+//
+// `fulfillment.tracking_url` is only ours AFTER the branded-tracking-link
+// rewrite has run, and that rewrite runs when we RECEIVE the fulfillment
+// webhook — i.e. after Shopify has already composed the shipping email.
+// Measured on real order #1020, 2026-08-10:
+//
+//     02:29:33.755  fulfillment created  → Shopify composes + queues the email
+//     02:29:34.387  our rewrite lands    → tracking_url finally points at us
+//
+// Roughly six hundred milliseconds too late, every time, by construction. And
+// on the ORDER CONFIRMATION email — which renders before any fulfillment
+// exists — `fulfillment.tracking_url` is blank forever, so the line was inert
+// there no matter how long you waited. Sam pasted it into that template and
+// correctly reported that nothing happened.
+//
+// THE NEW LINE CANNOT RACE. `ink.ink_token` is written by the orders/create
+// webhook at enrollment — on #1020 that was 02:20:32, NINE MINUTES before the
+// fulfillment existed. Every email for an enrolled order, in every template,
+// can already see it.
+//
+// The guard matters as much as the assign: when the token is blank (an order
+// that predates the app, or one whose enrollment failed) the line leaves
+// `order_status_url` exactly as Shopify set it. A merchant who pastes this can
+// never end up with a broken button — worst case they get today's behaviour.
+
+/** The metafield the orders/create webhook stamps at enrollment.
+ *  `webhooks.orders_create.ts` writes namespace "ink", key "ink_token". */
+const TOKEN_METAFIELD = "order.metafields.ink.ink_token";
+
+/** Build the paste-once Liquid for one brand.
+ *
+ *  `slug` is the brand's own subdomain label, resolved through
+ *  `brandSlugFromDoc` so this agrees with the tracking rewrite. A blank slug
+ *  falls back to the canonical `www.in.ink`, which resolves for any brand —
+ *  never a guessed host, because a wrong-but-plausible one (the myshopify
+ *  label, e.g. `sm-test-hhawzn52.in.ink`) is worse than the neutral one: it
+ *  looks right and 404s. */
+export function notificationSnippet(slug?: string | null): string {
+  const clean = String(slug || "").trim();
+  const base = clean ? `https://${clean}.in.ink/r/` : "https://www.in.ink/r/";
+  return (
+    `{% assign ink_token = ${TOKEN_METAFIELD} %}` +
+    `{% if ink_token != blank %}` +
+    `{% assign order_status_url = "${base}" | append: ink_token %}` +
+    `{% endif %}`
+  );
+}
+
+/** The templates this line belongs in, in the order a buyer meets them.
+ *  Order confirmation is FIRST and is the one the old line could never serve. */
+export const SNIPPET_TEMPLATES = [
+  "Order confirmation",
+  "Shipping confirmation",
+  "Shipping update",
+  "Out for delivery",
+  "Delivered",
+] as const;


### PR DESCRIPTION
Sam pasted our snippet, fulfilled a real order, and the shipping email's
button still opened Shopify. The snippet we hand merchants reads
fulfillment.tracking_url — which is only ours AFTER the branded-tracking-link
rewrite runs, and the rewrite runs when the fulfillment webhook arrives,
which is AFTER Shopify has composed the email. Measured on #1020:
fulfillment 02:29:33.755, our rewrite 02:29:34.387. The line loses by ~600ms
every time, by construction. On the order-confirmation email it never had a
chance at all: no fulfillment exists when that one renders.

The new line reads what already exists when ANY email renders:
order.metafields.ink.ink_token, stamped by orders/create at enrollment —
nine minutes before #1020's fulfillment. Blank-guarded, so an unenrolled
order keeps Shopify's own button; worst case is today's behaviour, never a
dead link.

The snippet is no longer a hardcoded constant. The settings loader builds it
per brand through brandSlugFromDoc — split out of resolveBrandPageUrl so the
card reads the brand the SAME way the tracking rewrite does. That resolver
disagreement is not hypothetical: the verify webhook builds
sm-test-hhawzn52.in.ink off the myshopify domain while the rewrite correctly
builds stevemadden.in.ink, two hosts on one order. No slug resolves to the
neutral www.in.ink host, never a guessed subdomain that looks right and 404s.

Order confirmation joins the template checklist (four → five): with the
metafield line the first email a buyer ever gets can carry the page, which
the old line structurally could not.

Store-side, existing pastes of the OLD line keep working exactly as badly as
before until replaced — the card now shows each merchant the new line.

Tests: 7 new on the snippet (proven against the old line: 4 fail on it,
including the one that names the race), the TEMPLATE_KEYS pin updated for
five. Full suite 61 green, tsc clean, real react-router build green.

---

**New surface:** none — the existing snippet card's line and checklist change; no new panel or page.

**After merge + deploy:** the Notifications page shows the brand-specific metafield line. The one store-side step that no API can do remains: replace the old pasted line with the new one, once per template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)