### PR TITLE
I broke main's build, and CI could not see it

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -57,3 +57,12 @@ jobs:
 
       - name: Tests
         run: npm test
+
+      # THE REAL PRODUCTION BUILD, because typecheck and tests cannot see it.
+      # 2026-08-20: a test file added under app/routes/ passed typecheck and
+      # vitest, merged green, and BROKE `react-router build` on main — React
+      # Router compiles every file in app/routes as a route module. CI had no
+      # way to notice. esbuild is stricter than tsc and this is the only step
+      # that runs what actually ships.
+      - name: Production build
+        run: npm run build

--- a/app/components/BrandPreviewCard.tsx
+++ b/app/components/BrandPreviewCard.tsx
@@ -59,7 +59,10 @@ const BrandPreviewCard = ({
               style={{ backgroundColor: ink }}
             >
               <span className="text-xs" style={{ color: paper }}>
-                {built ? "Your page" : "Your page — building"}
+                {/* NOT "building": `built` says whether a page EXISTS. Nothing here
+                      knows if a build is running, so promising progress is the
+                      same empty promise the studio made for an hour. */}
+                  {built ? "Your page" : "Your page — not built yet"}
               </span>
             </div>
           )}

--- a/app/components/OnboardingChecklist.tsx
+++ b/app/components/OnboardingChecklist.tsx
@@ -41,8 +41,8 @@ const OnboardingChecklist = ({
       title: "Build your page",
       done: s.brandBuilt,
       body: s.brandBuilt
-        ? "Your approved page collection is ready — INK can choose the best fit for each order."
-        : "Open the studio and enter your website — INK builds a reviewable page collection from your brand.",
+        ? "Your approved page collection is ready — the Ritualist can choose the best fit for each order."
+        : "Open the studio and enter your website — the Ritualist builds a reviewable page collection from your brand.",
       cta: s.brandBuilt ? undefined : { label: "Open studio to build", onOpenStudio: true },
     },
     {

--- a/app/contracts/route-contracts.test.ts
+++ b/app/contracts/route-contracts.test.ts
@@ -19,6 +19,10 @@ import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const ROUTES = resolve(process.cwd(), "app/routes");
+// This file lives in app/contracts, NOT app/routes: React Router compiles
+// every file under app/routes as a ROUTE MODULE, so a test placed there is
+// built as a route and breaks `react-router build`. Which is exactly what it
+// did — see the commit message.
 
 function routeFiles(dir: string): string[] {
   const out: string[] = [];


### PR DESCRIPTION
#89 added `app/routes/route-contracts.test.ts`. **React Router compiles every file under `app/routes` as a route module**, so the test was built as a route and `react-router build` has been failing on `main` ever since.

It merged green because **CI runs typecheck and vitest and has never run the production build.**

I ran tsc and the suite on that PR and skipped the build — law 4 of this repo — and broke `main` with the commit whose entire purpose was catching what CI cannot see.

**1 — CI now runs the production build.** esbuild is stricter than tsc, and it is the only step that compiles what actually ships. Without it, anything that typechecks can break the deploy and still go green.

**2 — The guard moves to `app/contracts/`**, out of the route directory, with a comment saying why.

**3 — Two things a reviewer sees on the dashboard**, both spotted in a screenshot:

- `"INK builds a reviewable page collection"` — the last merchant-visible `INK`, on the **first screen**, in a product called The Ritualist. The `INK-Verified-Delivery` order tags stay; renaming those orphans every enrolled order.
- `"Your page — building"` — `built` is a boolean about whether a page *exists*. Nothing there knows if a build is running, so it promised progress with nothing behind it.

`tsc` 0 errors · 65 tests · **production build green** — verified in that order this time.