### PR TITLE
The app stops handing merchants a line that cannot work

### DIFF
--- a/app/services/notification-snippet.test.ts
+++ b/app/services/notification-snippet.test.ts
@@ -1,58 +1,57 @@
-// The snippet's whole job is to survive the two things that broke the old one:
-// a template with no fulfillment, and an enrollment that never happened.
+// The snippet's whole job is to survive the thing that killed both earlier
+// versions: the email is composed BEFORE any of our data exists. So the line
+// may only read a Shopify fact, and must resolve to ours at click time.
 import { describe, it, expect } from "vitest";
 import { notificationSnippet, SNIPPET_TEMPLATES } from "./notification-snippet";
 
-describe("the pasted Liquid cannot race the email", () => {
-  it("reads the enrollment metafield, never the fulfillment", () => {
+describe("the pasted Liquid cannot lose the compose race", () => {
+  it("reads order_number — a fact Shopify has before we do", () => {
+    expect(notificationSnippet("stevemadden")).toContain("| append: order_number");
+  });
+
+  it("never reads anything we write", () => {
     const s = notificationSnippet("stevemadden");
-    expect(s).toContain("order.metafields.ink.ink_token");
-    // THE REGRESSION THIS FILE EXISTS FOR. `fulfillment.tracking_url` is
-    // written ~600ms after Shopify composes the shipping email (#1020,
-    // measured) and is blank forever on order confirmation.
+    // ATTEMPT 1: written ~600ms after the shipping email is composed (#1020),
+    // and blank forever on order confirmation.
     expect(s).not.toContain("fulfillment");
     expect(s).not.toContain("tracking_url");
+    // ATTEMPT 2: written five seconds after the confirmation email is
+    // composed (#1021). Both shipped; both were dead on arrival.
+    expect(s).not.toContain("metafields");
+    expect(s).not.toContain("ink_token");
+  });
+
+  it("points at the order door, not straight at a token", () => {
+    // /r/{token} would require knowing the token at compose time — the exact
+    // impossibility above. /o/{number} defers the lookup to the tap.
+    const s = notificationSnippet("stevemadden");
+    expect(s).toContain('"https://stevemadden.in.ink/o/"');
+    expect(s).not.toContain(".in.ink/r/");
   });
 
   it("reassigns the variable Shopify's own primary button reads", () => {
-    // If this ever stops assigning `order_status_url`, the paste is decorative:
-    // the button keeps pointing at Shopify and nobody finds out until a
-    // merchant taps it.
+    // Verified live on order #1023: with this assigned, the confirmation
+    // email's "View your order" opened the buyer's page.
     expect(notificationSnippet("stevemadden")).toContain(
       "{% assign order_status_url =",
     );
   });
 
-  it("guards on a blank token so it can never break a button", () => {
-    const s = notificationSnippet("stevemadden");
-    expect(s).toContain("{% if ink_token != blank %}");
-    expect(s.endsWith("{% endif %}")).toBe(true);
-    // An order that predates the app, or whose enroll failed, must fall
-    // through to whatever Shopify already set — today's behaviour, never a
-    // dead link.
-  });
-
-  it("builds the brand's own host from the resolved slug", () => {
-    expect(notificationSnippet("stevemadden")).toContain(
-      '"https://stevemadden.in.ink/r/" | append: ink_token',
-    );
-  });
-
   it("falls back to www, never to a guessed host", () => {
-    // The myshopify label (`sm-test-hhawzn52`) is the wrong-but-plausible
-    // host that already shipped in the verify webhook. A neutral www URL
-    // resolves for every brand; a guessed subdomain 404s while looking right.
+    // The myshopify label (`sm-test-hhawzn52`) is the wrong-but-plausible host
+    // already shipped once in the verify webhook. www resolves for every
+    // brand; a guessed subdomain 404s while looking right.
     for (const blank of [undefined, null, "", "   "]) {
-      expect(notificationSnippet(blank)).toContain('"https://www.in.ink/r/"');
+      expect(notificationSnippet(blank)).toContain('"https://www.in.ink/o/"');
     }
   });
 
-  it("is a single line — it is pasted into a template's first line", () => {
+  it("is a single line — it is pasted at the top of a template", () => {
     expect(notificationSnippet("stevemadden")).not.toContain("\n");
   });
 
-  it("names order confirmation first, the template the old line could not serve", () => {
+  it("names all five templates, order confirmation first", () => {
     expect(SNIPPET_TEMPLATES[0]).toBe("Order confirmation");
-    expect(SNIPPET_TEMPLATES).toContain("Shipping confirmation");
+    expect(SNIPPET_TEMPLATES).toHaveLength(5);
   });
 });

--- a/app/services/notification-snippet.ts
+++ b/app/services/notification-snippet.ts
@@ -1,64 +1,56 @@
-// THE ONE LINE A MERCHANT PASTES — and the reason the old one didn't work.
+// THE ONE LINE A MERCHANT PASTES — third version, and the first one that has
+// been tapped by a human and worked.
 //
-// Shopify has no API for editing a notification template, so this snippet is
-// the only way the store's own emails can point at the brand's page. That part
-// is unavoidable (AfterShip and Malomo ship the same instruction). What WAS
-// avoidable is what the line read.
+// Shopify has no API for editing a notification template, so this line is the
+// only way a store's own emails can point at the brand's page. That part is
+// unavoidable. What took three attempts was WHAT the line reads.
 //
-// THE OLD LINE RACED, AND LOST. It was:
-//
-//     {% if fulfillment.tracking_url %}
-//       {% assign order_status_url = fulfillment.tracking_url %}{% endif %}
-//
-// `fulfillment.tracking_url` is only ours AFTER the branded-tracking-link
-// rewrite has run, and that rewrite runs when we RECEIVE the fulfillment
-// webhook — i.e. after Shopify has already composed the shipping email.
-// Measured on real order #1020, 2026-08-10:
-//
+// ATTEMPT 1 — `fulfillment.tracking_url`. Only ours after the branded-tracking
+// rewrite runs, and that runs when we RECEIVE the fulfillment webhook — after
+// Shopify has already composed the shipping email. Measured on real order
+// #1020, 2026-08-10:
 //     02:29:33.755  fulfillment created  → Shopify composes + queues the email
 //     02:29:34.387  our rewrite lands    → tracking_url finally points at us
+// ~600ms too late, by construction. And blank forever on order confirmation,
+// where no fulfillment exists yet.
 //
-// Roughly six hundred milliseconds too late, every time, by construction. And
-// on the ORDER CONFIRMATION email — which renders before any fulfillment
-// exists — `fulfillment.tracking_url` is blank forever, so the line was inert
-// there no matter how long you waited. Sam pasted it into that template and
-// correctly reported that nothing happened.
+// ATTEMPT 2 — `order.metafields.ink.ink_token`. Written at enrollment, which
+// felt early enough. It is not. Measured on real order #1021:
+//     06:06:36  order created  → Shopify composes the confirmation email
+//     06:06:41  our enroll lands → proof, token and metafields exist
+// FIVE SECONDS too late. Sam pasted this into five templates before finding
+// out, which is the cost of shipping a line nobody had tapped.
 //
-// THE NEW LINE CANNOT RACE. `ink.ink_token` is written by the orders/create
-// webhook at enrollment — on #1020 that was 02:20:32, NINE MINUTES before the
-// fulfillment existed. Every email for an enrolled order, in every template,
-// can already see it.
+// THE LAW UNDERNEATH BOTH FAILURES: a notification can only ever carry what
+// Shopify itself knows WHILE COMPOSING. Anything of ours is younger than the
+// email. So the line must carry a Shopify fact and resolve to ours LATER.
 //
-// The guard matters as much as the assign: when the token is blank (an order
-// that predates the app, or one whose enrollment failed) the line leaves
-// `order_status_url` exactly as Shopify set it. A merchant who pastes this can
-// never end up with a broken button — worst case they get today's behaviour.
-
-/** The metafield the orders/create webhook stamps at enrollment.
- *  `webhooks.orders_create.ts` writes namespace "ink", key "ink_token". */
-const TOKEN_METAFIELD = "order.metafields.ink.ink_token";
+// ATTEMPT 3 — `order_number`, through the order door. Shopify knows the order
+// number before it knows anything else; `{brand}.in.ink/o/{number}` looks the
+// token up when the BUYER TAPS, by which point the proof has existed for
+// minutes. Verified end-to-end on real order #1023, 2026-08-10: the email's
+// "View your order" button opened the buyer's page. The door itself is
+// parallelreturns #855.
 
 /** Build the paste-once Liquid for one brand.
  *
  *  `slug` is the brand's own subdomain label, resolved through
- *  `brandSlugFromDoc` so this agrees with the tracking rewrite. A blank slug
- *  falls back to the canonical `www.in.ink`, which resolves for any brand —
- *  never a guessed host, because a wrong-but-plausible one (the myshopify
- *  label, e.g. `sm-test-hhawzn52.in.ink`) is worse than the neutral one: it
- *  looks right and 404s. */
+ *  `brandSlugFromDoc` so this agrees with the tracking rewrite rather than
+ *  deriving a wrong-but-plausible host from the myshopify domain.
+ *
+ *  No blank-guard, deliberately: `order_number` is present on every order in
+ *  every template, and the door already answers a miss by redirecting to the
+ *  brand's front page. A guard here would only add a shape to get wrong — and
+ *  the version a human actually tapped is this one, ungated. */
 export function notificationSnippet(slug?: string | null): string {
   const clean = String(slug || "").trim();
-  const base = clean ? `https://${clean}.in.ink/r/` : "https://www.in.ink/r/";
-  return (
-    `{% assign ink_token = ${TOKEN_METAFIELD} %}` +
-    `{% if ink_token != blank %}` +
-    `{% assign order_status_url = "${base}" | append: ink_token %}` +
-    `{% endif %}`
-  );
+  const base = clean ? `https://${clean}.in.ink/o/` : "https://www.in.ink/o/";
+  return `{% assign order_status_url = "${base}" | append: order_number %}`;
 }
 
 /** The templates this line belongs in, in the order a buyer meets them.
- *  Order confirmation is FIRST and is the one the old line could never serve. */
+ *  Order confirmation is FIRST — it is the email every buyer gets, and the
+ *  one both earlier attempts could never serve. */
 export const SNIPPET_TEMPLATES = [
   "Order confirmation",
   "Shipping confirmation",


### PR DESCRIPTION

Sam, after tapping a working link in his own inbox: "you hardcoded this into
the text box — why????"

He was right and it is worse than hardcoding. The working line exists ONLY in
his store, because he typed it. The Notifications page still hands every
merchant #84's metafield version — the one proven dead four hours later.

THE LAW BOTH EARLIER VERSIONS BROKE. A notification carries only what Shopify
knows WHILE COMPOSING. Everything of ours is younger than the email:

  #1020  02:29:33.755 fulfillment created (email composed)
         02:29:34.387 our tracking rewrite lands      → ~600ms late
  #1021  06:06:36     order created (email composed)
         06:06:41     our enroll lands                → 5s late

So the line must carry a SHOPIFY fact and resolve to ours at CLICK time.
`order_number` is the earliest fact there is, and parallelreturns #855's door
turns it into the buyer's page when the buyer taps — minutes later, when the
proof has long existed.

Verified end-to-end on real order #1023: the confirmation email's "View your
order" opened the buyer's page. First version of this line a human has tapped
and had work.

The blank-guard is deliberately gone. `order_number` is present on every order
in every template, and the door already answers a miss by redirecting to the
brand's front page — so a guard adds a shape to get wrong and protects
nothing. What ships is byte-identical to what was proven.

Templates 4 → 5 unchanged from #84 (Order confirmation stays first; it is the
email every buyer gets and the one both earlier attempts could never serve).

Tests watched fail against the metafield version before being trusted: 4 of 7
red, including "never reads anything we write".

Gate: 8 files, 61 tests, real react-router build.

---

**New surface:** none.

**Depends on** parallelreturns #855 (the `/o/` order door) — merged and live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)