### PR TITLE
The order page pointed at a 404, and never showed it to anyone

### DIFF
--- a/app/contracts/route-contracts.test.ts
+++ b/app/contracts/route-contracts.test.ts
@@ -90,6 +90,12 @@ const SOURCES = (function collect(dir: string): { path: string; src: string }[] 
   return out;
 })(resolve(process.cwd(), "app"));
 
+/** Source with // and /* *\/ comments removed. Prose that describes a banned
+ *  pattern is not an instance of it. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
 describe("route contracts", () => {
   it("finds routes to check", () => {
     expect(FILES.length).toBeGreaterThan(20);
@@ -204,6 +210,50 @@ describe("route contracts", () => {
       offenders,
       "A Polaris AppProvider without linkComponent makes every `url` prop a plain <a href>. In an embedded app that is a full document navigation, it drops the session params, and the merchant gets the re-authorize page rendered as a '200 error page'. Pass a React Router Link.",
     ).toEqual([]);
+  });
+
+  // 2026-08-20. app.orders.$orderId's loader hand-built the buyer's address as
+  // `https://in.ink/verify/${proofId}`. Loaded in a browser that renders
+  // "404 NOTHING HERE" — the live address is {brand}.in.ink/r/{nfc_token}.
+  //
+  // brand-page-url.server.ts opens with "one author, because two would drift",
+  // and names the exact damage: an email and a tracking button sending the same
+  // buyer to two different pages. This was the third copy, and the one that was
+  // wrong. So the rule is mechanical: nobody builds that address by hand.
+  it("nobody hand-builds the buyer's page URL", () => {
+    const AUTHOR = "app/services/brand-page-url.server.ts";
+    const offenders: string[] = [];
+    for (const f of SOURCES) {
+      if (f.path === AUTHOR) continue;
+      // in.ink/verify/... is the dead shape; in.ink/r/... is the live one, and
+      // only the author may assemble it. Literal hosts in tests are their own
+      // business — this scans app source, and the contract file excludes itself.
+      if (/in\.ink\/verify\//.test(stripComments(f.src))) {
+        offenders.push(`${f.path} (dead /verify/ shape)`);
+      }
+    }
+    expect(
+      offenders,
+      "The buyer's page address has one author: app/services/brand-page-url.server.ts. `in.ink/verify/{proof}` is not a real page — it renders 404 — and a second copy of this resolution is how an email and a tracking link end up pointing at two different pages.",
+    ).toEqual([]);
+  });
+
+  it("that detector fires on the URL that was actually shipped", () => {
+    const shipped = "verify_url: `https://in.ink/verify/${proofId}`,";
+    expect(/in\.ink\/verify\//.test(stripComments(shipped))).toBe(true);
+
+    const fixed = "verify_url: resolvedPage.pageUrl,";
+    expect(/in\.ink\/verify\//.test(stripComments(fixed))).toBe(false);
+
+    // A comment DESCRIBING the dead URL is not an offence — the first version
+    // of this contract failed on its own explanatory comment, which is how a
+    // detector teaches people to delete the explanation instead of the bug.
+    expect(
+      /in\.ink\/verify\//.test(stripComments("// this used to build in.ink/verify/{id}\nconst x = 1;")),
+    ).toBe(false);
+    expect(
+      /in\.ink\/verify\//.test(stripComments("/* in.ink/verify/{id} */\nconst x = 1;")),
+    ).toBe(false);
   });
 
   it("catches the exact code that was rejected", () => {

--- a/app/routes/app.orders.$orderId.tsx
+++ b/app/routes/app.orders.$orderId.tsx
@@ -216,7 +216,7 @@ export const loader = async ({
     request,
     params,
 }: LoaderFunctionArgs): Promise<LoaderData> => {
-    const { admin } = await authenticate.admin(request);
+    const { admin, session } = await authenticate.admin(request);
     const { orderId } = params;
 
     if (!orderId) {
@@ -325,9 +325,32 @@ export const loader = async ({
 
                 console.log(`✅ Proof data retrieved from Alan's API`);
 
+                // THE BUYER'S PAGE, from the one author of that address.
+                //
+                // This hand-built `https://in.ink/verify/{proof_id}`. That URL
+                // is dead — measured 2026-08-20, it renders "404 NOTHING HERE"
+                // — and it was a third copy of a resolution that
+                // brand-page-url.server.ts exists specifically to keep single:
+                // "one author, because two would drift." It drifted.
+                //
+                // The live address is {brand}.in.ink/r/{nfc_token}. pageUrl is
+                // null unless the proof carries a real nfc_token, which is the
+                // point: nothing gets published that we cannot stand behind.
+                const { resolveBrandPageUrl } = await import("../services/brand-page-url.server");
+                const { findMerchantDoc } = await import("../services/merchant-doc.server");
+                const firestore = (await import("../firestore.server")).default;
+                const merchantHit = await findMerchantDoc(firestore, session.shop);
+                const resolvedPage = await resolveBrandPageUrl({
+                    merchantApiKey: merchantHit?.data?.ink_api_key ?? null,
+                    proofId,
+                    shop: session.shop,
+                    merchantData: merchantHit?.data ?? {},
+                    label: "order-detail",
+                });
+
                 alanProofData = {
                     verification_status: proofResponse.delivery?.gps_verdict ? "verified" : "enrolled",
-                    verify_url: `https://in.ink/verify/${proofId}`,
+                    verify_url: resolvedPage.pageUrl,
                     verification_updated_at: proofResponse.delivery?.timestamp || null,
                     distance_meters: null, // Not returned by /retrieve, only /verify
                     gps_verdict: proofResponse.delivery?.gps_verdict || null,
@@ -818,6 +841,20 @@ export default function OrderDetails() {
                 }
                 subtitle={formatDate(order.createdAt)}
                 backAction={{ content: "Shipments", onAction: () => navigate(-1) }}
+                // The buyer's page, offered where a merchant is already looking
+                // at the order. It was resolved in the loader and then rendered
+                // nowhere — a typed field nobody shows is invisible to tsc, to
+                // the suite, and to review. `external` keeps it a real anchor:
+                // it leaves the embedded app for {brand}.in.ink.
+                secondaryActions={
+                    order.localProof?.verify_url
+                        ? [{
+                            content: "Open the buyer's page",
+                            url: order.localProof.verify_url,
+                            external: true,
+                        }]
+                        : undefined
+                }
             >
                 <Layout>
                     {/* Left Column: Customer + Products */}


### PR DESCRIPTION
The loader hand-built the buyer's address:

```ts
verify_url: `https://in.ink/verify/${proofId}`,
```

Loaded in a browser, that renders **"404 NOTHING HERE"**. The live address is `{brand}.in.ink/r/{nfc_token}` — measured today:

```
/o/1009  ->  "Order received · Corvara Bar Tape + Finishing Kit · sam"
/o/1006  ->  "On its way · Corvara Team Jersey — Nero · Nina"
```

`brand-page-url.server.ts` opens with *"one author, because two would drift"*, and names the damage it exists to prevent: an email and a tracking button sending the same buyer to two different pages. This was the third copy, and the wrong one. It now calls that author.

## And it was never rendered

The field was typed on `LoaderData`, assembled in the loader, returned to the client, and displayed **nowhere** — so nothing could show it was broken. A typed field nobody renders is invisible to `tsc`, to the suite and to review. That's law 9 in TECH_BIBLE, and this was exactly its shape.

So it's rendered now, as a secondary action on the order: **"Open the buyer's page"**. A merchant looking at an order can open what their customer sees. It's `external`, so `PolarisLink` keeps it a real anchor out to `{brand}.in.ink` rather than a client-side navigation — the case #94 added that fallback for.

The link only appears when `resolveBrandPageUrl` returns a `pageUrl`, which is null unless the proof carries a real `nfc_token`. Nothing gets published that can't be stood behind.

## The contract, and why its first version was wrong

`route-contracts` gains **"nobody hand-builds the buyer's page URL"**.

Its first version failed on the *comment* I had just written explaining the dead URL. A detector that fires on its own documentation teaches people to delete the explanation instead of the bug. It strips comments before scanning, and the self-test pins that: the shipped literal trips it, the fix doesn't, and neither does prose describing either one.

Reverted against the shipped loader it fails, naming `app.orders.$orderId.tsx`.

`tsc` 0 errors · 70 tests · production build green.