### PR TITLE
The "200 error page" — a Remix Response inside a React Router 7 route

### DIFF
--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -1,5 +1,5 @@
 import { type LoaderFunctionArgs } from "react-router";
-import { redirect } from "@remix-run/node";
+import { redirect } from "react-router";
 import { LandingPageContent } from "../../components/LandingPageContent";
 import { login } from "../../shopify.server";
 

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -1,5 +1,4 @@
 import { useLoaderData, type LoaderFunctionArgs } from "react-router";
-import { json } from "@remix-run/node";
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
 import { getInventory, getInventoryByShopDomain, getShopIdByDomain } from "../services/ink-api.server";
@@ -89,7 +88,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
     console.warn("Could not fetch shopId:", e);
   }
 
-  return json(payload);
+  // PLAIN OBJECT, NOT A Response. This is React Router 7, where a route with
+  // a component returns its data directly and the framework serialises it.
+  // Returning Remix v2's `json()` here hands single-fetch a raw Response it
+  // cannot encode; the failure bubbles to app.tsx's boundary.error(), which
+  // renders the Response's STATUS — a page containing the bare text "200".
+  //
+  // That is Shopify rejection 2.1.1, second round, verbatim: "going to the
+  // billing section and navigating back ... shows an 200 error page". The
+  // Billing page's backAction points at /app/settings, so the reviewer hit it
+  // on the one navigation they were asked to make.
+  return payload;
 }
 
 export default function SettingsPage() {

--- a/app/routes/app.settings_.advanced.tsx
+++ b/app/routes/app.settings_.advanced.tsx
@@ -1,8 +1,8 @@
-import { json } from "@remix-run/node";
 import SettingsAdvanced from "../components/settings/SettingsAdvanced";
 
 export async function loader() {
-  return json({});
+  // Plain object — see app.settings.tsx for why a Response breaks RR7 here.
+  return {};
 }
 
 export default function AdvancedSettingsPage() {


### PR DESCRIPTION
Shopify 2.1.1, second round, verbatim:

> *"When going to the billing section and navigating back it doesn't go through it shows an 200 error page."*

**Reproduced from the code path, not guessed at.** `/app/billing`'s `Page` carries `backAction → /app/settings`. That route has a **component** and calls `useLoaderData`, but its loader returned Remix v2's `json(payload)`.

This app is React Router 7. Under single fetch, a route with a component returns its data **directly** and the framework serialises it. Handing it a raw `Response` gives turbo-stream something it cannot encode, the failure bubbles to `app.tsx`'s `boundary.error()`, and what renders is the Response's **status** — a page whose entire body is the text `200`.

The reviewer took the one navigation they were asked to take and landed on it.

| file | before | after |
|---|---|---|
| `app.settings.tsx` | `return json(payload)` | `return payload` |
| `app.settings_.advanced.tsx` | `return json({})` | `return {}` |
| `_index/route.tsx` | `redirect` from `@remix-run/node` | from `react-router` |

`@remix-run/node` is now imported by nothing under `app/`.

**Swept the class:** checked every route with both a component and a Response-returning loader — this was the only one. The `app.api.*` routes return Responses on purpose; they are resource routes with no component, which is exactly where a Response belongs.

`tsc` 0 errors · production build green.