### PR TITLE
"Your page — not built yet", over a page that renders

### DIFF
--- a/app/routes/app.api.onboarding.status.tsx
+++ b/app/routes/app.api.onboarding.status.tsx
@@ -74,7 +74,29 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         };
         // "Built" = the book has real brand media (logo or hero), not just a
         // provisioned shell.
-        brandBuilt = Boolean(kit.logoUrl || kit.heroUrl);
+        // "BUILD YOUR PAGE" IS ANSWERED BY A PAGE, NOT BY PICTURES.
+        //
+        // This read `Boolean(kit.logoUrl || kit.heroUrl)`, which asks whether
+        // the brand has imagery. Those are different questions, and they came
+        // apart on the first real Shopify install to reach this screen
+        // (Corvara Cicli, 2026-08-20):
+        //
+        //   book.tap_page                      present — the page renders
+        //   runtime…logo.primary_logo_candidate ""     — the logo the kit reads
+        //   tokens.logo.primary_url            set     — where the logo IS
+        //   tap_page.hero_url                  null    — EMPTY BY DESIGN: a
+        //     non-Instagram page leaves the hero to the live order's product
+        //   instagram.posts                    0       — no Instagram
+        //
+        // So a merchant with a working page was told "Your page — not built
+        // yet" and handed a button to go build one. For a store behind a
+        // storefront password that button is a dead end, which is the exact
+        // shape of the 2.1.1 rejection.
+        //
+        // A page exists when the book carries one. Imagery still counts —
+        // a brand mid-build with a logo and no page has started — but it is
+        // no longer the only way to answer yes.
+        brandBuilt = Boolean(kit.hasPage || kit.logoUrl || kit.heroUrl);
       }
       if (stats) {
         ordersEnrolled = stats.enrollments ?? 0;

--- a/app/services/brand-built-means-a-page.test.ts
+++ b/app/services/brand-built-means-a-page.test.ts
@@ -1,0 +1,71 @@
+// "BUILD YOUR PAGE" IS ANSWERED BY A PAGE.
+//
+// The dashboard answered it with `logoUrl || heroUrl` — a question about
+// pictures. On Corvara Cicli (2026-08-20, the first real Shopify install to
+// reach this screen) the two came apart:
+//
+//   book.tap_page                       present  — the page renders live
+//   runtime…logo.primary_logo_candidate ""       — what the kit reads
+//   tokens.logo.primary_url             set      — where the logo actually is
+//   tap_page.hero_url                   null     — EMPTY BY DESIGN, a non-IG
+//     page leaves the hero for the live order's product (tapPageFromEntry)
+//   instagram.posts                     0
+//
+// So a merchant whose page works was told "Your page — not built yet" and
+// handed a button to go build one. Behind a storefront password that button is
+// a dead end — the exact shape of the 2.1.1 rejection.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const STATUS = readFileSync(
+  resolve(process.cwd(), "app/routes/app.api.onboarding.status.tsx"),
+  "utf8",
+);
+const KIT = readFileSync(
+  resolve(process.cwd(), "app/services/brand-email.server.ts"),
+  "utf8",
+);
+
+/** Prose describing a rule is not an instance of it. */
+const stripComments = (src: string) =>
+  src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+
+describe("brandBuilt", () => {
+  it("the kit reports whether a page exists", () => {
+    const kit = stripComments(KIT);
+    expect(kit, "BrandEmailKit no longer carries hasPage").toMatch(/hasPage\s*:\s*boolean/);
+    expect(
+      kit,
+      "hasPage must be derived from the book's own page, not from imagery",
+    ).toMatch(/hasPage\s*:\s*Boolean\(\s*book\?\.tap_page\s*\)/);
+  });
+
+  it("the dashboard asks the page question, not the pictures question", () => {
+    const status = stripComments(STATUS);
+    const assign = status.match(/brandBuilt\s*=\s*Boolean\(([^)]*)\)/);
+    expect(assign, "brandBuilt assignment is gone or reshaped").not.toBeNull();
+    expect(
+      assign![1],
+      "brandBuilt still answers 'is your page built?' using only imagery. A live page with no logo and no hero — which is every non-Instagram page, because tapPageFromEntry leaves hero_url empty on purpose — reads as 'not built yet'.",
+    ).toMatch(/hasPage/);
+  });
+
+  it("imagery alone still counts — a brand mid-build has started", () => {
+    // The fix must not INVERT the bug: a logo with no page yet is still
+    // progress, and demoting it would be the same error pointing the other way.
+    const status = stripComments(STATUS);
+    const assign = status.match(/brandBuilt\s*=\s*Boolean\(([^)]*)\)/)![1];
+    expect(assign).toMatch(/logoUrl/);
+    expect(assign).toMatch(/heroUrl/);
+  });
+
+  it("the detector fires on the line that shipped", () => {
+    const shipped = "brandBuilt = Boolean(kit.logoUrl || kit.heroUrl);";
+    expect(/hasPage/.test(shipped)).toBe(false);
+    const fixed = "brandBuilt = Boolean(kit.hasPage || kit.logoUrl || kit.heroUrl);";
+    expect(/hasPage/.test(fixed)).toBe(true);
+    // a comment naming hasPage is not compliance
+    expect(/hasPage/.test(stripComments("// one day, hasPage\nconst x = 1;"))).toBe(false);
+  });
+});

--- a/app/services/brand-email.server.ts
+++ b/app/services/brand-email.server.ts
@@ -39,6 +39,15 @@ export interface BrandEmailKit {
   paper: string;
   /** The page's own hero media (IG post / published hero) — the email's visual. */
   heroUrl: string | null;
+  /** Does a page EXIST for this brand — `book.tap_page` is present.
+   *
+   *  Separate from logoUrl/heroUrl on purpose. The dashboard used to answer
+   *  "is your page built?" with `logoUrl || heroUrl`, which is a question
+   *  about PICTURES, not about a page. Corvara Cicli, 2026-08-20: a live
+   *  broadsheet front page that renders for every order, and the merchant's
+   *  first screen still read "Your page — not built yet" with a button
+   *  inviting them to go build one. */
+  hasPage: boolean;
   campaigns: EmailCampaign[];
 }
 
@@ -86,6 +95,7 @@ export async function fetchBrandEmailKit(shopId: string): Promise<BrandEmailKit 
         httpsImage(igPosts.find((p) => p?.display_url && p?.enabled !== false)?.display_url) ??
         httpsImage(book?.imagery?.hero?.[0]?.url) ??
         null,
+      hasPage: Boolean(book?.tap_page),
       campaigns: Array.isArray(book?.campaigns) ? (book.campaigns as EmailCampaign[]) : [],
     };
   } catch {


### PR DESCRIPTION
**Not a blocker.** The reviewer saw this card in the last submission and said nothing — the rejections were 2.1.1 and 4.5.3. It's simply wrong, and it's wrong on the merchant's first screen.

```ts
brandBuilt = Boolean(kit.logoUrl || kit.heroUrl)
```

That asks whether the brand has **pictures**, to answer whether a **page** exists. The two came apart on the first real Shopify install to reach this screen — Corvara Cicli:

```
book.tap_page                        present   the page renders live
runtime…logo.primary_logo_candidate  ""        what the kit reads
tokens.logo.primary_url              set       where the logo actually is
tap_page.hero_url                    null      EMPTY BY DESIGN
instagram.posts                      0
```

`tap_page.hero_url` being null isn't a fault — `tapPageFromEntry` leaves the hero empty for every non-Instagram page on purpose, so the live order's own product fills it at tap time. Which means **every non-Instagram page reads as "not built yet"** unless the brand also happens to carry a logo at one specific runtime path.

So the merchant is told their page doesn't exist, and handed a button to go build one. On a storefront behind a password that button is a dead end — the same shape as the rejection, one screen earlier.

## The fix

The kit reports `hasPage` from `book.tap_page`; the dashboard reads it.

Imagery still counts. A brand mid-build with a logo and no page **has** started, and demoting that would be the same error pointed the other way. The guard pins both directions — and pins that a comment naming `hasPage` isn't compliance.

Reverted against the shipped tree it fails on both halves.

## Noted, not fixed here

- The logo lives at `tokens.logo.primary_url` while the kit reads `runtime…primary_logo_candidate` — one thing, two names.
- Corvara's logo is a `favicon.ico`.

`tsc` 0 errors · 74 tests · production build green.