### PR TITLE
The real "200": a reauthorize Response with no boundary to catch it

### DIFF
--- a/app/routes/app.dashboard.tsx
+++ b/app/routes/app.dashboard.tsx
@@ -1,5 +1,6 @@
+import { boundary } from "@shopify/shopify-app-react-router/server";
 import { useEffect, useRef, useState } from "react";
-import { useFetcher, type ActionFunctionArgs } from "react-router";
+import { useFetcher, type ActionFunctionArgs, useRouteError, type HeadersFunction } from "react-router";
 import {
   Page,
   Card,
@@ -177,3 +178,19 @@ const Dashboard = () => {
 };
 
 export default Dashboard;
+
+// EVERY EMBEDDED ROUTE NEEDS SHOPIFY'S BOUNDARY.
+// When a session needs re-auth, @shopify/shopify-app-react-router THROWS a
+// Response with status 200 carrying X-Shopify-API-Request-Failure-Reauthorize
+// headers, for App Bridge to intercept. Without boundary.error(), React Router
+// treats it as a route error response and renders its STATUS — a page whose
+// entire body is the text "200". That is Shopify rejection 2.1.1, round two:
+// "going to the billing section and navigating back ... shows an 200 error
+// page". Billing had this block; /app/settings, its own backAction target, did
+// not. `headers` matters too: boundary.headers forwards the reauthorize
+// headers App Bridge is waiting for.
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);

--- a/app/routes/app.debug.tsx
+++ b/app/routes/app.debug.tsx
@@ -1,4 +1,5 @@
-import { type LoaderFunctionArgs, type ActionFunctionArgs } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+import { type LoaderFunctionArgs, type ActionFunctionArgs, useRouteError, type HeadersFunction } from "react-router";
 import { useLoaderData, useFetcher } from "react-router";
 import { authenticate } from "../shopify.server";
 import { assertDevRoutesEnabled } from "../flags.server";
@@ -179,3 +180,19 @@ export default function Debug() {
     </Page>
   );
 }
+
+// EVERY EMBEDDED ROUTE NEEDS SHOPIFY'S BOUNDARY.
+// When a session needs re-auth, @shopify/shopify-app-react-router THROWS a
+// Response with status 200 carrying X-Shopify-API-Request-Failure-Reauthorize
+// headers, for App Bridge to intercept. Without boundary.error(), React Router
+// treats it as a route error response and renders its STATUS — a page whose
+// entire body is the text "200". That is Shopify rejection 2.1.1, round two:
+// "going to the billing section and navigating back ... shows an 200 error
+// page". Billing had this block; /app/settings, its own backAction target, did
+// not. `headers` matters too: boundary.headers forwards the reauthorize
+// headers App Bridge is waiting for.
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);

--- a/app/routes/app.help.tsx
+++ b/app/routes/app.help.tsx
@@ -1,3 +1,5 @@
+import { boundary } from "@shopify/shopify-app-react-router/server";
+import { useRouteError, type HeadersFunction } from "react-router";
 import { useState } from "react";
 import {
   Page,
@@ -213,3 +215,19 @@ const Help = () => {
 };
 
 export default Help;
+
+// EVERY EMBEDDED ROUTE NEEDS SHOPIFY'S BOUNDARY.
+// When a session needs re-auth, @shopify/shopify-app-react-router THROWS a
+// Response with status 200 carrying X-Shopify-API-Request-Failure-Reauthorize
+// headers, for App Bridge to intercept. Without boundary.error(), React Router
+// treats it as a route error response and renders its STATUS — a page whose
+// entire body is the text "200". That is Shopify rejection 2.1.1, round two:
+// "going to the billing section and navigating back ... shows an 200 error
+// page". Billing had this block; /app/settings, its own backAction target, did
+// not. `headers` matters too: boundary.headers forwards the reauthorize
+// headers App Bridge is waiting for.
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);

--- a/app/routes/app.payment.callback.tsx
+++ b/app/routes/app.payment.callback.tsx
@@ -1,4 +1,5 @@
-import { redirect, type LoaderFunctionArgs } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+import { redirect, type LoaderFunctionArgs, useRouteError, type HeadersFunction } from "react-router";
 import { authenticate } from "../shopify.server";
 
 // Orphaned with /app/payment. Kept as a redirect so any stale return URL
@@ -7,3 +8,19 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   await authenticate.admin(request);
   return redirect("/app/billing");
 };
+
+// EVERY EMBEDDED ROUTE NEEDS SHOPIFY'S BOUNDARY.
+// When a session needs re-auth, @shopify/shopify-app-react-router THROWS a
+// Response with status 200 carrying X-Shopify-API-Request-Failure-Reauthorize
+// headers, for App Bridge to intercept. Without boundary.error(), React Router
+// treats it as a route error response and renders its STATUS — a page whose
+// entire body is the text "200". That is Shopify rejection 2.1.1, round two:
+// "going to the billing section and navigating back ... shows an 200 error
+// page". Billing had this block; /app/settings, its own backAction target, did
+// not. `headers` matters too: boundary.headers forwards the reauthorize
+// headers App Bridge is waiting for.
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);

--- a/app/routes/app.payment.tsx
+++ b/app/routes/app.payment.tsx
@@ -1,4 +1,5 @@
-import { redirect, type LoaderFunctionArgs } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+import { redirect, type LoaderFunctionArgs, useRouteError, type HeadersFunction } from "react-router";
 import { authenticate } from "../shopify.server";
 
 // Legacy manual-payment entry. Billing now runs through Shopify App Pricing,
@@ -7,3 +8,19 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   await authenticate.admin(request);
   return redirect("/app/billing");
 };
+
+// EVERY EMBEDDED ROUTE NEEDS SHOPIFY'S BOUNDARY.
+// When a session needs re-auth, @shopify/shopify-app-react-router THROWS a
+// Response with status 200 carrying X-Shopify-API-Request-Failure-Reauthorize
+// headers, for App Bridge to intercept. Without boundary.error(), React Router
+// treats it as a route error response and renders its STATUS — a page whose
+// entire body is the text "200". That is Shopify rejection 2.1.1, round two:
+// "going to the billing section and navigating back ... shows an 200 error
+// page". Billing had this block; /app/settings, its own backAction target, did
+// not. `headers` matters too: boundary.headers forwards the reauthorize
+// headers App Bridge is waiting for.
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);

--- a/app/routes/app.reorder-tags.tsx
+++ b/app/routes/app.reorder-tags.tsx
@@ -1,4 +1,5 @@
-import { redirect, type LoaderFunctionArgs } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+import { redirect, type LoaderFunctionArgs, useRouteError, type HeadersFunction } from "react-router";
 import { authenticate } from "../shopify.server";
 import { FEATURE_NFC } from "../flags";
 
@@ -61,3 +62,19 @@ export default function ReorderTags() {
     </div>
   );
 }
+
+// EVERY EMBEDDED ROUTE NEEDS SHOPIFY'S BOUNDARY.
+// When a session needs re-auth, @shopify/shopify-app-react-router THROWS a
+// Response with status 200 carrying X-Shopify-API-Request-Failure-Reauthorize
+// headers, for App Bridge to intercept. Without boundary.error(), React Router
+// treats it as a route error response and renders its STATUS — a page whose
+// entire body is the text "200". That is Shopify rejection 2.1.1, round two:
+// "going to the billing section and navigating back ... shows an 200 error
+// page". Billing had this block; /app/settings, its own backAction target, did
+// not. `headers` matters too: boundary.headers forwards the reauthorize
+// headers App Bridge is waiting for.
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -1,4 +1,5 @@
-import { useLoaderData, type LoaderFunctionArgs } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+import { useLoaderData, type LoaderFunctionArgs, useRouteError, type HeadersFunction } from "react-router";
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
 import { getInventory, getInventoryByShopDomain, getShopIdByDomain } from "../services/ink-api.server";
@@ -105,3 +106,19 @@ export default function SettingsPage() {
   const data = useLoaderData<typeof loader>();
   return <Settings initialData={data} />;
 }
+
+// EVERY EMBEDDED ROUTE NEEDS SHOPIFY'S BOUNDARY.
+// When a session needs re-auth, @shopify/shopify-app-react-router THROWS a
+// Response with status 200 carrying X-Shopify-API-Request-Failure-Reauthorize
+// headers, for App Bridge to intercept. Without boundary.error(), React Router
+// treats it as a route error response and renders its STATUS — a page whose
+// entire body is the text "200". That is Shopify rejection 2.1.1, round two:
+// "going to the billing section and navigating back ... shows an 200 error
+// page". Billing had this block; /app/settings, its own backAction target, did
+// not. `headers` matters too: boundary.headers forwards the reauthorize
+// headers App Bridge is waiting for.
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);

--- a/app/routes/app.settings_.advanced.tsx
+++ b/app/routes/app.settings_.advanced.tsx
@@ -1,3 +1,5 @@
+import { boundary } from "@shopify/shopify-app-react-router/server";
+import { useRouteError, type HeadersFunction } from "react-router";
 import SettingsAdvanced from "../components/settings/SettingsAdvanced";
 
 export async function loader() {
@@ -8,3 +10,19 @@ export async function loader() {
 export default function AdvancedSettingsPage() {
   return <SettingsAdvanced />;
 }
+
+// EVERY EMBEDDED ROUTE NEEDS SHOPIFY'S BOUNDARY.
+// When a session needs re-auth, @shopify/shopify-app-react-router THROWS a
+// Response with status 200 carrying X-Shopify-API-Request-Failure-Reauthorize
+// headers, for App Bridge to intercept. Without boundary.error(), React Router
+// treats it as a route error response and renders its STATUS — a page whose
+// entire body is the text "200". That is Shopify rejection 2.1.1, round two:
+// "going to the billing section and navigating back ... shows an 200 error
+// page". Billing had this block; /app/settings, its own backAction target, did
+// not. `headers` matters too: boundary.headers forwards the reauthorize
+// headers App Bridge is waiting for.
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);

--- a/app/routes/app.tag-existing-orders.tsx
+++ b/app/routes/app.tag-existing-orders.tsx
@@ -1,3 +1,5 @@
+import { boundary } from "@shopify/shopify-app-react-router/server";
+import { useRouteError, type HeadersFunction } from "react-router";
 import { authenticate } from "../shopify.server";
 import { assertDevRoutesEnabled } from "../flags.server";
 
@@ -126,3 +128,19 @@ export async function action({ request }: any) {
     }
   );
 }
+
+// EVERY EMBEDDED ROUTE NEEDS SHOPIFY'S BOUNDARY.
+// When a session needs re-auth, @shopify/shopify-app-react-router THROWS a
+// Response with status 200 carrying X-Shopify-API-Request-Failure-Reauthorize
+// headers, for App Bridge to intercept. Without boundary.error(), React Router
+// treats it as a route error response and renders its STATUS — a page whose
+// entire body is the text "200". That is Shopify rejection 2.1.1, round two:
+// "going to the billing section and navigating back ... shows an 200 error
+// page". Billing had this block; /app/settings, its own backAction target, did
+// not. `headers` matters too: boundary.headers forwards the reauthorize
+// headers App Bridge is waiting for.
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);

--- a/app/routes/app.tagged-shipments.$orderId.tsx
+++ b/app/routes/app.tagged-shipments.$orderId.tsx
@@ -1,2 +1,3 @@
+import { useRouteError, type HeadersFunction } from "react-router";
 // Re-export the existing order detail page under the new /tagged-shipments/:orderId path
 export { loader, action, default as default, ErrorBoundary, headers } from "./app.orders.$orderId";

--- a/app/routes/app.tagged-shipments._index.tsx
+++ b/app/routes/app.tagged-shipments._index.tsx
@@ -1,5 +1,6 @@
+import { boundary } from "@shopify/shopify-app-react-router/server";
 import { useState, useEffect, useCallback } from "react";
-import { useLoaderData, useRevalidator } from "react-router";
+import { useLoaderData, useRevalidator, useRouteError, type HeadersFunction } from "react-router";
 import type { LoaderFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import { getMerchant } from "../services/merchant.server";
@@ -552,3 +553,19 @@ export default function ShipmentsIndex() {
     </PolarisAppLayout>
   );
 }
+
+// EVERY EMBEDDED ROUTE NEEDS SHOPIFY'S BOUNDARY.
+// When a session needs re-auth, @shopify/shopify-app-react-router THROWS a
+// Response with status 200 carrying X-Shopify-API-Request-Failure-Reauthorize
+// headers, for App Bridge to intercept. Without boundary.error(), React Router
+// treats it as a route error response and renders its STATUS — a page whose
+// entire body is the text "200". That is Shopify rejection 2.1.1, round two:
+// "going to the billing section and navigating back ... shows an 200 error
+// page". Billing had this block; /app/settings, its own backAction target, did
+// not. `headers` matters too: boundary.headers forwards the reauthorize
+// headers App Bridge is waiting for.
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);


### PR DESCRIPTION
I was wrong about the cause. #88 blamed Remix's `json()` in an RR7 loader, shipped, deployed — **and the page still renders `200`.** Watched it live on Corvara: `/app/settings`, app frame intact, body just `200`.

A bare status with no status text is React Router rendering a **thrown Response**. When a session needs re-auth, `@shopify/shopify-app-react-router` throws a Response with **status 200** carrying `X-Shopify-API-Request-Failure-Reauthorize` headers for App Bridge to intercept. Without `boundary.error()` on the route, React Router treats it as a route error response and renders its status.

The asymmetry says it plainly:

| route | ErrorBoundary | headers |
|---|---|---|
| `app.billing.tsx` | ✅ | ✅ |
| `app.settings.tsx` — billing's own backAction target | ❌ | ❌ |

Ten other routes were the same. `headers` matters as much as the boundary — `boundary.headers` forwards the reauthorize headers App Bridge is waiting on.

**What I got wrong:** I diagnosed from the code and shipped without loading the page. The Remix `json()` was real and worth fixing, but it wasn't this. It only became findable once I looked at the running app.

`tsc` 0 errors · 65 tests · production build green.