### PR TITLE
The "200 error page" was a plain <a href>, not the loader

### DIFF
--- a/app/contracts/route-contracts.test.ts
+++ b/app/contracts/route-contracts.test.ts
@@ -79,6 +79,17 @@ function handlerBodies(src: string): string[] {
 const rethrowsResponse = (body: string) =>
   /instanceof\s+Response\b[\s\S]{0,400}?\bthrow\s+\w/.test(body);
 
+const SOURCES = (function collect(dir: string): { path: string; src: string }[] {
+  const out: { path: string; src: string }[] = [];
+  for (const name of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, name.name);
+    if (name.isDirectory()) out.push(...collect(full));
+    else if (/\.tsx$/.test(name.name) && !/\.test\.tsx$/.test(name.name))
+      out.push({ path: full.slice(full.indexOf("app/")), src: readFileSync(full, "utf8") });
+  }
+  return out;
+})(resolve(process.cwd(), "app"));
+
 describe("route contracts", () => {
   it("finds routes to check", () => {
     expect(FILES.length).toBeGreaterThan(20);
@@ -155,6 +166,44 @@ describe("route contracts", () => {
 
     // and it does NOT fire once the re-throw is gone
     expect(handlerBodies(rejected.replace("if (err instanceof Response) throw err;", "")).some(rethrowsResponse)).toBe(false);
+  });
+
+  // 2026-08-20, the ACTUAL "200 error page". Polaris's UnstyledLink falls back to
+  // a plain <a href> whenever AppProvider has no linkComponent. Inside the
+  // embedded iframe that is a FULL DOCUMENT navigation: ?shop=&host=&id_token=
+  // are dropped, the request arrives unauthenticated, and the server answers
+  // with App Bridge's re-authorize page — status 200, rendered in the frame.
+  //
+  // Measured in Cloud Run: the back arrow logged `GET /app/settings` with no
+  // authentication and no `/app/settings.data` ever. The loader was never
+  // reached, which is why #88, #91 and #92 all missed it.
+  it("Polaris AppProvider always routes urls through the router", () => {
+    // Only POLARIS's AppProvider takes linkComponent. auth.login renders
+    // Shopify's same-named AppProvider, which does not — resolve the local
+    // alias from the import instead of matching the tag name blindly.
+    const offenders: string[] = [];
+    let checked = 0;
+    for (const f of SOURCES) {
+      const imp = f.src.match(
+        /import\s*\{([^}]*)\}\s*from\s*["']@shopify\/polaris["']/,
+      );
+      if (!imp) continue;
+      const alias = imp[1]
+        .split(",")
+        .map((x) => x.trim())
+        .find((x) => /^AppProvider(\s+as\s+\w+)?$/.test(x));
+      if (!alias) continue;
+      const local = alias.includes(" as ") ? alias.split(/\s+as\s+/)[1].trim() : "AppProvider";
+      for (const tag of f.src.match(new RegExp(`<${local}\\b[^>]*>`, "g")) ?? []) {
+        checked++;
+        if (!/linkComponent=/.test(tag)) offenders.push(`${f.path}: ${tag.slice(0, 60)}`);
+      }
+    }
+    expect(checked, "no Polaris AppProvider found — did it move?").toBeGreaterThan(0);
+    expect(
+      offenders,
+      "A Polaris AppProvider without linkComponent makes every `url` prop a plain <a href>. In an embedded app that is a full document navigation, it drops the session params, and the merchant gets the re-authorize page rendered as a '200 error page'. Pass a React Router Link.",
+    ).toEqual([]);
   });
 
   it("catches the exact code that was rejected", () => {

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import { Outlet, useLoaderData, useRouteError, useRouteLoaderData, Link, type HeadersFunction, type LoaderFunctionArgs, type LinksFunction } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 import { AppProvider as ShopifyAppProvider } from "@shopify/shopify-app-react-router/react";
@@ -95,13 +96,59 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 };
 
 
+// THE "200 ERROR PAGE" — root cause, and it was never the loader.
+//
+// Polaris renders every `url` prop it is given — Page backAction, Button url,
+// Link url — through UnstyledLink, which does exactly this:
+//
+//     const LinkComponent = useLink();
+//     if (LinkComponent) return <LinkComponent {...props} />;
+//     return <a href={url} ... />;            // ← when no linkComponent is set
+//
+// Nothing in this app ever set one, so those were plain anchors. A plain
+// <a href> inside the embedded iframe is a FULL DOCUMENT navigation: it drops
+// ?shop=&host=&id_token=, the request arrives unauthenticated, and the server
+// answers with App Bridge's re-authorize page — carrying status 200. The iframe
+// renders that, and the merchant sees a screen whose body is the text "200".
+//
+// Measured 2026-08-20 in Cloud Run, which is the only reason it was found:
+// clicking through to Billing logs `GET /app/billing.data` — authenticated,
+// session loaded, 70ms. Clicking Billing's BACK ARROW logs `GET /app/settings`
+// — a document request, no params, no "Authenticating admin request" line at
+// all, 10ms — and `/app/settings.data` never appears anywhere in the logs. The
+// settings loader was never reached. All three earlier fixes (#88, #91, #92)
+// treated the loader, which is why logging out and back in changed nothing.
+//
+// Routing Polaris urls through React Router's Link makes them client-side
+// navigations, which keep the embedded session. This covers the whole class,
+// not just Billing's back arrow: app/components/settings/SettingsAdvanced.tsx
+// carries the identical backAction.
+const PolarisLink = forwardRef<HTMLAnchorElement, any>(function PolarisLink(
+  { url = "", external, target, children, ...rest },
+  ref,
+) {
+  // Anything leaving the app stays a real anchor.
+  if (external || target === "_blank" || /^(https?:|mailto:|tel:)/i.test(url)) {
+    return (
+      <a href={url} target={target ?? "_blank"} rel="noopener noreferrer" ref={ref} {...rest}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link to={url} ref={ref} {...rest}>
+      {children}
+    </Link>
+  );
+});
+
 export default function App() {
   const { apiKey } = useLoaderData<typeof loader>();
 
   return (
     <QueryClientProvider client={queryClient}>
       <ShopifyAppProvider embedded apiKey={apiKey}>
-        <PolarisAppProvider i18n={translations}>
+        <PolarisAppProvider i18n={translations} linkComponent={PolarisLink}>
           <ShopProvider>
             <TooltipProvider>
               <Toaster />
@@ -122,7 +169,7 @@ export function ErrorBoundary() {
   if (data && data.apiKey) {
     return (
       <ShopifyAppProvider embedded apiKey={data.apiKey}>
-        <PolarisAppProvider i18n={translations}>
+        <PolarisAppProvider i18n={translations} linkComponent={PolarisLink}>
           {boundary.error(error)}
         </PolarisAppProvider>
       </ShopifyAppProvider>


### PR DESCRIPTION
Three fixes missed this because all three treated the loader. **The loader was never reached.**

## What the logs say

Cloud Run, 2026-08-20, one merchant clicking:

```
18:22:10  GET /app/billing.data     200   70.3 ms   session loaded, shop identified
18:22:11  GET /app/settings         200   10.3 ms   (no "Authenticating admin request")
```

Navigating **to** Billing is a client-side navigation — it authenticates and loads the session. Clicking Billing's **back arrow** produces a *document* request for `/app/settings` with no query params, no authentication, and a 10ms round trip. `/app/settings.data` never appears in the logs at all.

## Why

Billing's back arrow is `backAction={{ url: "/app/settings" }}`. Polaris routes every `url` through `UnstyledLink`:

```js
const LinkComponent = useLink();
if (LinkComponent) return <LinkComponent {...props} />;
return <a href={url} ... />;
```

Nothing in this app ever passed `linkComponent` to Polaris's `AppProvider`, so that was a plain anchor. Inside the embedded iframe a plain anchor is a **full document navigation**: `?shop=&host=&id_token=` are dropped, the request arrives unauthenticated, and `@shopify/shopify-app-react-router` answers with App Bridge's re-authorize page — which carries **status 200**. The iframe renders it.

That is the screen the reviewer photographed. It is also why logging out and back in changed nothing: a fresh session cannot survive a navigation that discards it.

## The fix

Both `PolarisAppProvider` instances now take a `linkComponent` that routes internal urls through React Router's `Link` and leaves external ones as anchors.

This covers the class, not one arrow — `components/settings/SettingsAdvanced.tsx` carries the identical `backAction`, and every Polaris `Button`/`Link` `url` in the app was the same plain anchor.

## The guard, watched failing

`route-contracts` gains **"Polaris AppProvider always routes urls through the router"**. Strip `linkComponent` and it fails, naming both providers in `app/routes/app.tsx`.

It resolves the local alias from the `@shopify/polaris` import rather than matching the tag name, because `auth.login/route.tsx` renders Shopify's identically-named `AppProvider`, which takes no `linkComponent` — matching blindly reports that as a false offender.

## On the earlier fixes

`#88` (Remix `json`), `#91` (boundary on every route) and `#92` (try/catch in the settings loader) are all real hardening and all stay. None of them was this.

`tsc` 0 errors · 68 tests · production build green.

**Verification after deploy:** clicking Billing's back arrow should log `GET /app/settings.data` — authenticated, session loaded — instead of a bare `GET /app/settings`.