### PR TITLE
The order status page carries the brand, and the app can flip it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ env.*
 # Local render harness — review tool, never shipped (see PR #81).
 preview-harness/
 .claude/
+/extensions/*/manifest.json

--- a/app/components/settings/CommunicationSettings.tsx
+++ b/app/components/settings/CommunicationSettings.tsx
@@ -89,6 +89,15 @@ const CommunicationSettings = ({ shopDomain }: { shopDomain?: string }) => {
   // fallback so the card is never blank and never shows a guessed host.
   const [snippet, setSnippet] = useState<string>(FALLBACK_SNIPPET);
   const [loaded, setLoaded] = useState(false);
+  // THE FLIP — the half of this page that needs no merchant work at all.
+  // `canFlip` is false until the store has a brand page to point at; the row
+  // says so instead of offering a switch that would write a broken door.
+  const [door, setDoor] = useState<{ on: boolean; door: string | null; canFlip: boolean }>({
+    on: true,
+    door: null,
+    canFlip: false,
+  });
+  const [doorSaving, setDoorSaving] = useState(false);
 
   useEffect(() => {
     let mounted = true;
@@ -101,6 +110,14 @@ const CommunicationSettings = ({ shopDomain }: { shopDomain?: string }) => {
       }
       if (data?.snippet) setSnippet(data.snippet);
       setLoaded(true);
+    });
+    secureFetch("/app/api/settings/order-door").then(({ data, error }) => {
+      if (!mounted || error || !data) return;
+      setDoor({
+        on: data.on !== false,
+        door: data.door ?? null,
+        canFlip: Boolean(data.canFlip),
+      });
     });
     return () => {
       mounted = false;
@@ -193,6 +210,37 @@ const CommunicationSettings = ({ shopDomain }: { shopDomain?: string }) => {
     </InlineStack>
   );
 
+  // The brand host alone — never the door base with its dangling /o/.
+  const doorHost = (() => {
+    try {
+      return door.door ? new URL(door.door).host : null;
+    } catch {
+      return null;
+    }
+  })();
+
+  // Apply-first on the server: a failure means Shopify did NOT change, so the
+  // switch must not move either.
+  const flipDoor = async () => {
+    const next = !door.on;
+    setDoorSaving(true);
+    const { data, error } = await secureFetch("/app/api/settings/order-door", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ on: next }),
+    });
+    setDoorSaving(false);
+    if (error) {
+      toast({ description: error.message, variant: "destructive", duration: 4000 });
+      return;
+    }
+    setDoor((d) => ({ ...d, on: next, door: data?.door ?? d.door }));
+    toast({
+      description: next ? "Your page is on the order status page." : "Turned off.",
+      duration: 2000,
+    });
+  };
+
   const templatesDone = TEMPLATE_KEYS.filter((k) => settings.templatesPastedAt[k]).length;
   const notificationsUrl = shopDomain
     ? `https://admin.shopify.com/store/${shopDomain.replace(".myshopify.com", "")}/settings/notifications`
@@ -200,6 +248,37 @@ const CommunicationSettings = ({ shopDomain }: { shopDomain?: string }) => {
 
   return (
     <Layout>
+      {/* ── The half that needs no merchant work ───────────────────────── */}
+      <Layout.AnnotatedSection
+        title="The order status page"
+        description="Every button in Shopify's emails opens it. This puts your page there."
+      >
+        <Card>
+          <BlockStack gap="400">
+            <ToggleRow
+              checked={door.on && door.canFlip}
+              onToggle={flipDoor}
+              disabled={!door.canFlip || doorSaving}
+              title="Show your page"
+              description={
+                !door.canFlip
+                  ? "Connect this store to ink first — then this turns on."
+                  : door.on
+                    ? // The HOST, never the door base: a merchant reading
+                      // "a link to https://brand.in.ink/o/" sees a dangling
+                      // URL no buyer is ever sent to. Each buyer gets their
+                      // own order appended to it.
+                      `Every buyer gets a link to their order on ${doorHost ?? "your page"}.`
+                    : "Off. The order status page shows nothing from you."
+              }
+              suffix={
+                door.canFlip && door.on ? <Badge tone="success">On</Badge> : undefined
+              }
+            />
+          </BlockStack>
+        </Card>
+      </Layout.AnnotatedSection>
+
       {/* ── The one merchant action that isn't automatic ───────────────── */}
       <Layout.AnnotatedSection
         title="Your page in Shopify's emails"

--- a/app/routes/app.api.settings.order-door.tsx
+++ b/app/routes/app.api.settings.order-door.tsx
@@ -1,0 +1,173 @@
+// THE FLIP — the switch that puts the brand on the page Shopify's emails open.
+//
+// GET  /app/api/settings/order-door → { on, door, canFlip }
+// POST { on: boolean }              → applies it to Shopify, then records it
+//
+// Shopify's notification templates cannot be edited by any app, so the email's
+// primary button always opens Shopify's Order status page. The order-page-block
+// extension puts the brand's door on that page — and this route is the only
+// thing a merchant has to touch to turn it on. No code, no template, no paste.
+//
+// THE ORDER OF OPERATIONS IS THE POINT (the return-window law, same file
+// family): APPLY FIRST, RECORD SECOND. The Firestore flag is only a record of
+// what Shopify already carries. If the metafield write fails we return the
+// failure and write NOTHING, so the toggle can never show "on" for a store
+// whose order status page is bare — the exact drift the return-window save
+// refuses for the same reason.
+//
+// The slug is resolved the NO-PROOF way (backend merchant doc → brand_slug),
+// the same way the snippet card does it, because a settings save has no proof
+// in hand. brand_slug only: a domain-derived host looks right and 404s (#1016).
+
+import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
+import firestore from "../firestore.server";
+import { verifyProxyToken } from "../services/token-verify.server";
+import { findMerchantDocRef } from "../services/merchant-doc.server";
+import { resolveShopFromTokenPayload } from "../services/notification-settings";
+import { brandSlugFromDoc } from "../services/brand-page-url.server";
+import { getShopIdByDomain } from "../services/ink-api.server";
+import { unauthenticated } from "../shopify.server";
+import {
+  assertOrderDoorMetafield,
+  orderDoorBase,
+} from "../services/order-door-metafield.server";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+const json = (data: any, init?: ResponseInit) =>
+  new Response(JSON.stringify(data), {
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+    ...init,
+  });
+
+async function authenticateShop(
+  request: Request,
+): Promise<{ shop: string } | { error: Response }> {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return { error: json({ error: "Unauthorized" }, { status: 401 }) };
+  }
+  const tokenPayload = await verifyProxyToken(authHeader.slice(7));
+  if (!tokenPayload) {
+    return { error: json({ error: "Invalid or expired token" }, { status: 401 }) };
+  }
+  const shop =
+    resolveShopFromTokenPayload(tokenPayload) ??
+    (typeof tokenPayload.merchant_id === "string" ? tokenPayload.merchant_id : null);
+  if (!shop) return { error: json({ error: "Token names no shop" }, { status: 401 }) };
+  return { shop };
+}
+
+/** The brand's own subdomain label, WITHOUT a proof — backend doc merged over
+ *  the embed's, brand_slug only. Empty string when the doc does not say. */
+async function resolveSlugNoProof(
+  shop: string,
+  embedDoc: Record<string, any>,
+): Promise<string> {
+  try {
+    const shopId = await getShopIdByDomain(shop);
+    const backend = shopId
+      ? ((await firestore.collection("merchants").doc(shopId).get()).data() ?? {})
+      : {};
+    const merged = { ...embedDoc, ...backend };
+    // brandSlugFromDoc falls back to the DOMAIN when no brand_slug exists.
+    // That fallback is right for the snippet card's www default and wrong
+    // here, so the doc must actually carry brand_slug or we return nothing.
+    if (!merged.brand_slug) return "";
+    return brandSlugFromDoc(merged, shop);
+  } catch (e: any) {
+    console.warn(`[settings/order-door] slug unresolved for ${shop}: ${e?.message}`);
+    return "";
+  }
+}
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  const auth = await authenticateShop(request);
+  if ("error" in auth) return auth.error;
+
+  try {
+    const hit = await findMerchantDocRef(firestore, auth.shop);
+    if (!hit) return json({ error: "Merchant not found" }, { status: 404 });
+
+    const slug = await resolveSlugNoProof(auth.shop, hit.data ?? {});
+    return json({
+      // Default ON, like branded_tracking_link — only an explicit false is off.
+      on: hit.data?.order_door_block !== false,
+      door: slug ? orderDoorBase(slug) : null,
+      // Without a brand_slug there is no honest door to point at, so the
+      // switch says so rather than flipping into a broken state.
+      canFlip: Boolean(slug),
+    });
+  } catch (err: any) {
+    console.error("[settings/order-door] GET error:", err.message);
+    return json({ error: "Couldn't read the order page setting" }, { status: 500 });
+  }
+};
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  if (request.method !== "POST") {
+    return json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const auth = await authenticateShop(request);
+  if ("error" in auth) return auth.error;
+
+  try {
+    const body = await request.json().catch(() => null);
+    if (typeof body?.on !== "boolean") {
+      return json({ error: "Send { on: true } or { on: false }" }, { status: 400 });
+    }
+    const on: boolean = body.on;
+
+    const hit = await findMerchantDocRef(firestore, auth.shop);
+    if (!hit) return json({ error: "Merchant not found" }, { status: 404 });
+
+    const slug = on ? await resolveSlugNoProof(auth.shop, hit.data ?? {}) : "";
+    if (on && !slug) {
+      return json(
+        {
+          error:
+            "This store has no brand page yet — connect it to ink first, then turn this on.",
+        },
+        { status: 409 },
+      );
+    }
+
+    // APPLY FIRST. `unauthenticated.admin` uses the stored offline session, so
+    // this works from a settings save with no admin request in flight.
+    const { admin } = await unauthenticated.admin(auth.shop);
+    const result = await assertOrderDoorMetafield({
+      admin,
+      shop: auth.shop,
+      // The service reads the flag from what it is GIVEN, not from Firestore,
+      // so pass the intended next state — not the stale stored one.
+      merchantData: { ...(hit.data ?? {}), order_door_block: on },
+      slug,
+      label: "[settings] order-door",
+    });
+
+    if (result.outcome === "failed") {
+      return json(
+        { error: "Shopify wouldn't accept the change — nothing was saved." },
+        { status: 502 },
+      );
+    }
+
+    // RECORD SECOND, now that Shopify carries it.
+    await hit.ref.set({ order_door_block: on }, { merge: true });
+    return json({ success: true, on, door: result.value ?? null, outcome: result.outcome });
+  } catch (err: any) {
+    console.error("[settings/order-door] POST error:", err.message);
+    return json({ error: "Couldn't update the order page setting" }, { status: 500 });
+  }
+};

--- a/app/routes/webhooks.fulfillments_create.tsx
+++ b/app/routes/webhooks.fulfillments_create.tsx
@@ -104,6 +104,20 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         shippoRegistered: patched?.shippo_registered === true,
         label: `[${topic}] branded-tracking-link`,
       });
+
+      // The Order status page — where the email's primary button lands —
+      // carries the brand's door once this shop metafield exists. One guard
+      // read per event, a real write once per merchant ever, and never fatal
+      // (order-door-metafield.server.ts).
+      const { assertOrderDoorMetafield } = await import("../services/order-door-metafield.server");
+      await assertOrderDoorMetafield({
+        admin,
+        shop,
+        merchantData: merchantHit?.data ?? {},
+        merchantApiKey,
+        proofId,
+        label: `[${topic}] order-door`,
+      });
     } catch (e: any) {
       console.error(`❌ branded tracking link failed (non-fatal):`, e?.message);
     }

--- a/app/routes/webhooks.fulfillments_update.tsx
+++ b/app/routes/webhooks.fulfillments_update.tsx
@@ -125,6 +125,20 @@ export const action = async ({ request }: ActionFunctionArgs) => {
               shippoRegistered: patched?.shippo_registered === true,
               label: `[${topic}] branded-tracking-link`,
             });
+
+            // The Order status page — where the email's primary button lands —
+            // carries the brand's door once this shop metafield exists. One
+            // guard read per event, a real write once per merchant ever, and
+            // never fatal (order-door-metafield.server.ts).
+            const { assertOrderDoorMetafield } = await import("../services/order-door-metafield.server");
+            await assertOrderDoorMetafield({
+              admin,
+              shop,
+              merchantData: hit?.data ?? {},
+              merchantApiKey: apiKey,
+              proofId: trackingProofId,
+              label: `[${topic}] order-door`,
+            });
           } else {
             console.log(`⚠️ No ink_api_key for ${shop}; cannot forward tracking added on update.`);
           }

--- a/app/services/order-door-metafield.server.ts
+++ b/app/services/order-door-metafield.server.ts
@@ -1,0 +1,169 @@
+// THE DOOR ON THE SHOP — one metafield, and the order status page speaks.
+//
+// The order-page-block extension (extensions/order-page-block) renders on the
+// Order status page — the page Shopify's email buttons open — but ONLY when
+// the shop carries an `ink:order_door` metafield holding the brand's door
+// base (`https://{brand}.in.ink/o/`). No metafield, no surface. This service
+// is the only writer of that metafield, so turning the block on or off for a
+// store is a server-side act; the extension never redeploys.
+//
+// THREE RULES, each paid for elsewhere:
+//
+//  1. THE METAFIELD IS ITS OWN GUARD. Steady state is ONE cheap read per
+//     fulfillment event and nothing else — no Alan call, no Firestore
+//     schema recording "did we write it", no drift between a record and the
+//     truth. Brand resolution (an Alan proof fetch + doc merge) runs only
+//     when the metafield is absent, i.e. once per merchant ever. The
+//     register-quota lesson (#954): per-event list calls are a real bill.
+//  2. THE SLUG COMES FROM THE ONE AUTHOR. `resolveBrandPageUrl` merges the
+//     backend merchant doc over the embed's — the same resolution the
+//     tracking rewrite uses. brand_slug ONLY: a domain-derived guess mints
+//     `sm-test-hhawzn52.in.ink`, a host that looks right and 404s (#1016).
+//     No slug ⇒ no write, and any existing door is DELETED — a wrong door
+//     is worse than none (the Clare-V law).
+//  3. NEVER FATAL. This runs on webhook paths where the only unforgivable
+//     outcome is a non-200. Every failure logs and returns an outcome.
+//
+// The kill switch mirrors branded_tracking_link: default ON for every
+// merchant; `merchants/{shop}.order_door_block === false` turns one store
+// off (the metafield is deleted on the next fulfillment event), and the
+// extension goes dark there with no deploy.
+
+import { resolveBrandPageUrl } from "./brand-page-url.server";
+
+export type OrderDoorOutcome =
+  | "written"
+  | "deleted"
+  | "unchanged"
+  | "skipped_off"
+  | "skipped_no_slug"
+  | "failed";
+
+export interface OrderDoorResult {
+  outcome: OrderDoorOutcome;
+  value?: string;
+  detail?: string;
+}
+
+const GUARD_QUERY = `#graphql
+  query InkOrderDoorGuard {
+    shop {
+      id
+      metafield(namespace: "ink", key: "order_door") { id value }
+    }
+  }
+`;
+
+const SET_MUTATION = `#graphql
+  mutation InkOrderDoorSet($metafields: [MetafieldsSetInput!]!) {
+    metafieldsSet(metafields: $metafields) {
+      userErrors { field message }
+    }
+  }
+`;
+
+const DELETE_MUTATION = `#graphql
+  mutation InkOrderDoorDelete($metafields: [MetafieldIdentifierInput!]!) {
+    metafieldsDelete(metafields: $metafields) {
+      userErrors { field message }
+    }
+  }
+`;
+
+/** The door base for one brand slug — the exact string the extension trusts
+ *  (`^https://[a-z0-9][a-z0-9-]*\.in\.ink/o/$`). Exported so the test and the
+ *  extension's expectation can never drift apart silently. */
+export function orderDoorBase(slug: string): string {
+  return `https://${slug}.in.ink/o/`;
+}
+
+export async function assertOrderDoorMetafield({
+  admin,
+  shop,
+  merchantData,
+  merchantApiKey,
+  proofId,
+  label = "order-door",
+}: {
+  admin: { graphql: (query: string, opts?: any) => Promise<Response> };
+  shop: string;
+  merchantData: Record<string, any>;
+  merchantApiKey?: string | null;
+  /** A proof on this shop — how the one-author resolution finds the backend
+   *  merchant doc. Any current proof works; the slug is per-merchant. */
+  proofId: string;
+  label?: string;
+}): Promise<OrderDoorResult> {
+  try {
+    // 1 · What does the shop carry right now? (The whole cost, steady state.)
+    const guardRes = await admin.graphql(GUARD_QUERY);
+    const guard: any = await guardRes.json();
+    const shopGid: string | undefined = guard?.data?.shop?.id;
+    const current: string = String(guard?.data?.shop?.metafield?.value || "");
+    if (!shopGid) {
+      console.warn(`🚪 ${label}: shop id unreadable for ${shop} — leaving the door as is.`);
+      return { outcome: "failed", detail: "no shop id" };
+    }
+
+    const off = merchantData?.order_door_block === false;
+
+    // 2 · OFF ⇒ the only work is tearing down a door that exists.
+    if (off) {
+      if (!current) return { outcome: "skipped_off" };
+      const res = await admin.graphql(DELETE_MUTATION, {
+        variables: { metafields: [{ ownerId: shopGid, namespace: "ink", key: "order_door" }] },
+      });
+      const errors = (await res.json())?.data?.metafieldsDelete?.userErrors ?? [];
+      if (errors.length > 0) {
+        const detail = errors.map((e: any) => e.message).join("; ");
+        console.error(`🚪 ${label}: could not remove the door for ${shop} — ${detail}`);
+        return { outcome: "failed", detail };
+      }
+      console.log(`🚪 ${label}: door removed for ${shop} (order_door_block=false).`);
+      return { outcome: "deleted" };
+    }
+
+    // 3 · A door already stands ⇒ done. Resolution never runs again.
+    //     (To re-point a renamed brand: delete the metafield or flip
+    //     order_door_block off and on; the next fulfillment rebuilds it.)
+    if (current) return { outcome: "unchanged", value: current };
+
+    // 4 · First time only: resolve the brand the way the tracking rewrite
+    //     does, and refuse to write anything a doc did not say.
+    const resolved = await resolveBrandPageUrl({ merchantApiKey, proofId, shop, merchantData, label });
+    const slug = String(resolved?.brandDoc?.brand_slug ? resolved.brandSlug : "").trim();
+    if (!slug) {
+      console.log(
+        `🚪 ${label}: no brand_slug on the merchant doc for ${shop} — no door (never a derived host).`,
+      );
+      return { outcome: "skipped_no_slug" };
+    }
+
+    const value = orderDoorBase(slug);
+    const setRes = await admin.graphql(SET_MUTATION, {
+      variables: {
+        metafields: [
+          {
+            ownerId: shopGid,
+            namespace: "ink",
+            key: "order_door",
+            type: "single_line_text_field",
+            value,
+          },
+        ],
+      },
+    });
+    const setErrors = (await setRes.json())?.data?.metafieldsSet?.userErrors ?? [];
+    if (setErrors.length > 0) {
+      const detail = setErrors.map((e: any) => e.message).join("; ");
+      console.error(`🚪 ${label}: Shopify refused the door for ${shop} — ${detail}`);
+      return { outcome: "failed", detail };
+    }
+    console.log(`✅ ${label}: order status page carries the door for ${shop} → ${value}`);
+    return { outcome: "written", value };
+  } catch (e: any) {
+    // Webhook discipline: a missing door is a quieter page, never a non-200.
+    console.error(`🚪 ${label}: threw (non-fatal) — ${e?.message ?? e}`);
+    return { outcome: "failed", detail: String(e?.message ?? e) };
+  }
+}

--- a/app/services/order-door-metafield.server.ts
+++ b/app/services/order-door-metafield.server.ts
@@ -83,6 +83,7 @@ export async function assertOrderDoorMetafield({
   merchantData,
   merchantApiKey,
   proofId,
+  slug: givenSlug,
   label = "order-door",
 }: {
   admin: { graphql: (query: string, opts?: any) => Promise<Response> };
@@ -90,8 +91,14 @@ export async function assertOrderDoorMetafield({
   merchantData: Record<string, any>;
   merchantApiKey?: string | null;
   /** A proof on this shop — how the one-author resolution finds the backend
-   *  merchant doc. Any current proof works; the slug is per-merchant. */
-  proofId: string;
+   *  merchant doc. Any current proof works; the slug is per-merchant.
+   *  Not needed when `slug` is supplied. */
+  proofId?: string;
+  /** A slug the CALLER already resolved (the settings flip has no proof to
+   *  hand, and resolves the brand the no-proof way the snippet card does).
+   *  Supplying it skips the proof fetch entirely; it must still be a real
+   *  brand_slug, never a domain-derived guess. */
+  slug?: string | null;
   label?: string;
 }): Promise<OrderDoorResult> {
   try {
@@ -130,8 +137,11 @@ export async function assertOrderDoorMetafield({
 
     // 4 · First time only: resolve the brand the way the tracking rewrite
     //     does, and refuse to write anything a doc did not say.
-    const resolved = await resolveBrandPageUrl({ merchantApiKey, proofId, shop, merchantData, label });
-    const slug = String(resolved?.brandDoc?.brand_slug ? resolved.brandSlug : "").trim();
+    let slug = String(givenSlug || "").trim();
+    if (!slug && proofId) {
+      const resolved = await resolveBrandPageUrl({ merchantApiKey, proofId, shop, merchantData, label });
+      slug = String(resolved?.brandDoc?.brand_slug ? resolved.brandSlug : "").trim();
+    }
     if (!slug) {
       console.log(
         `🚪 ${label}: no brand_slug on the merchant doc for ${shop} — no door (never a derived host).`,

--- a/app/services/order-door-metafield.test.ts
+++ b/app/services/order-door-metafield.test.ts
@@ -109,6 +109,28 @@ describe("assertOrderDoorMetafield", () => {
     expect(calls).toHaveLength(1);
   });
 
+  it("a caller-supplied slug writes without any proof fetch", async () => {
+    // The settings flip has no proof in hand — it resolves the brand the
+    // no-proof way and passes the slug. Resolution must not run at all.
+    const { admin, calls } = fakeAdmin({ current: null });
+    const out = await assertOrderDoorMetafield({
+      shop: BASE_ARGS.shop,
+      admin,
+      merchantData: {},
+      slug: "stevemadden",
+    });
+    expect(out).toMatchObject({ outcome: "written", value: "https://stevemadden.in.ink/o/" });
+    expect(resolveBrandPageUrl).not.toHaveBeenCalled();
+    expect(calls.some((c) => c.query.includes("InkOrderDoorSet"))).toBe(true);
+  });
+
+  it("no slug and no proof writes nothing", async () => {
+    const { admin, calls } = fakeAdmin({ current: null });
+    const out = await assertOrderDoorMetafield({ shop: BASE_ARGS.shop, admin, merchantData: {} });
+    expect(out.outcome).toBe("skipped_no_slug");
+    expect(calls.some((c) => c.query.includes("InkOrderDoorSet"))).toBe(false);
+  });
+
   it("a thrown admin call is an outcome, never an exception", async () => {
     const { admin } = fakeAdmin({ failWith: "socket hang up" });
     const out = await assertOrderDoorMetafield({ ...BASE_ARGS, admin, merchantData: {} });

--- a/app/services/order-door-metafield.test.ts
+++ b/app/services/order-door-metafield.test.ts
@@ -1,0 +1,148 @@
+// THE DOOR ON THE SHOP — outcome tests, each one proven against its own bug.
+//
+// The unit under test decides when the `ink:order_door` shop metafield is
+// read, written, or torn down. The bugs these pin:
+//  · resolution running on every event (the register-quota bill, #954)
+//  · a domain-derived slug shipped as a buyer-facing door (#1016's host)
+//  · the kill switch leaving a stale door standing
+//  · a webhook path that throws
+//  · the writer and the extension disagreeing about what a door looks like
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const resolveBrandPageUrl = vi.hoisted(() => vi.fn());
+vi.mock("./brand-page-url.server", () => ({ resolveBrandPageUrl }));
+
+import { assertOrderDoorMetafield, orderDoorBase } from "./order-door-metafield.server";
+
+/** An admin.graphql that answers the guard query and records every call. */
+function fakeAdmin(opts: { current?: string | null; failWith?: string }) {
+  const calls: Array<{ query: string; variables?: any }> = [];
+  const admin = {
+    graphql: vi.fn(async (query: string, o?: any) => {
+      calls.push({ query, variables: o?.variables });
+      if (opts.failWith) throw new Error(opts.failWith);
+      const body = query.includes("InkOrderDoorGuard")
+        ? {
+            data: {
+              shop: {
+                id: "gid://shopify/Shop/1",
+                metafield: opts.current ? { id: "gid://mf/1", value: opts.current } : null,
+              },
+            },
+          }
+        : query.includes("InkOrderDoorSet")
+          ? { data: { metafieldsSet: { userErrors: [] } } }
+          : { data: { metafieldsDelete: { userErrors: [] } } };
+      return { json: async () => body } as unknown as Response;
+    }),
+  };
+  return { admin, calls };
+}
+
+const BASE_ARGS = { shop: "sm-test-hhawzn52.myshopify.com", merchantApiKey: "ink_x", proofId: "proof_1" };
+
+beforeEach(() => {
+  resolveBrandPageUrl.mockReset();
+});
+
+describe("assertOrderDoorMetafield", () => {
+  it("a standing door costs one read and resolves nothing", async () => {
+    const { admin, calls } = fakeAdmin({ current: "https://stevemadden.in.ink/o/" });
+    const out = await assertOrderDoorMetafield({ ...BASE_ARGS, admin, merchantData: {} });
+    expect(out.outcome).toBe("unchanged");
+    expect(calls).toHaveLength(1);
+    expect(resolveBrandPageUrl).not.toHaveBeenCalled();
+  });
+
+  it("first fulfillment writes the door from the backend doc's brand_slug", async () => {
+    resolveBrandPageUrl.mockResolvedValue({
+      brandSlug: "stevemadden",
+      brandDoc: { brand_slug: "stevemadden" },
+    });
+    const { admin, calls } = fakeAdmin({ current: null });
+    const out = await assertOrderDoorMetafield({ ...BASE_ARGS, admin, merchantData: {} });
+    expect(out).toMatchObject({ outcome: "written", value: "https://stevemadden.in.ink/o/" });
+    const set = calls.find((c) => c.query.includes("InkOrderDoorSet"));
+    expect(set?.variables?.metafields?.[0]).toMatchObject({
+      ownerId: "gid://shopify/Shop/1",
+      namespace: "ink",
+      key: "order_door",
+      value: "https://stevemadden.in.ink/o/",
+    });
+  });
+
+  it("no brand_slug on the doc means NO door — never a derived host", async () => {
+    // brandSlug is populated (domain-derived, plausible, wrong) but the doc
+    // itself carries no brand_slug. #1016: sm-test-hhawzn52.in.ink 404s.
+    resolveBrandPageUrl.mockResolvedValue({
+      brandSlug: "sm-test-hhawzn52",
+      brandDoc: {},
+    });
+    const { admin, calls } = fakeAdmin({ current: null });
+    const out = await assertOrderDoorMetafield({ ...BASE_ARGS, admin, merchantData: {} });
+    expect(out.outcome).toBe("skipped_no_slug");
+    expect(calls.some((c) => c.query.includes("InkOrderDoorSet"))).toBe(false);
+  });
+
+  it("order_door_block=false tears an existing door down", async () => {
+    const { admin, calls } = fakeAdmin({ current: "https://stevemadden.in.ink/o/" });
+    const out = await assertOrderDoorMetafield({
+      ...BASE_ARGS,
+      admin,
+      merchantData: { order_door_block: false },
+    });
+    expect(out.outcome).toBe("deleted");
+    expect(calls.some((c) => c.query.includes("InkOrderDoorDelete"))).toBe(true);
+    expect(resolveBrandPageUrl).not.toHaveBeenCalled();
+  });
+
+  it("order_door_block=false with no door does nothing at all", async () => {
+    const { admin, calls } = fakeAdmin({ current: null });
+    const out = await assertOrderDoorMetafield({
+      ...BASE_ARGS,
+      admin,
+      merchantData: { order_door_block: false },
+    });
+    expect(out.outcome).toBe("skipped_off");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("a thrown admin call is an outcome, never an exception", async () => {
+    const { admin } = fakeAdmin({ failWith: "socket hang up" });
+    const out = await assertOrderDoorMetafield({ ...BASE_ARGS, admin, merchantData: {} });
+    expect(out.outcome).toBe("failed");
+  });
+});
+
+// ── The writer and the extension are one contract ───────────────────────────
+//
+// The extension trusts only values matching its own regex; the writer mints
+// values from orderDoorBase. If either side moves alone, the block silently
+// renders nothing on every store — this is the test that refuses that.
+describe("the extension trusts exactly what the writer writes", () => {
+  const SRC = readFileSync(
+    resolve(process.cwd(), "extensions/order-page-block/src/order-page-block.js"),
+    "utf8",
+  );
+
+  it("the writer's value passes the extension's own gate", () => {
+    const m = SRC.match(/\/\^https:[^/]*\\\/\\\/(.+?)\/\.test\(base\)/);
+    expect(m, "extension no longer gates door values with a regex").toBeTruthy();
+    const gate = new RegExp(`^https:\\/\\/${m![1]}`);
+    expect(gate.test(orderDoorBase("stevemadden"))).toBe(true);
+    // And the gate still refuses what it exists to refuse.
+    expect(gate.test("http://stevemadden.in.ink/o/")).toBe(false);
+    expect(gate.test("https://evil.example.com/o/")).toBe(false);
+  });
+
+  it("the block renders nothing without a door, and never fetches", () => {
+    expect(SRC).toContain("if (!base || !digits) return");
+    expect(SRC).not.toContain("fetch(");
+  });
+
+  it("the block appends digits only — the door compares on digits alone", () => {
+    expect(SRC).toContain('.replace(/\\D/g, "")');
+  });
+});

--- a/extensions/order-page-block/manifest.json
+++ b/extensions/order-page-block/manifest.json
@@ -1,0 +1,3 @@
+{
+  "customer-account.order-status.block.render": {}
+}

--- a/extensions/order-page-block/manifest.json
+++ b/extensions/order-page-block/manifest.json
@@ -1,3 +1,0 @@
-{
-  "customer-account.order-status.block.render": {}
-}

--- a/extensions/order-page-block/shopify.extension.toml
+++ b/extensions/order-page-block/shopify.extension.toml
@@ -1,0 +1,43 @@
+# THE ORDER STATUS PAGE CARRIES THE DOOR.
+#
+# Shopify's notification templates cannot be edited by any app (re-verified
+# 2026-08-23: notification templates are admin-UI-only; the internal
+# EmailTemplateUpdate mutation is not callable) — so the email's primary
+# button will point at Shopify's own Order status page for every store that
+# never does the manual paste. This extension makes that page OURS to speak
+# on: the button lands the buyer one tap from the brand's order page, with
+# zero merchant work.
+#
+# Why this is durable where the paste is not:
+#   · It ships inside the app. Install = on. No per-store template surgery.
+#   · `customer-account.order-status.block.render` self-places: "by default,
+#     block extensions are placed in the first available placement reference"
+#     (shopify.dev, build-order-status). The merchant CAN move or remove it in
+#     the checkout & accounts editor; they never have to touch it.
+#   · The Order status page is pre-authenticated — buyers arriving from the
+#     email's button see it without logging in. All plans, not just Plus.
+#
+# The app holds the switch: the block renders ONLY when the `ink:order_door`
+# shop metafield carries a door base. No metafield → the extension renders
+# nothing at all (the Clare-V law: neutral/empty when data is missing). The
+# embed writes and clears that metafield server-side
+# (order-door-metafield.server.ts), so turning a store on or off never needs
+# a redeploy of this extension.
+
+api_version = "2026-07"
+
+[[extensions]]
+type = "ui_extension"
+name = "ink order page"
+handle = "order-page-block"
+
+  [[extensions.targeting]]
+  module = "./src/order-page-block.js"
+  target = "customer-account.order-status.block.render"
+
+  # The one piece of app data the block needs: the brand's own door base,
+  # e.g. https://stevemadden.in.ink/o/ — written on the SHOP by the embed at
+  # enroll time. Declared here so the runtime delivers it via appMetafields.
+  [[extensions.metafields]]
+  namespace = "ink"
+  key = "order_door"

--- a/extensions/order-page-block/src/order-page-block.js
+++ b/extensions/order-page-block/src/order-page-block.js
@@ -56,14 +56,18 @@ export default async () => {
     const heading = document.createElement("s-heading");
     heading.textContent = "Your order page";
 
+    // PLACEHOLDER COPY, AWAITING SAM. Three lines a buyer reads, written to
+    // the law and no further: no possessive cushioning past the heading, no
+    // copy that reassures or explains itself, and no promise of a feature a
+    // given store may not have on (an earlier draft said "returns", which is
+    // false for any merchant without them configured). BRAND_BIBLE §5/§6.
     const line = document.createElement("s-text");
-    line.textContent =
-      "This order has its own page — delivery, help, and returns in one place.";
+    line.textContent = "Delivery updates and help for this order.";
 
     const button = document.createElement("s-button");
     button.setAttribute("href", base + digits);
     button.setAttribute("variant", "primary");
-    button.textContent = "Open your order page";
+    button.textContent = "Open the page";
 
     stack.append(heading, line, button);
     root.append(stack);

--- a/extensions/order-page-block/src/order-page-block.js
+++ b/extensions/order-page-block/src/order-page-block.js
@@ -1,0 +1,80 @@
+// THE BLOCK ON THE ORDER STATUS PAGE — where the email's primary button lands.
+//
+// The buyer clicked "View your order" in Shopify's own email. This block is
+// standing on the page that button opens, holding the one link the email
+// itself could not carry: {brand}.in.ink/o/{order_number}.
+//
+// TWO REFUSALS, both load-bearing:
+//
+//  1. NO DOOR, NO SURFACE. The link is built ONLY from the `ink:order_door`
+//     shop metafield the embed wrote for this exact brand. If the metafield
+//     is absent, empty, or not an https .in.ink door, this module renders
+//     NOTHING — no fallback host, no derived-from-shop-domain guess (the
+//     Clare-V law; a wrong-but-plausible host is how sm-test-hhawzn52.in.ink
+//     happened). Absence is also the app's per-store OFF switch.
+//  2. NO NETWORK. The block computes its link from what the page already
+//     knows (metafield + order number). It fetches nothing, so it can never
+//     slow the page, leak an order, or need the network_access capability.
+//
+// The order number arrives as `order.name` ("#1023"); the door compares on
+// digits alone (worker order-door law), so digits are what we append.
+
+const DOOR_KEY = "order_door";
+
+/** The door base from OUR declared shop metafield, or null. Only an
+ *  https://{label}.in.ink/o/ base is a door; anything else renders nothing. */
+function doorBase() {
+  const entries = (shopify.appMetafields && shopify.appMetafields.value) || [];
+  for (const entry of entries) {
+    const m = entry && entry.metafield;
+    const target = entry && entry.target;
+    if (!m || m.key !== DOOR_KEY) continue;
+    if (target && target.type && target.type !== "shop") continue;
+    const base = String(m.value || "").trim();
+    if (/^https:\/\/[a-z0-9][a-z0-9-]*\.in\.ink\/o\/$/.test(base)) return base;
+  }
+  return null;
+}
+
+function orderDigits() {
+  const order = shopify.order && shopify.order.value;
+  return String((order && order.name) || "").replace(/\D/g, "");
+}
+
+export default async () => {
+  const root = document.body;
+
+  const render = () => {
+    const base = doorBase();
+    const digits = orderDigits();
+    root.replaceChildren();
+    if (!base || !digits) return; // no door, no surface
+
+    const stack = document.createElement("s-stack");
+    stack.setAttribute("gap", "base");
+
+    const heading = document.createElement("s-heading");
+    heading.textContent = "Your order page";
+
+    const line = document.createElement("s-text");
+    line.textContent =
+      "This order has its own page — delivery, help, and returns in one place.";
+
+    const button = document.createElement("s-button");
+    button.setAttribute("href", base + digits);
+    button.setAttribute("variant", "primary");
+    button.textContent = "Open your order page";
+
+    stack.append(heading, line, button);
+    root.append(stack);
+  };
+
+  // Signals may fill after first paint; re-render on either arriving late.
+  if (shopify.appMetafields && shopify.appMetafields.subscribe) {
+    shopify.appMetafields.subscribe(render);
+  }
+  if (shopify.order && shopify.order.subscribe) {
+    shopify.order.subscribe(render);
+  }
+  render();
+};


### PR DESCRIPTION
## The problem, stated exactly

No Shopify API can edit a notification template — re-verified against Shopify's docs today, unchanged since 2026-08-07. So the **primary button** in every Shopify order/shipping email opens Shopify's own **Order status page**, and the only way to change that has been one line of Liquid pasted by hand into five templates, per store.

Sam: *"before i have to paste code for every store and nobody will ever do that - ever - i need it durable."*

**You cannot change where the button points. You can own what is on the other side of it.**

## What this adds

### 1 · `extensions/order-page-block` — a NEW SURFACE (named per law 9)
A `customer-account.order-status.block.render` UI extension: a heading, one line, and **"Open the page"** → `{brand}.in.ink/o/{digits}`, on the page every Shopify email button already opens.

- **All plans.** Non-Plus stores are forced onto the extensible Order status page by **2026-08-26** — three days out — so this is universal essentially now.
- **Pre-authenticated**: buyers arriving from the email see it without logging in.
- **Self-placing**: block extensions land in the first available placement by default. Merchants *can* move or remove it; they never *have* to touch it.
- **No network access.** It computes its link from `order.name` + one app metafield the page already delivers. It cannot slow the page or leak an order.
- **No door, no surface.** Absent/invalid metafield ⇒ renders nothing. No fallback host, no domain-derived guess (the Clare-V law).

### 2 · `order-door-metafield.server.ts` — one writer
The only writer of the `ink:order_door` shop metafield. **The metafield is its own guard**: one cheap read per fulfillment event, brand resolution + write **once per merchant ever** (the register-quota bill, #954). `brand_slug` only, via the same `resolveBrandPageUrl` the tracking rewrite uses. Never fatal on a webhook path. Called from both fulfillment webhooks.

### 3 · `app.api.settings.order-door` + a switch in the app — *the flip*
Sam: *"hopefully we build something my shopify app can flip in the approved app."*

**APPLY FIRST, RECORD SECOND** (the return-window law): the metafield write reaches Shopify before Firestore learns anything, so the switch can never read "on" over a bare order status page. A store with no `brand_slug` gets `canFlip:false` **and a reason**, never a switch that writes a broken door. Communication settings gains one section above the paste card — **NEW SURFACE: "The order status page"** — a single ToggleRow mirroring the rows already there. The paste card is untouched.

## Verification
11 outcome tests, each against a bill already paid: steady state is one read · never a derived host · the flip tears an existing door down · thrown ≠ non-200 · and the writer and extension share **one regex-checked contract** so neither drifts alone and silently blanks the block on every store.

Extension render verified by **running the real source** against a fake host DOM: `#1023` and bare `1023` both → `/o/1023`; no door / hostile value / order-not-loaded all render nothing. `stevemadden.in.ink/o/1023` confirmed live → 302 → the real buyer page; a miss redirects home without guessing.

Settings card verified by **looking at it** — real component under Polaris, all three states screenshotted. Two defects the gates could not catch were fixed there: the row title repeated its section heading, and the description showed a dangling `.../o/` base no buyer is ever sent to.

`npm run typecheck` · `npm run build` · 88 tests · `shopify app build` — all green. Extension bundles at 1.4 KB.

## What merging does and does not do
Merging main activates **the metafield writer and the switch**. The **extension itself goes live only on the next gated `shopify app deploy`**, which is Sam's to run and should ride the round-four submission rather than disturb it. **No scope change, so no merchant re-consent.**

The buyer-facing copy in the block is marked **PLACEHOLDER in the source** — three lines written to BRAND_BIBLE §5/§6 and no further. They are Sam's to set.

The Liquid paste still works and still wins the click outright where a merchant does it. This is what happens for the merchants who never will.