### PR TITLE
The order the pilot doesn't run on is still recorded, just never announced

### DIFF
--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -5,6 +5,7 @@ import { enrollOrder, createMerchant } from "../services/ink-api.server";
 import { attachProductUrls, productDetailFromLineItem } from "../services/order-line-item";
 import { findMerchantDocRef } from "../services/merchant-doc.server";
 import {
+  countryOfWebhookOrder,
   orderActivates,
   productsActivate,
   scopeOfMerchant,
@@ -295,9 +296,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   // ─── THE SLICE ──────────────────────────────────────────────────────
-  // A merchant may run their pilot on part of their business — today, the
-  // states they ship to. This is the ONE decision, and it decides
-  // ACTIVATION only:
+  // A merchant may run their pilot on part of their business: a set number
+  // of orders, certain places (a country as readily as a US state), certain
+  // products. Whatever they narrowed by, it decides ACTIVATION only:
   //   • the order is enrolled either way — ink's backend gets every order
   //     the store sends ("we want all the data"), so widening the slice
   //     later reveals a history that was there all along;
@@ -313,9 +314,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   const shipToOk = orderActivates(data, activationScope);
   if (!shipToOk) {
     console.log(
-      `🔒 [orders/create] Order ${orderName} ships outside this merchant's chosen states ` +
-        `(${(activationScope?.ship_to?.states ?? []).join(", ")}; this order: ` +
-        `${stateOfWebhookOrder(data) ?? "no readable state"}) — recording it, no page.`
+      `🔒 [orders/create] Order ${orderName} ships outside this merchant's chosen places ` +
+        `(${[
+          ...(activationScope?.ship_to?.countries ?? []),
+          ...(activationScope?.ship_to?.states ?? []),
+        ].join(", ")}; this order: ` +
+        `${stateOfWebhookOrder(data) ?? countryOfWebhookOrder(data) ?? "nowhere readable"})` +
+        ` — recording it, no page.`
     );
   }
   // WHAT is on it and WHETHER the cap has room are not answerable yet: the
@@ -341,7 +346,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       const apiKey = await getMerchantApiKey(shop);
       if (!apiKey) {
         console.warn(
-          `[orders/create] No ink_api_key for ${shop} — order tagged, auto-enroll skipped`
+          // NOT "order tagged" any more: a merchant who narrowed by product
+          // or by a cap cannot be judged without the order read below, and
+          // unknown never counts as yes — so a scoped merchant's order is
+          // recorded and left un-activated rather than tagged on a guess.
+          `[orders/create] No ink_api_key for ${shop} — auto-enroll skipped for ${orderName}`
         );
       } else {
         const odRes = await admin.graphql(ORDER_DETAIL_QUERY, {

--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -3,6 +3,12 @@ import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
 import { enrollOrder, createMerchant } from "../services/ink-api.server";
 import { attachProductUrls, productDetailFromLineItem } from "../services/order-line-item";
+import { findMerchantDocRef } from "../services/merchant-doc.server";
+import {
+  orderActivates,
+  scopeOfMerchant,
+  stateOfWebhookOrder,
+} from "../services/activation-scope.server";
 
 /**
  * Look up the merchant's verified-delivery mode preference.
@@ -261,6 +267,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   // Background enrollment: INK is hidden from checkout and never appears as a
   // customer-paid shipping option, so every order on this shop is eligible.
   const deliveryMode = await getMerchantDeliveryMode(shop);
+  // The merchant doc, through the ONE resolver — three doc-identity
+  // conventions coexist in this collection and a hand-rolled lookup is the
+  // §17.2 landmine (merchant-doc.server.ts). Never fatal: an unreadable
+  // merchant means no slice, which means today's behaviour.
+  const merchantForScope = await findMerchantDocRef(firestore, shop).catch((e) => {
+    console.warn(`[orders/create] Could not read merchant doc for ${shop}:`, e);
+    return null;
+  });
   const shouldEnroll = hasPremiumDelivery || deliveryMode === "background";
 
   if (!shouldEnroll) {
@@ -278,19 +292,44 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     );
   }
 
+  // ─── THE SLICE ──────────────────────────────────────────────────────
+  // A merchant may run their pilot on part of their business — today, the
+  // states they ship to. This is the ONE decision, and it decides
+  // ACTIVATION only:
+  //   • the order is enrolled either way — ink's backend gets every order
+  //     the store sends ("we want all the data"), so widening the slice
+  //     later reveals a history that was there all along;
+  //   • an out-of-slice order gets NO Shopify tag and NO ink.* metafields,
+  //     and every buyer-facing thing downstream gates on
+  //     ink.proof_reference — the fulfillment webhooks early-return 200
+  //     without it — so nothing ever reaches that customer.
+  // Absent scope (every merchant today) ⇒ activates, exactly as before.
+  const activationScope = scopeOfMerchant(merchantForScope?.data);
+  const activates = orderActivates(data, activationScope);
+  if (!activates) {
+    console.log(
+      `🔒 [orders/create] Order ${orderName} is outside this merchant's chosen states ` +
+        `(${(activationScope?.ship_to?.states ?? []).join(", ")}; this order: ` +
+        `${stateOfWebhookOrder(data) ?? "no readable state"}) — recording it, no page.`
+    );
+  }
+
   try {
-    // Tag the order
-    const tagRes = await admin.graphql(TAG_MUTATION, {
-      variables: { id: orderGid, tags: ["INK-Verified-Delivery"] },
-    });
-    const tagJson = await tagRes.json();
-    const tagErrors = tagJson?.data?.tagsAdd?.userErrors;
-    if (tagErrors && tagErrors.length > 0) {
-      console.error(`[orders/create] tagsAdd userErrors:`, tagErrors);
-    } else {
-      console.log(
-        `✅ [orders/create] Tagged order ${orderName} with "INK-Verified-Delivery"`
-      );
+    // Tag the order — the merchant's own view of which orders ink runs on,
+    // so it follows the slice.
+    if (activates) {
+      const tagRes = await admin.graphql(TAG_MUTATION, {
+        variables: { id: orderGid, tags: ["INK-Verified-Delivery"] },
+      });
+      const tagJson = await tagRes.json();
+      const tagErrors = tagJson?.data?.tagsAdd?.userErrors;
+      if (tagErrors && tagErrors.length > 0) {
+        console.error(`[orders/create] tagsAdd userErrors:`, tagErrors);
+      } else {
+        console.log(
+          `✅ [orders/create] Tagged order ${orderName} with "INK-Verified-Delivery"`
+        );
+      }
     }
 
     // ─── AUTO-ENROLL ────────────────────────────────────────────────
@@ -473,60 +512,74 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     // Initialize / update INK metafields — proof_reference + ink_token are now
     // real (when auto-enroll succeeded) so the order is linked to its proof and
     // the warehouse knows which tap URL to write onto the sticker.
-    const metafieldRes = await admin.graphql(METAFIELD_MUTATION, {
-      variables: {
-        metafields: [
-          {
-            ownerId: orderGid,
-            namespace: "ink",
-            key: "verification_status",
-            type: "single_line_text_field",
-            value: verificationStatus,
-          },
-          {
-            ownerId: orderGid,
-            namespace: "ink",
-            key: "delivery_type",
-            type: "single_line_text_field",
-            value: deliveryMode === "background" ? "background" : "premium",
-          },
-          {
-            ownerId: orderGid,
-            namespace: "ink",
-            key: "proof_reference",
-            type: "single_line_text_field",
-            value: proofReference,
-          },
-          {
-            ownerId: orderGid,
-            namespace: "ink",
-            key: "ink_token",
-            type: "single_line_text_field",
-            value: inkToken,
-          },
-          {
-            ownerId: orderGid,
-            namespace: "ink",
-            key: "nfc_uid",
-            type: "single_line_text_field",
-            value: "",
-          },
-          {
-            ownerId: orderGid,
-            namespace: "ink",
-            key: "customer_phone",
-            type: "single_line_text_field",
-            value: finalPhone,
-          },
-        ].filter((m) => m.value !== ""),
-      },
-    });
-    const metafieldJson = await metafieldRes.json();
-    const metaErrors = metafieldJson?.data?.metafieldsSet?.userErrors;
-    if (metaErrors && metaErrors.length > 0) {
-      console.error(`[orders/create] metafieldsSet userErrors:`, metaErrors);
+    //
+    // THE SLICE'S REAL TEETH. Everything the buyer could ever see hangs off
+    // ink.proof_reference: the branded tracking link, the order door, and
+    // every state email all read it and early-return 200 when it is absent
+    // (webhooks.fulfillments_create.tsx:69, fulfillments_update.tsx:171).
+    // So an out-of-slice order is enrolled and recorded, and simply never
+    // announced — one skip here, no suppression logic anywhere downstream.
+    if (!activates) {
+      console.log(
+        `🔒 [orders/create] ${orderName} recorded (proof ${proofReference || "—"}) ` +
+          `without metafields — outside the merchant's chosen states.`
+      );
     } else {
-      console.log(`✅ [orders/create] Metafields initialized for ${orderName}`);
+      const metafieldRes = await admin.graphql(METAFIELD_MUTATION, {
+        variables: {
+          metafields: [
+            {
+              ownerId: orderGid,
+              namespace: "ink",
+              key: "verification_status",
+              type: "single_line_text_field",
+              value: verificationStatus,
+            },
+            {
+              ownerId: orderGid,
+              namespace: "ink",
+              key: "delivery_type",
+              type: "single_line_text_field",
+              value: deliveryMode === "background" ? "background" : "premium",
+            },
+            {
+              ownerId: orderGid,
+              namespace: "ink",
+              key: "proof_reference",
+              type: "single_line_text_field",
+              value: proofReference,
+            },
+            {
+              ownerId: orderGid,
+              namespace: "ink",
+              key: "ink_token",
+              type: "single_line_text_field",
+              value: inkToken,
+            },
+            {
+              ownerId: orderGid,
+              namespace: "ink",
+              key: "nfc_uid",
+              type: "single_line_text_field",
+              value: "",
+            },
+            {
+              ownerId: orderGid,
+              namespace: "ink",
+              key: "customer_phone",
+              type: "single_line_text_field",
+              value: finalPhone,
+            },
+          ].filter((m) => m.value !== ""),
+        },
+      });
+      const metafieldJson = await metafieldRes.json();
+      const metaErrors = metafieldJson?.data?.metafieldsSet?.userErrors;
+      if (metaErrors && metaErrors.length > 0) {
+        console.error(`[orders/create] metafieldsSet userErrors:`, metaErrors);
+      } else {
+        console.log(`✅ [orders/create] Metafields initialized for ${orderName}`);
+      }
     }
   } catch (error: any) {
     console.error(
@@ -550,7 +603,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   console.log(
-    `✅ [orders/create] Successfully processed order ${orderName} (mode=${deliveryMode})\n`
+    `✅ [orders/create] Successfully processed order ${orderName} (mode=${deliveryMode}` +
+      `${activates ? "" : ", recorded only — outside the merchant's chosen states"})\n`
   );
+  // 200 either way. An out-of-slice order is a DECISION, not a failure —
+  // a 500 here would have Shopify redeliver it forever.
   return new Response("ok");
 };

--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -6,9 +6,11 @@ import { attachProductUrls, productDetailFromLineItem } from "../services/order-
 import { findMerchantDocRef } from "../services/merchant-doc.server";
 import {
   orderActivates,
+  productsActivate,
   scopeOfMerchant,
   stateOfWebhookOrder,
 } from "../services/activation-scope.server";
+import { spendFromCap } from "../services/activation-counter.server";
 
 /**
  * Look up the merchant's verified-delivery mode preference.
@@ -305,33 +307,28 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   //     without it — so nothing ever reaches that customer.
   // Absent scope (every merchant today) ⇒ activates, exactly as before.
   const activationScope = scopeOfMerchant(merchantForScope?.data);
-  const activates = orderActivates(data, activationScope);
-  if (!activates) {
+
+  // WHERE it ships is answerable right now, from the body Shopify already
+  // sent — no query, no scope, no cost.
+  const shipToOk = orderActivates(data, activationScope);
+  if (!shipToOk) {
     console.log(
-      `🔒 [orders/create] Order ${orderName} is outside this merchant's chosen states ` +
+      `🔒 [orders/create] Order ${orderName} ships outside this merchant's chosen states ` +
         `(${(activationScope?.ship_to?.states ?? []).join(", ")}; this order: ` +
         `${stateOfWebhookOrder(data) ?? "no readable state"}) — recording it, no page.`
     );
   }
+  // WHAT is on it and WHETHER the cap has room are not answerable yet: the
+  // first needs the order's lines, the second needs the tally. They start
+  // UNKNOWN and are settled below, and unknown never counts as yes — a
+  // merchant who narrowed by product or cap is fail-closed until the answer
+  // actually arrives. A merchant with neither is true from the start, so
+  // nothing about today's behaviour depends on the query succeeding.
+  let productsOk: boolean | null = activationScope?.products ? null : true;
+  let capOk: boolean | null = activationScope?.volume ? null : true;
+  const activatesNow = () => shipToOk && productsOk === true && capOk === true;
 
   try {
-    // Tag the order — the merchant's own view of which orders ink runs on,
-    // so it follows the slice.
-    if (activates) {
-      const tagRes = await admin.graphql(TAG_MUTATION, {
-        variables: { id: orderGid, tags: ["INK-Verified-Delivery"] },
-      });
-      const tagJson = await tagRes.json();
-      const tagErrors = tagJson?.data?.tagsAdd?.userErrors;
-      if (tagErrors && tagErrors.length > 0) {
-        console.error(`[orders/create] tagsAdd userErrors:`, tagErrors);
-      } else {
-        console.log(
-          `✅ [orders/create] Tagged order ${orderName} with "INK-Verified-Delivery"`
-        );
-      }
-    }
-
     // ─── AUTO-ENROLL ────────────────────────────────────────────────
     // Create the Parallel proof now so the order autopopulates into Parallel
     // Orders (the merchant later just writes the tap URL onto a physical
@@ -353,6 +350,54 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         const odJson = await odRes.json();
         const order = odJson?.data?.order;
         const already = order?.metafield?.value;
+
+        // ─── THE REST OF THE SLICE ──────────────────────────────────
+        // The order's lines are in hand now, so the product question can be
+        // answered — off the SAME query, with no field added to it (one
+        // unauthorized selection there fails the whole query silently, which
+        // is how order #1019 died).
+        if (productsOk === null) {
+          const lines = (order?.lineItems?.edges || []).map((e: any) => e.node);
+          productsOk = productsActivate(lines, activationScope);
+          if (!productsOk) {
+            console.log(
+              `🔒 [orders/create] Order ${orderName} holds none of this merchant's chosen ` +
+                `products — recording it, no page.`
+            );
+          }
+        }
+        // And the cap, which only the tally can answer. Spent LAST, so a
+        // cap is never burned on an order that was never going to get a
+        // page for another reason. Idempotent across Shopify's redeliveries.
+        if (capOk === null) {
+          const cap = activationScope?.volume?.cap ?? 0;
+          const ref = merchantForScope?.ref;
+          if (!ref || !shipToOk || productsOk !== true) {
+            // Nothing to spend it on, or nowhere to keep the count. Refusing
+            // is the fail-closed side, and it spends nothing.
+            capOk = false;
+          } else {
+            try {
+              const decision = await spendFromCap(
+                firestore, ref, shop, data?.id ?? orderGid, cap,
+              );
+              capOk = decision.ok;
+              console.log(
+                `[orders/create] ${orderName} cap ${decision.used}/${decision.cap}` +
+                  `${decision.replay ? " (redelivery — already counted)" : ""}` +
+                  `${decision.ok ? "" : " — spent, recording it, no page"}`
+              );
+            } catch (capErr: any) {
+              // A tally we cannot read is not a permission. Fail closed and
+              // say so; the order is still captured either way.
+              capOk = false;
+              console.error(
+                `[orders/create] Could not read this merchant's cap for ${orderName}:`,
+                capErr?.message || capErr
+              );
+            }
+          }
+        }
 
         if (already) {
           // Idempotent: webhook retried (Shopify is at-least-once) — already enrolled.
@@ -509,6 +554,30 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       );
     }
 
+    // THE ANSWER IS SETTLED HERE, and everything below reads it.
+    const activates = activatesNow();
+
+    // Tag the order — the merchant's own mark, in their own admin, for the
+    // orders ink runs on. It sits AFTER the enroll on purpose: the product
+    // and cap answers only exist once the order has been read, and a tag
+    // that promised a page we then withheld would be a lie in their admin.
+    // Still tagged when the enroll itself failed (that order is in scope and
+    // recoverable) — the behaviour the comment above depends on.
+    if (activates) {
+      const tagRes = await admin.graphql(TAG_MUTATION, {
+        variables: { id: orderGid, tags: ["INK-Verified-Delivery"] },
+      });
+      const tagJson = await tagRes.json();
+      const tagErrors = tagJson?.data?.tagsAdd?.userErrors;
+      if (tagErrors && tagErrors.length > 0) {
+        console.error(`[orders/create] tagsAdd userErrors:`, tagErrors);
+      } else {
+        console.log(
+          `✅ [orders/create] Tagged order ${orderName} with "INK-Verified-Delivery"`
+        );
+      }
+    }
+
     // Initialize / update INK metafields — proof_reference + ink_token are now
     // real (when auto-enroll succeeded) so the order is linked to its proof and
     // the warehouse knows which tap URL to write onto the sticker.
@@ -522,7 +591,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     if (!activates) {
       console.log(
         `🔒 [orders/create] ${orderName} recorded (proof ${proofReference || "—"}) ` +
-          `without metafields — outside the merchant's chosen states.`
+          `without metafields — outside the piece this pilot runs on.`
       );
     } else {
       const metafieldRes = await admin.graphql(METAFIELD_MUTATION, {
@@ -604,7 +673,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   console.log(
     `✅ [orders/create] Successfully processed order ${orderName} (mode=${deliveryMode}` +
-      `${activates ? "" : ", recorded only — outside the merchant's chosen states"})\n`
+      `${activatesNow() ? "" : ", recorded only — outside the piece this pilot runs on"})\n`
   );
   // 200 either way. An out-of-slice order is a DECISION, not a failure —
   // a 500 here would have Shopify redeliver it forever.

--- a/app/services/activation-counter.server.test.ts
+++ b/app/services/activation-counter.server.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { activationMarkerId, spendFromCap } from "./activation-counter.server";
+
+// THE CAP — "run it on my next 200 orders."
+//
+// A cap is the one part of a slice that cannot be answered from an order
+// alone, so these pin the two things that would otherwise make it lie to a
+// merchant: counting the same order twice, and letting two orders both
+// spend the last one.
+
+/** A Firestore stand-in with just enough transaction to be honest about
+ *  ordering: every read must precede every write, and writes only land when
+ *  the transaction body returns. */
+function fakeFirestore(initial: Record<string, any> = {}) {
+  const docs = new Map<string, any>(Object.entries(initial));
+  const ref = (path: string) => ({
+    path,
+    get _key() {
+      return path;
+    },
+  });
+  const firestore: any = {
+    docs,
+    collection: (name: string) => ({ doc: (id: string) => ref(`${name}/${id}`) }),
+    async runTransaction(fn: (tx: any) => Promise<any>) {
+      const writes: Array<[string, any, boolean]> = [];
+      let reading = true;
+      const tx = {
+        async get(r: any) {
+          if (!reading) throw new Error("read after write in a transaction");
+          const data = docs.get(r.path);
+          return { exists: data !== undefined, data: () => data };
+        },
+        set(r: any, value: any, opts?: { merge?: boolean }) {
+          reading = false;
+          writes.push([r.path, value, Boolean(opts?.merge)]);
+        },
+      };
+      const out = await fn(tx);
+      for (const [path, value, merge] of writes) {
+        docs.set(path, merge ? { ...(docs.get(path) ?? {}), ...value } : value);
+      }
+      return out;
+    },
+  };
+  return { firestore, docs, ref };
+}
+
+const MERCHANT = "merchants/shop.myshopify.com";
+
+describe("an order id that is not a document id", () => {
+  it("escapes the slashes Shopify puts in order names", () => {
+    // Same escaping the backend's enroll lock already does — a slash is
+    // illegal in a Firestore id and order names carry them (#1001/2).
+    expect(activationMarkerId("s.myshopify.com", "1001/2")).toBe("s.myshopify.com__1001_2");
+    expect(activationMarkerId("s.myshopify.com", 1001)).toBe("s.myshopify.com__1001");
+  });
+});
+
+describe("spending from a cap", () => {
+  it("grants a page and moves the tally by exactly one", async () => {
+    const { firestore, docs } = fakeFirestore({ [MERCHANT]: { activation_count: { activated: 4 } } });
+    const out = await spendFromCap(firestore, { path: MERCHANT } as any, "s", "1001", 200);
+
+    expect(out).toEqual({ ok: true, cap: 200, used: 5, replay: false });
+    expect(docs.get(MERCHANT).activation_count.activated).toBe(5);
+  });
+
+  it("starts from zero for a merchant who has never had one", async () => {
+    const { firestore, docs } = fakeFirestore({ [MERCHANT]: {} });
+    const out = await spendFromCap(firestore, { path: MERCHANT } as any, "s", "1", 3);
+
+    expect(out.ok).toBe(true);
+    expect(docs.get(MERCHANT).activation_count.activated).toBe(1);
+  });
+
+  it("keeps the `since` stamp rather than restarting it every order", async () => {
+    const { firestore, docs } = fakeFirestore({
+      [MERCHANT]: { activation_count: { since: "2026-08-27T00:00:00.000Z", activated: 1 } },
+    });
+    await spendFromCap(firestore, { path: MERCHANT } as any, "s", "1", 10);
+
+    expect(docs.get(MERCHANT).activation_count).toEqual({
+      since: "2026-08-27T00:00:00.000Z",
+      activated: 2,
+    });
+  });
+
+  it("refuses once the cap is spent, and never goes past it", async () => {
+    const { firestore, docs } = fakeFirestore({
+      [MERCHANT]: { activation_count: { activated: 200 } },
+    });
+    const out = await spendFromCap(firestore, { path: MERCHANT } as any, "s", "999", 200);
+
+    expect(out).toEqual({ ok: false, cap: 200, used: 200, replay: false });
+    // The tally did not move — a refusal costs nothing.
+    expect(docs.get(MERCHANT).activation_count.activated).toBe(200);
+  });
+});
+
+describe("A REDELIVERY IS NOT A SECOND ORDER", () => {
+  it("answers the same thing twice and spends once", async () => {
+    // Shopify is at-least-once, and this handler deliberately returns 500 to
+    // ask for a redelivery — so the same order arrives again as a matter of
+    // routine. Counting it twice would rob the merchant of a page they paid
+    // no attention to.
+    const { firestore, docs } = fakeFirestore({ [MERCHANT]: {} });
+    const first = await spendFromCap(firestore, { path: MERCHANT } as any, "s", "1001", 2);
+    const again = await spendFromCap(firestore, { path: MERCHANT } as any, "s", "1001", 2);
+
+    expect(first).toEqual({ ok: true, cap: 2, used: 1, replay: false });
+    expect(again.ok).toBe(true);
+    expect(again.replay).toBe(true);
+    expect(docs.get(MERCHANT).activation_count.activated).toBe(1);
+  });
+
+  it("remembers a REFUSAL too, so a redelivery is not re-judged later", async () => {
+    // Without this, an order refused at 200/200 could be redelivered after
+    // the merchant raised their cap and quietly become a page — a different
+    // answer for the same order, decided by timing.
+    const { firestore } = fakeFirestore({ [MERCHANT]: { activation_count: { activated: 1 } } });
+    const refused = await spendFromCap(firestore, { path: MERCHANT } as any, "s", "1001", 1);
+    const again = await spendFromCap(firestore, { path: MERCHANT } as any, "s", "1001", 99);
+
+    expect(refused.ok).toBe(false);
+    expect(again.ok).toBe(false);
+    expect(again.replay).toBe(true);
+  });
+
+  it("counts different orders separately", async () => {
+    const { firestore, docs } = fakeFirestore({ [MERCHANT]: {} });
+    await spendFromCap(firestore, { path: MERCHANT } as any, "s", "1", 5);
+    await spendFromCap(firestore, { path: MERCHANT } as any, "s", "2", 5);
+
+    expect(docs.get(MERCHANT).activation_count.activated).toBe(2);
+  });
+});
+
+describe("the transaction's shape", () => {
+  it("reads everything before it writes anything", async () => {
+    // Firestore refuses a read after a write inside a transaction; the fake
+    // above throws on it, so this test fails loudly if the order slips.
+    const { firestore } = fakeFirestore({ [MERCHANT]: {} });
+    await expect(
+      spendFromCap(firestore, { path: MERCHANT } as any, "s", "1", 10),
+    ).resolves.toMatchObject({ ok: true });
+  });
+});

--- a/app/services/activation-counter.server.ts
+++ b/app/services/activation-counter.server.ts
@@ -1,0 +1,118 @@
+// THE CAP — "run it on my next 200 orders" (Sam, 2026-08-27: the cheapest
+// yes of all, because the merchant chooses nothing about their catalogue).
+//
+// A cap is different in kind from every other way a pilot can be narrowed.
+// A state or a product is a PROPERTY of an order: any reader can answer it
+// from the order alone, forever, and two readers always agree. A cap is a
+// RUNNING TALLY: the answer depends on what came before, so exactly one
+// thing may keep it, and that thing is this file.
+//
+// Two properties it must have, or it lies to a merchant:
+//
+//   1. IT MUST NOT DOUBLE-COUNT. Shopify webhooks are at-least-once and
+//      this handler deliberately returns 500 to ask for a redelivery, so
+//      the SAME order arrives more than once as a matter of routine. A
+//      marker doc keyed on (shop, order) makes counting idempotent: the
+//      second delivery is told the same answer as the first and spends
+//      nothing.
+//   2. IT MUST NOT OVERSHOOT UNDER LOAD. Two orders landing together must
+//      not both read "199 used" and both activate. The read, the decision
+//      and the write happen in one Firestore transaction.
+//
+// The tally lives BESIDE the merchant's choice, never inside it
+// (`activation_count`, not `activation_scope`): the choice is theirs and the
+// count is ours, and a settings save must never be able to reset the count
+// — nor a count clobber the choice.
+
+import type { DocumentReference, Firestore } from "firebase-admin/firestore";
+
+export interface CapDecision {
+  /** May this order have a page? */
+  ok: boolean;
+  /** The cap in force, for the log line. */
+  cap: number;
+  /** How many have been spent AFTER this decision. */
+  used: number;
+  /** True when this delivery had already been counted — a redelivery. */
+  replay: boolean;
+}
+
+/** A deterministic id, so the same order always finds its own marker.
+ *  Slashes are illegal in a Firestore document id and order names carry
+ *  them (`#1001/2`), which is the same escaping the backend's enroll lock
+ *  already does. */
+export function activationMarkerId(shop: string, orderId: string | number): string {
+  return `${shop}__${String(orderId).replace(/\//g, "_")}`;
+}
+
+/**
+ * Spend one from the merchant's cap for this order, if there is one to
+ * spend. Returns the decision; never throws for the ordinary cases.
+ *
+ * Call this ONLY for an order that has already passed every other part of
+ * the slice — a cap should not be spent on an order that was never going to
+ * get a page for another reason.
+ */
+export async function spendFromCap(
+  firestore: Firestore,
+  merchantRef: DocumentReference,
+  shop: string,
+  orderId: string | number,
+  cap: number,
+): Promise<CapDecision> {
+  const markerRef = firestore
+    .collection("activation_counted")
+    .doc(activationMarkerId(shop, orderId));
+
+  return firestore.runTransaction(async (tx) => {
+    // Both reads first — Firestore requires every read in a transaction to
+    // precede every write.
+    const [markerSnap, merchantSnap] = await Promise.all([
+      tx.get(markerRef),
+      tx.get(merchantRef),
+    ]);
+
+    const data = merchantSnap.data() ?? {};
+    const used = Number(data?.activation_count?.activated) || 0;
+
+    // A REDELIVERY IS NOT A SECOND ORDER. It already spent its one, so it
+    // gets the same answer it got the first time and the tally is untouched.
+    if (markerSnap.exists) {
+      const grantedBefore = markerSnap.data()?.activated === true;
+      return { ok: grantedBefore, cap, used, replay: true };
+    }
+
+    if (used >= cap) {
+      // Spent. Remember the refusal too, so a redelivery of THIS order is
+      // answered from the marker rather than re-deciding at a later tally.
+      tx.set(markerRef, {
+        shop,
+        order_id: String(orderId),
+        activated: false,
+        at: new Date().toISOString(),
+      });
+      return { ok: false, cap, used, replay: false };
+    }
+
+    tx.set(markerRef, {
+      shop,
+      order_id: String(orderId),
+      activated: true,
+      at: new Date().toISOString(),
+    });
+    tx.set(
+      merchantRef,
+      {
+        activation_count: {
+          // `since` is stamped by whoever sets the cap; preserve whatever is
+          // there rather than restarting the clock on every order.
+          ...(data?.activation_count?.since ? { since: data.activation_count.since } : {}),
+          activated: used + 1,
+        },
+        updatedAt: new Date(),
+      },
+      { merge: true },
+    );
+    return { ok: true, cap, used: used + 1, replay: false };
+  });
+}

--- a/app/services/activation-scope.server.test.ts
+++ b/app/services/activation-scope.server.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeScope,
+  normalizeStateCode,
+  orderActivates,
+  scopeOfMerchant,
+  stateOfWebhookOrder,
+} from "./activation-scope.server";
+
+describe("every merchant on the platform today", () => {
+  it("activates every order, because nobody has a slice", () => {
+    // The Clare-V law: absent config = today's behaviour, byte for byte.
+    expect(scopeOfMerchant({})).toBeNull();
+    expect(scopeOfMerchant({ ink_api_key: "sk_live_x" })).toBeNull();
+    expect(scopeOfMerchant(null)).toBeNull();
+    expect(scopeOfMerchant(undefined)).toBeNull();
+    expect(orderActivates({ shipping_address: { province_code: "TX" } }, null)).toBe(true);
+    expect(orderActivates({}, null)).toBe(true);
+  });
+
+  it("is never darkened by config it cannot read", () => {
+    // Empty, malformed, or a country we do not understand all mean "not
+    // narrowed" — never "narrowed to nothing", which would silently stop
+    // every page on a live store.
+    expect(scopeOfMerchant({ activation_scope: { ship_to: { states: [] } } })).toBeNull();
+    expect(scopeOfMerchant({ activation_scope: { ship_to: null } })).toBeNull();
+    expect(scopeOfMerchant({ activation_scope: "california" })).toBeNull();
+    expect(
+      scopeOfMerchant({ activation_scope: { ship_to: { country: "CA", states: ["ON"] } } }),
+    ).toBeNull();
+    expect(
+      orderActivates(
+        { shipping_address: { province_code: "TX" } },
+        normalizeScope({ ship_to: { states: ["nowhere"] } }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("reading the raw Shopify body", () => {
+  it("prefers province_code — already a code, and costs no new query", () => {
+    // Adding a field to ORDER_DETAIL_QUERY is the #1019 landmine; the raw
+    // webhook body already carries this.
+    expect(stateOfWebhookOrder({ shipping_address: { province_code: "CA" } })).toBe("CA");
+    expect(
+      stateOfWebhookOrder({ shipping_address: { province_code: "ca", province: "Texas" } }),
+    ).toBe("CA");
+  });
+
+  it("falls back to the province NAME when no code is sent", () => {
+    expect(stateOfWebhookOrder({ shipping_address: { province: "California" } })).toBe("CA");
+    expect(stateOfWebhookOrder({ shipping_address: { province: "new york" } })).toBe("NY");
+  });
+
+  it("says null for no address, an unknown place, or abroad", () => {
+    expect(stateOfWebhookOrder({})).toBeNull();
+    expect(stateOfWebhookOrder(null)).toBeNull();
+    expect(stateOfWebhookOrder({ shipping_address: {} })).toBeNull();
+    expect(
+      stateOfWebhookOrder({ shipping_address: { province: "Ontario", country_code: "CA" } }),
+    ).toBeNull();
+  });
+
+  it("normalizes a state however it is written", () => {
+    expect(normalizeStateCode("CA")).toBe("CA");
+    expect(normalizeStateCode(" california ")).toBe("CA");
+    expect(normalizeStateCode("District of Columbia")).toBe("DC");
+    expect(normalizeStateCode("Ontario")).toBeNull();
+    expect(normalizeStateCode(7)).toBeNull();
+  });
+});
+
+describe("a merchant running on chosen states", () => {
+  const scope = normalizeScope({ ship_to: { country: "US", states: ["CA"] } });
+
+  it("activates an order shipping into the slice", () => {
+    expect(orderActivates({ shipping_address: { province_code: "CA" } }, scope)).toBe(true);
+    expect(orderActivates({ shipping_address: { province: "California" } }, scope)).toBe(true);
+  });
+
+  it("does NOT activate an order shipping elsewhere", () => {
+    expect(orderActivates({ shipping_address: { province_code: "TX" } }, scope)).toBe(false);
+  });
+
+  it("FAILS CLOSED when the order cannot say where it ships", () => {
+    // We never guess in the direction that puts a page in a stranger's
+    // hands. The order is still captured — capture is not activation.
+    expect(orderActivates({}, scope)).toBe(false);
+    expect(orderActivates({ shipping_address: { country_code: "CA" } }, scope)).toBe(false);
+    expect(orderActivates(null, scope)).toBe(false);
+  });
+
+  it("holds a multi-state slice however it was written", () => {
+    const multi = normalizeScope({ ship_to: { states: ["new york", "CA", "ca"] } });
+    expect(multi?.ship_to?.states).toEqual(["CA", "NY"]);
+    expect(orderActivates({ shipping_address: { province_code: "NY" } }, multi)).toBe(true);
+    expect(orderActivates({ shipping_address: { province_code: "WA" } }, multi)).toBe(false);
+  });
+
+  it("reads the slice straight off the merchant doc", () => {
+    expect(
+      scopeOfMerchant({ activation_scope: { ship_to: { country: "US", states: ["ca"] } } }),
+    ).toEqual({ ship_to: { country: "US", states: ["CA"] } });
+  });
+});

--- a/app/services/activation-scope.server.test.ts
+++ b/app/services/activation-scope.server.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeScope,
   normalizeStateCode,
   orderActivates,
+  productsActivate,
   scopeOfMerchant,
   stateOfWebhookOrder,
 } from "./activation-scope.server";
@@ -101,5 +102,71 @@ describe("a merchant running on chosen states", () => {
     expect(
       scopeOfMerchant({ activation_scope: { ship_to: { country: "US", states: ["ca"] } } }),
     ).toEqual({ ship_to: { country: "US", states: ["CA"] } });
+  });
+});
+
+// ── THE OTHER WAYS A PILOT ROLLS OUT ─────────────────────────────────────
+// Sam, 2026-08-27: a cap ("your next 200 orders") and a product line
+// ("just our boots", or exact SKUs), beside the states.
+
+describe("the ship-to check answers only what the raw body can say", () => {
+  it("passes an order when the slice names no states at all", () => {
+    // A cap-only or product-only pilot must not be refused here — this
+    // function speaks for ship-to and nothing else.
+    const capOnly = normalizeScope({ volume: { cap: 200 } });
+    const productOnly = normalizeScope({ products: { match: "boot" } });
+    expect(orderActivates({}, capOnly)).toBe(true);
+    expect(orderActivates({ shipping_address: { province_code: "TX" } }, productOnly)).toBe(true);
+  });
+});
+
+describe("a pilot on one product line", () => {
+  const boots = normalizeScope({ products: { match: "boot" } });
+  const bySku = normalizeScope({ products: { skus: ["sm-1234"] } });
+
+  it("runs on an order HOLDING the product", () => {
+    expect(productsActivate([{ title: "Chelsea Boot" }, { title: "Socks" }], boots)).toBe(true);
+    expect(productsActivate([{ title: "Socks" }], boots)).toBe(false);
+  });
+
+  it("matches a SKU exactly, however either side is cased", () => {
+    expect(bySku?.products?.skus).toEqual(["SM-1234"]);
+    expect(productsActivate([{ sku: "sm-1234" }], bySku)).toBe(true);
+    expect(productsActivate([{ sku: "SM-0000" }], bySku)).toBe(false);
+  });
+
+  it("passes everything when no product constraint is set", () => {
+    expect(productsActivate([{ title: "Anything" }], null)).toBe(true);
+    expect(productsActivate([], normalizeScope({ ship_to: { states: ["CA"] } }))).toBe(true);
+  });
+
+  it("FAILS CLOSED when the order lists nothing readable", () => {
+    // Never guess from an absent catalogue in the direction that puts a
+    // page in a stranger's hands.
+    expect(productsActivate([], boots)).toBe(false);
+    expect(productsActivate(null, boots)).toBe(false);
+  });
+});
+
+describe("a cap is recorded but never answered here", () => {
+  it("is kept, normalized, and left for the counter to decide", () => {
+    expect(normalizeScope({ volume: { cap: 200 } })).toEqual({ volume: { cap: 200 } });
+    // 0 is a pilot that is over before it starts; nobody asks for that.
+    for (const cap of [0, -1, 2.5, "200"]) {
+      expect(normalizeScope({ volume: { cap } })).toBeNull();
+    }
+  });
+
+  it("keeps every part when a merchant narrows more than one way", () => {
+    const all = normalizeScope({
+      ship_to: { states: ["ca"] },
+      products: { match: "Boot" },
+      volume: { cap: 50 },
+    });
+    expect(all).toEqual({
+      ship_to: { country: "US", states: ["CA"] },
+      volume: { cap: 50 },
+      products: { match: "Boot" },
+    });
   });
 });

--- a/app/services/activation-scope.server.test.ts
+++ b/app/services/activation-scope.server.test.ts
@@ -217,3 +217,21 @@ describe("a US-only slice written before this was international", () => {
     ).toBe(false);
   });
 });
+
+describe("a merchant can type their product's real name", () => {
+  // Measured on the real fixture ledger 2026-08-27: "Côte" matched nothing
+  // while "cote" matched, because only one side of the comparison had its
+  // accents flattened. The gate must agree with the workspace, or a
+  // merchant sees one set of orders and their customers get another.
+  const lines = [{ title: "La Côte Tote" }];
+
+  it("matches an accented product by its accented name, in any case", () => {
+    for (const typed of ["Côte", "côte", "CÔTE"]) {
+      expect(productsActivate(lines, normalizeScope({ products: { match: typed } }))).toBe(true);
+    }
+  });
+
+  it("does not match a product the order does not hold", () => {
+    expect(productsActivate(lines, normalizeScope({ products: { match: "backpack" } }))).toBe(false);
+  });
+});

--- a/app/services/activation-scope.server.test.ts
+++ b/app/services/activation-scope.server.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   normalizeScope,
   normalizeStateCode,
+  countryOfWebhookOrder,
   orderActivates,
   productsActivate,
   scopeOfMerchant,
@@ -99,9 +100,11 @@ describe("a merchant running on chosen states", () => {
   });
 
   it("reads the slice straight off the merchant doc", () => {
+    // The legacy `country: "US"` is read and then DROPPED — it qualified the
+    // states rather than naming a place, so it is not written back.
     expect(
       scopeOfMerchant({ activation_scope: { ship_to: { country: "US", states: ["ca"] } } }),
-    ).toEqual({ ship_to: { country: "US", states: ["CA"] } });
+    ).toEqual({ ship_to: { states: ["CA"] } });
   });
 });
 
@@ -164,9 +167,53 @@ describe("a cap is recorded but never answered here", () => {
       volume: { cap: 50 },
     });
     expect(all).toEqual({
-      ship_to: { country: "US", states: ["CA"] },
+      ship_to: { states: ["CA"] },
       volume: { cap: 50 },
       products: { match: "Boot" },
     });
+  });
+});
+
+// ── THIS IS AN INTERNATIONAL PRODUCT ─────────────────────────────────────
+describe("a pilot on a country", () => {
+  const uk = normalizeScope({ ship_to: { countries: ["GB"] } });
+
+  it("reads country_code first, then the name", () => {
+    expect(countryOfWebhookOrder({ shipping_address: { country_code: "GB" } })).toBe("GB");
+    expect(countryOfWebhookOrder({ shipping_address: { country: "United Kingdom" } })).toBe("GB");
+    // The names people and storefronts actually use.
+    expect(normalizeScope({ ship_to: { countries: ["uk"] } })?.ship_to?.countries).toEqual(["GB"]);
+  });
+
+  it("activates an order shipping there and no other", () => {
+    expect(orderActivates({ shipping_address: { country_code: "GB" } }, uk)).toBe(true);
+    expect(orderActivates({ shipping_address: { country_code: "US" } }, uk)).toBe(false);
+  });
+
+  it("FAILS CLOSED on a country it cannot place", () => {
+    expect(orderActivates({ shipping_address: { country: "Freedonia" } }, uk)).toBe(false);
+    expect(orderActivates({}, uk)).toBe(false);
+  });
+
+  it("matches places with OR — the UK, and California", () => {
+    const both = normalizeScope({ ship_to: { countries: ["GB"], states: ["CA"] } });
+    expect(orderActivates({ shipping_address: { country_code: "GB" } }, both)).toBe(true);
+    expect(
+      orderActivates({ shipping_address: { country_code: "US", province_code: "CA" } }, both),
+    ).toBe(true);
+    expect(
+      orderActivates({ shipping_address: { country_code: "US", province_code: "TX" } }, both),
+    ).toBe(false);
+  });
+});
+
+describe("a US-only slice written before this was international", () => {
+  it("keeps its states and is NOT widened to all of America", () => {
+    const legacy = normalizeScope({ ship_to: { country: "US", states: ["CA"] } });
+    expect(legacy?.ship_to?.states).toEqual(["CA"]);
+    expect(legacy?.ship_to?.countries).toBeUndefined();
+    expect(
+      orderActivates({ shipping_address: { country_code: "US", province_code: "TX" } }, legacy),
+    ).toBe(false);
   });
 });

--- a/app/services/activation-scope.server.test.ts
+++ b/app/services/activation-scope.server.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeStateCode,
   countryOfWebhookOrder,
   orderActivates,
+  postcodeOfWebhookOrder,
   productsActivate,
   scopeOfMerchant,
   stateOfWebhookOrder,
@@ -233,5 +234,46 @@ describe("a merchant can type their product's real name", () => {
 
   it("does not match a product the order does not hold", () => {
     expect(productsActivate(lines, normalizeScope({ products: { match: "backpack" } }))).toBe(false);
+  });
+});
+
+describe("a pilot on a ZIP or postcode", () => {
+  it("reads it off the raw body and normalizes ZIP+4 to its five", () => {
+    expect(postcodeOfWebhookOrder({ shipping_address: { zip: "90026-1234" } })).toBe("90026");
+    expect(postcodeOfWebhookOrder({ shipping_address: { zip: "sw1a 1aa" } })).toBe("SW1A1AA");
+    expect(postcodeOfWebhookOrder({ shipping_address: {} })).toBeNull();
+    expect(postcodeOfWebhookOrder(null)).toBeNull();
+  });
+
+  it("activates an exact match and a PREFIX", () => {
+    const one = normalizeScope({ ship_to: { postcodes: ["90026"] } });
+    expect(orderActivates({ shipping_address: { zip: "90026" } }, one)).toBe(true);
+    expect(orderActivates({ shipping_address: { zip: "90210" } }, one)).toBe(false);
+
+    const region = normalizeScope({ ship_to: { postcodes: ["900"] } });
+    expect(orderActivates({ shipping_address: { zip: "90026" } }, region)).toBe(true);
+    expect(orderActivates({ shipping_address: { zip: "90210" } }, region)).toBe(false);
+  });
+
+  it("is not US-only", () => {
+    const london = normalizeScope({ ship_to: { postcodes: ["SW1A"] } });
+    expect(orderActivates({ shipping_address: { zip: "SW1A 1AA" } }, london)).toBe(true);
+    expect(orderActivates({ shipping_address: { zip: "EC1A1BB" } }, london)).toBe(false);
+  });
+
+  it("FAILS CLOSED with no postcode on the order", () => {
+    const one = normalizeScope({ ship_to: { postcodes: ["90026"] } });
+    expect(orderActivates({ shipping_address: { city: "Los Angeles" } }, one)).toBe(false);
+    expect(orderActivates({}, one)).toBe(false);
+  });
+
+  it("sits beside countries and states, matched with OR", () => {
+    const mixed = normalizeScope({
+      ship_to: { countries: ["GB"], states: ["CA"], postcodes: ["10011"] },
+    });
+    expect(orderActivates({ shipping_address: { country_code: "GB" } }, mixed)).toBe(true);
+    expect(orderActivates({ shipping_address: { province_code: "CA" } }, mixed)).toBe(true);
+    expect(orderActivates({ shipping_address: { zip: "10011" } }, mixed)).toBe(true);
+    expect(orderActivates({ shipping_address: { province_code: "TX", zip: "73301" } }, mixed)).toBe(false);
   });
 });

--- a/app/services/activation-scope.server.ts
+++ b/app/services/activation-scope.server.ts
@@ -1,9 +1,15 @@
+import { normalizeCountryCode } from "./countries.server";
+
 // THE SLICE, webhook side — does this order ACTIVATE for this merchant?
 //
 // Sam, 2026-08-27: a merchant runs their pilot on the piece of their
 // business they are ready for ("might make it easier for them to commit -
-// if it isnt their entire global sales"). Today that piece is the states
-// they ship to.
+// if it isnt their entire global sales"): a set number of orders, certain
+// places, certain products.
+//
+// PLACES ARE INTERNATIONAL ("this is an international product"). A place is
+// a country as readily as a US state, so a London brand can describe its
+// own business — the first cut of this file could only name US states.
 //
 // CAPTURE IS NOT ACTIVATION, and this file only decides the second one.
 // ink's backend still records EVERY order the store sends — the enroll
@@ -47,7 +53,16 @@ const US_STATE_NAME_TO_CODE: Record<string, string> = {
 };
 
 export interface ActivationScope {
-  ship_to?: { country?: string; states?: string[] } | null;
+  /** WHERE it ships — a set of PLACES, matched with OR. ink is an
+   *  international product, so a place is a country as readily as a US
+   *  state. `country` (singular) is LEGACY: the US-only first cut wrote it
+   *  beside its states, where it qualified them rather than naming a place
+   *  of its own. Read, never written. */
+  ship_to?: {
+    countries?: string[];
+    states?: string[];
+    country?: string;
+  } | null;
   /** A count that depletes. NOT answered here — a cap is a running tally,
    *  so only the counter can answer it (activation-counter.server.ts). This
    *  file reports that a cap EXISTS; it never pretends to know the tally. */
@@ -89,19 +104,29 @@ export function normalizeScope(raw: unknown): ActivationScope | null {
 
   const shipTo = input.ship_to;
   if (shipTo && typeof shipTo === "object") {
-    const country =
-      typeof shipTo.country === "string" ? shipTo.country.trim().toUpperCase() : "US";
-    const states =
-      country === "US" && Array.isArray(shipTo.states)
-        ? Array.from(
-            new Set(
-              shipTo.states
-                .map(normalizeStateCode)
-                .filter((s): s is string => s !== null),
-            ),
-          ).sort()
-        : [];
-    if (states.length) scope.ship_to = { country: "US", states };
+    const states = Array.isArray(shipTo.states)
+      ? Array.from(
+          new Set(
+            shipTo.states.map(normalizeStateCode).filter((s): s is string => s !== null),
+          ),
+        ).sort()
+      : [];
+    const countries = Array.isArray(shipTo.countries)
+      ? Array.from(
+          new Set(
+            shipTo.countries
+              .map(normalizeCountryCode)
+              .filter((c): c is string => c !== null),
+          ),
+        ).sort()
+      : [];
+    // The legacy `country: "US"` is read as NOTHING: it qualified the states
+    // rather than naming a place, and promoting it would silently widen a
+    // merchant's slice from California to all of America.
+    const place: NonNullable<ActivationScope["ship_to"]> = {};
+    if (countries.length) place.countries = countries;
+    if (states.length) place.states = states;
+    if (countries.length || states.length) scope.ship_to = place;
   }
 
   // A cap of 0 is a pilot that is over before it starts — nobody asks for
@@ -167,11 +192,27 @@ export function orderActivates(
   scope: ActivationScope | null,
 ): boolean {
   const normalized = normalizeScope(scope);
-  const states = normalized?.ship_to?.states;
-  if (!states?.length) return true;
+  const states = normalized?.ship_to?.states ?? [];
+  const countries = normalized?.ship_to?.countries ?? [];
+  if (!states.length && !countries.length) return true;
   const state = stateOfWebhookOrder(payload);
-  if (!state) return false;
-  return states.includes(state);
+  const country = countryOfWebhookOrder(payload);
+  // OR across places: "the UK, and California" takes an order to London and
+  // an order to Los Angeles, and nothing else.
+  if (state && states.includes(state)) return true;
+  if (country && countries.includes(country)) return true;
+  return false;
+}
+
+/** The ISO country this raw webhook body ships to, or null. `country_code`
+ *  first — Shopify sends it, so this costs no query. */
+export function countryOfWebhookOrder(payload: unknown): string | null {
+  const address = (payload as { shipping_address?: Record<string, unknown> } | null)
+    ?.shipping_address;
+  if (!address) return null;
+  return (
+    normalizeCountryCode(address.country_code) ?? normalizeCountryCode(address.country)
+  );
 }
 
 /** Does the PRODUCT part pass? Asked once the order's lines are in hand —

--- a/app/services/activation-scope.server.ts
+++ b/app/services/activation-scope.server.ts
@@ -1,0 +1,127 @@
+// THE SLICE, webhook side — does this order ACTIVATE for this merchant?
+//
+// Sam, 2026-08-27: a merchant runs their pilot on the piece of their
+// business they are ready for ("might make it easier for them to commit -
+// if it isnt their entire global sales"). Today that piece is the states
+// they ship to.
+//
+// CAPTURE IS NOT ACTIVATION, and this file only decides the second one.
+// ink's backend still records EVERY order the store sends — the enroll
+// call is untouched ("we want all the data. Shopify doesn't have our
+// data."). What a slice withholds is the ritual: the Shopify tag and the
+// ink.* metafields, and therefore the buyer's page, the branded tracking
+// link and every state email — all of which gate on ink.proof_reference
+// downstream, so this is the one place the decision has to be made.
+//
+// A deliberately dumb mirror of the app's src/lib/activation-scope.ts.
+// Same law, same tests, no imports across repos: the two must agree, so
+// keep them boring enough to compare by eye.
+//
+// ABSENT CONFIG MEANS TODAY'S BEHAVIOUR. Every merchant on the platform
+// has no scope, so every merchant activates everything, exactly as before
+// (the Clare-V law — no hardcoded state, no default cohort anywhere).
+
+/** USPS codes we understand. Mirrors the app's table (moments.ts). */
+const US_STATES = new Set([
+  "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DC", "DE", "FL", "GA", "HI",
+  "IA", "ID", "IL", "IN", "KS", "KY", "LA", "MA", "MD", "ME", "MI", "MN",
+  "MO", "MS", "MT", "NC", "ND", "NE", "NH", "NJ", "NM", "NV", "NY", "OH",
+  "OK", "OR", "PA", "PR", "RI", "SC", "SD", "TN", "TX", "UT", "VA", "VI",
+  "VT", "WA", "WI", "WV", "WY",
+]);
+
+const US_STATE_NAME_TO_CODE: Record<string, string> = {
+  alabama: "AL", alaska: "AK", arizona: "AZ", arkansas: "AR", california: "CA",
+  colorado: "CO", connecticut: "CT", delaware: "DE", "district of columbia": "DC",
+  florida: "FL", georgia: "GA", hawaii: "HI", idaho: "ID", illinois: "IL",
+  indiana: "IN", iowa: "IA", kansas: "KS", kentucky: "KY", louisiana: "LA",
+  maine: "ME", maryland: "MD", massachusetts: "MA", michigan: "MI",
+  minnesota: "MN", mississippi: "MS", missouri: "MO", montana: "MT",
+  nebraska: "NE", nevada: "NV", "new hampshire": "NH", "new jersey": "NJ",
+  "new mexico": "NM", "new york": "NY", "north carolina": "NC",
+  "north dakota": "ND", ohio: "OH", oklahoma: "OK", oregon: "OR",
+  pennsylvania: "PA", "puerto rico": "PR", "rhode island": "RI",
+  "south carolina": "SC", "south dakota": "SD", tennessee: "TN", texas: "TX",
+  utah: "UT", vermont: "VT", virginia: "VA", "virgin islands": "VI",
+  washington: "WA", "west virginia": "WV", wisconsin: "WI", wyoming: "WY",
+};
+
+export interface ActivationScope {
+  ship_to?: { country?: string; states?: string[] } | null;
+}
+
+/** "california" / "CA" / " Ca " → "CA". Unknown → null (never a guess). */
+export function normalizeStateCode(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const normalized = raw.trim().toLowerCase().replace(/\s+/g, " ");
+  if (!normalized) return null;
+  const code =
+    normalized.length === 2
+      ? normalized.toUpperCase()
+      : US_STATE_NAME_TO_CODE[normalized];
+  return code && US_STATES.has(code) ? code : null;
+}
+
+/** A scope with something to say, or null for "not narrowed". Null is the
+ *  answer for absent, empty, malformed, and a country we do not
+ *  understand — a merchant is never darkened by data we cannot read. */
+export function normalizeScope(raw: unknown): ActivationScope | null {
+  if (!raw || typeof raw !== "object") return null;
+  const shipTo = (raw as ActivationScope).ship_to;
+  if (!shipTo || typeof shipTo !== "object") return null;
+  const country =
+    typeof shipTo.country === "string" ? shipTo.country.trim().toUpperCase() : "US";
+  if (country !== "US") return null;
+  const states = Array.isArray(shipTo.states)
+    ? Array.from(
+        new Set(
+          shipTo.states
+            .map(normalizeStateCode)
+            .filter((s): s is string => s !== null),
+        ),
+      ).sort()
+    : [];
+  if (states.length === 0) return null;
+  return { ship_to: { country: "US", states } };
+}
+
+/** The merchant's slice, off the Firestore merchants doc. */
+export function scopeOfMerchant(merchantData: unknown): ActivationScope | null {
+  if (!merchantData || typeof merchantData !== "object") return null;
+  return normalizeScope((merchantData as Record<string, unknown>).activation_scope);
+}
+
+/** The state this RAW Shopify webhook body ships to, or null.
+ *
+ *  province_code first: Shopify's orders/create body already carries the
+ *  two-letter code, so this costs no extra query and — crucially — no new
+ *  field on ORDER_DETAIL_QUERY, where one unauthorized selection fails the
+ *  whole query silently (order #1019). */
+export function stateOfWebhookOrder(payload: unknown): string | null {
+  const address = (payload as { shipping_address?: Record<string, unknown> } | null)
+    ?.shipping_address;
+  if (!address) return null;
+  return (
+    normalizeStateCode(address.province_code) ??
+    normalizeStateCode(address.province) ??
+    normalizeStateCode(address.state)
+  );
+}
+
+/** Does this order get the ritual? Un-narrowed merchants: always yes.
+ *
+ *  FAIL-CLOSED when a slice is set and the order cannot say where it
+ *  ships — the same law aim-audience.ts already rules for aims in the app.
+ *  The order is still captured; it simply is not confirmed to be in the
+ *  piece the merchant committed to, and we never guess in the direction
+ *  that puts a page in a stranger's hands. */
+export function orderActivates(
+  payload: unknown,
+  scope: ActivationScope | null,
+): boolean {
+  const normalized = normalizeScope(scope);
+  if (!normalized) return true;
+  const state = stateOfWebhookOrder(payload);
+  if (!state) return false;
+  return (normalized.ship_to?.states ?? []).includes(state);
+}

--- a/app/services/activation-scope.server.ts
+++ b/app/services/activation-scope.server.ts
@@ -215,6 +215,13 @@ export function countryOfWebhookOrder(payload: unknown): string | null {
   );
 }
 
+/** Flatten a product title the way the app's normalizeProductTitle does —
+ *  lowercase, and every character outside a-z0-9 collapsed to a space. Both
+ *  sides of the comparison go through it or they cannot agree. */
+function flattenTitle(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
 /** Does the PRODUCT part pass? Asked once the order's lines are in hand —
  *  from ORDER_DETAIL_QUERY, which already fetches `title` and `sku`.
  *
@@ -230,11 +237,17 @@ export function productsActivate(
   const list = Array.isArray(lines) ? lines.filter(Boolean) : [];
   if (!list.length) return false;
   const skus = products.skus ?? [];
-  const needle = products.match?.trim().toLowerCase() ?? "";
+  // THE SEARCH AND THE TITLE ARE FLATTENED THE SAME WAY, or a merchant
+  // cannot find their own products. Measured 2026-08-27: typing "Côte" —
+  // the name in their own catalogue — matched nothing, while plain "cote"
+  // matched, because only one side had its accents handled. Worst for
+  // exactly the international brands this is for. Mirrors the app's
+  // normalizeProductTitle: anything outside a-z0-9 becomes a space.
+  const needle = flattenTitle(products.match ?? "");
   return list.some((line) => {
     const sku = typeof line.sku === "string" ? line.sku.trim().toUpperCase() : "";
     if (sku && skus.includes(sku)) return true;
     if (!needle) return false;
-    return `${line.title ?? ""} ${line.name ?? ""}`.toLowerCase().includes(needle);
+    return flattenTitle(`${line.title ?? ""} ${line.name ?? ""}`).includes(needle);
   });
 }

--- a/app/services/activation-scope.server.ts
+++ b/app/services/activation-scope.server.ts
@@ -48,6 +48,23 @@ const US_STATE_NAME_TO_CODE: Record<string, string> = {
 
 export interface ActivationScope {
   ship_to?: { country?: string; states?: string[] } | null;
+  /** A count that depletes. NOT answered here — a cap is a running tally,
+   *  so only the counter can answer it (activation-counter.server.ts). This
+   *  file reports that a cap EXISTS; it never pretends to know the tally. */
+  volume?: { cap: number } | null;
+  /** Which products. An order counts when ANY line on it matches — the same
+   *  reading the app's campaigns already use ("boot" holds every boot).
+   *  Cheap by construction: ORDER_DETAIL_QUERY already asks for `title` and
+   *  `sku`, so this needs no new Shopify permission and no new query. A real
+   *  Shopify COLLECTION is on no wire we have and is deliberately absent. */
+  products?: { skus?: string[]; match?: string } | null;
+}
+
+/** One line on an order, however the payload spells it. */
+export interface ScopableLine {
+  sku?: string | null;
+  title?: string | null;
+  name?: string | null;
 }
 
 /** "california" / "CA" / " Ca " → "CA". Unknown → null (never a guess). */
@@ -67,22 +84,51 @@ export function normalizeStateCode(raw: unknown): string | null {
  *  understand — a merchant is never darkened by data we cannot read. */
 export function normalizeScope(raw: unknown): ActivationScope | null {
   if (!raw || typeof raw !== "object") return null;
-  const shipTo = (raw as ActivationScope).ship_to;
-  if (!shipTo || typeof shipTo !== "object") return null;
-  const country =
-    typeof shipTo.country === "string" ? shipTo.country.trim().toUpperCase() : "US";
-  if (country !== "US") return null;
-  const states = Array.isArray(shipTo.states)
-    ? Array.from(
-        new Set(
-          shipTo.states
-            .map(normalizeStateCode)
-            .filter((s): s is string => s !== null),
-        ),
-      ).sort()
-    : [];
-  if (states.length === 0) return null;
-  return { ship_to: { country: "US", states } };
+  const input = raw as ActivationScope;
+  const scope: ActivationScope = {};
+
+  const shipTo = input.ship_to;
+  if (shipTo && typeof shipTo === "object") {
+    const country =
+      typeof shipTo.country === "string" ? shipTo.country.trim().toUpperCase() : "US";
+    const states =
+      country === "US" && Array.isArray(shipTo.states)
+        ? Array.from(
+            new Set(
+              shipTo.states
+                .map(normalizeStateCode)
+                .filter((s): s is string => s !== null),
+            ),
+          ).sort()
+        : [];
+    if (states.length) scope.ship_to = { country: "US", states };
+  }
+
+  // A cap of 0 is a pilot that is over before it starts — nobody asks for
+  // that, so it reads as no cap rather than as silence forever.
+  const cap = input.volume?.cap;
+  if (typeof cap === "number" && Number.isInteger(cap) && cap > 0) {
+    scope.volume = { cap };
+  }
+
+  const products = input.products;
+  if (products && typeof products === "object") {
+    const skus = Array.isArray(products.skus)
+      ? Array.from(
+          new Set(
+            products.skus
+              .map((s) => (typeof s === "string" ? s.trim().toUpperCase() : ""))
+              .filter(Boolean),
+          ),
+        ).sort()
+      : [];
+    const match = typeof products.match === "string" ? products.match.trim() : "";
+    if (skus.length || match) {
+      scope.products = { ...(skus.length ? { skus } : {}), ...(match ? { match } : {}) };
+    }
+  }
+
+  return Object.keys(scope).length ? scope : null;
 }
 
 /** The merchant's slice, off the Firestore merchants doc. */
@@ -108,7 +154,8 @@ export function stateOfWebhookOrder(payload: unknown): string | null {
   );
 }
 
-/** Does this order get the ritual? Un-narrowed merchants: always yes.
+/** Does the SHIP-TO part of the slice pass? Answered from the raw webhook
+ *  body alone, so it costs nothing and can be asked before any query.
  *
  *  FAIL-CLOSED when a slice is set and the order cannot say where it
  *  ships — the same law aim-audience.ts already rules for aims in the app.
@@ -120,8 +167,33 @@ export function orderActivates(
   scope: ActivationScope | null,
 ): boolean {
   const normalized = normalizeScope(scope);
-  if (!normalized) return true;
+  const states = normalized?.ship_to?.states;
+  if (!states?.length) return true;
   const state = stateOfWebhookOrder(payload);
   if (!state) return false;
-  return (normalized.ship_to?.states ?? []).includes(state);
+  return states.includes(state);
+}
+
+/** Does the PRODUCT part pass? Asked once the order's lines are in hand —
+ *  from ORDER_DETAIL_QUERY, which already fetches `title` and `sku`.
+ *
+ *  Fail-closed the same way: a product-narrowed pilot whose order lists
+ *  nothing readable does not activate. Nothing is guessed from an absent
+ *  catalogue. */
+export function productsActivate(
+  lines: ScopableLine[] | null | undefined,
+  scope: ActivationScope | null,
+): boolean {
+  const products = normalizeScope(scope)?.products;
+  if (!products) return true;
+  const list = Array.isArray(lines) ? lines.filter(Boolean) : [];
+  if (!list.length) return false;
+  const skus = products.skus ?? [];
+  const needle = products.match?.trim().toLowerCase() ?? "";
+  return list.some((line) => {
+    const sku = typeof line.sku === "string" ? line.sku.trim().toUpperCase() : "";
+    if (sku && skus.includes(sku)) return true;
+    if (!needle) return false;
+    return `${line.title ?? ""} ${line.name ?? ""}`.toLowerCase().includes(needle);
+  });
 }

--- a/app/services/activation-scope.server.ts
+++ b/app/services/activation-scope.server.ts
@@ -61,6 +61,10 @@ export interface ActivationScope {
   ship_to?: {
     countries?: string[];
     states?: string[];
+    /** ZIP or postcode, matched EXACT-OR-PREFIX so "90026" names one place
+     *  and "900" names a region. Not US-only: "SW1A" names a London
+     *  district the same way. */
+    postcodes?: string[];
     country?: string;
   } | null;
   /** A count that depletes. NOT answered here — a cap is a running tally,
@@ -80,6 +84,17 @@ export interface ScopableLine {
   sku?: string | null;
   title?: string | null;
   name?: string | null;
+}
+
+/** "90026" / "90026-1234" / "sw1a 1aa" → "90026" / "90026" / "SW1A1AA".
+ *  A ZIP+4 keeps only its five — the last four are a delivery segment
+ *  nobody narrows a pilot by. */
+export function normalizePostcode(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const cleaned = raw.trim().toUpperCase().replace(/[^A-Z0-9]/g, "");
+  if (!cleaned) return null;
+  if (/^\d{9}$/.test(cleaned)) return cleaned.slice(0, 5);
+  return cleaned;
 }
 
 /** "california" / "CA" / " Ca " → "CA". Unknown → null (never a guess). */
@@ -123,10 +138,18 @@ export function normalizeScope(raw: unknown): ActivationScope | null {
     // The legacy `country: "US"` is read as NOTHING: it qualified the states
     // rather than naming a place, and promoting it would silently widen a
     // merchant's slice from California to all of America.
+    const postcodes = Array.isArray(shipTo.postcodes)
+      ? Array.from(
+          new Set(
+            shipTo.postcodes.map(normalizePostcode).filter((z): z is string => z !== null),
+          ),
+        ).sort()
+      : [];
     const place: NonNullable<ActivationScope["ship_to"]> = {};
     if (countries.length) place.countries = countries;
     if (states.length) place.states = states;
-    if (countries.length || states.length) scope.ship_to = place;
+    if (postcodes.length) place.postcodes = postcodes;
+    if (countries.length || states.length || postcodes.length) scope.ship_to = place;
   }
 
   // A cap of 0 is a pilot that is over before it starts — nobody asks for
@@ -194,14 +217,26 @@ export function orderActivates(
   const normalized = normalizeScope(scope);
   const states = normalized?.ship_to?.states ?? [];
   const countries = normalized?.ship_to?.countries ?? [];
-  if (!states.length && !countries.length) return true;
+  const postcodes = normalized?.ship_to?.postcodes ?? [];
+  if (!states.length && !countries.length && !postcodes.length) return true;
   const state = stateOfWebhookOrder(payload);
   const country = countryOfWebhookOrder(payload);
-  // OR across places: "the UK, and California" takes an order to London and
-  // an order to Los Angeles, and nothing else.
+  const postcode = postcodeOfWebhookOrder(payload);
+  // OR across places: "the UK, and California, and 90026" takes an order to
+  // any of them and nothing else.
   if (state && states.includes(state)) return true;
   if (country && countries.includes(country)) return true;
+  if (postcode && postcodes.some((z) => postcode === z || postcode.startsWith(z))) return true;
   return false;
+}
+
+/** The postcode this raw webhook body ships to, or null. Shopify sends it
+ *  as `zip` on the shipping address, so this costs no query. */
+export function postcodeOfWebhookOrder(payload: unknown): string | null {
+  const address = (payload as { shipping_address?: Record<string, unknown> } | null)
+    ?.shipping_address;
+  if (!address) return null;
+  return normalizePostcode(address.zip) ?? normalizePostcode(address.postal_code);
 }
 
 /** The ISO country this raw webhook body ships to, or null. `country_code`

--- a/app/services/countries.server.ts
+++ b/app/services/countries.server.ts
@@ -1,0 +1,127 @@
+// COUNTRIES — a deliberately dumb mirror of the app's src/lib/countries.ts.
+//
+// ink is an international product (Sam, 2026-08-27), so a slice can name a
+// country as readily as a US state. The three copies of this table must
+// agree, so they are generated from the same source text and kept boring
+// enough to diff by eye.
+//
+// COMPLETENESS IS THE POINT: an unresolvable country fails CLOSED, so a
+// missing row would mean a merchant picks their own country and quietly
+// serves nobody.
+
+const COUNTRY_NAMES: Record<string, string> = {
+  AD: "Andorra", AE: "United Arab Emirates", AF: "Afghanistan",
+  AG: "Antigua and Barbuda", AI: "Anguilla", AL: "Albania", AM: "Armenia",
+  AO: "Angola", AQ: "Antarctica", AR: "Argentina", AS: "American Samoa",
+  AT: "Austria", AU: "Australia", AW: "Aruba", AX: "Åland Islands",
+  AZ: "Azerbaijan", BA: "Bosnia and Herzegovina", BB: "Barbados",
+  BD: "Bangladesh", BE: "Belgium", BF: "Burkina Faso", BG: "Bulgaria",
+  BH: "Bahrain", BI: "Burundi", BJ: "Benin", BL: "Saint Barthélemy",
+  BM: "Bermuda", BN: "Brunei", BO: "Bolivia", BQ: "Caribbean Netherlands",
+  BR: "Brazil", BS: "Bahamas", BT: "Bhutan", BV: "Bouvet Island",
+  BW: "Botswana", BY: "Belarus", BZ: "Belize", CA: "Canada",
+  CC: "Cocos (Keeling) Islands", CD: "Congo - Kinshasa",
+  CF: "Central African Republic", CG: "Congo - Brazzaville",
+  CH: "Switzerland", CI: "Côte d’Ivoire", CK: "Cook Islands", CL: "Chile",
+  CM: "Cameroon", CN: "China", CO: "Colombia", CR: "Costa Rica", CU: "Cuba",
+  CV: "Cape Verde", CW: "Curaçao", CX: "Christmas Island", CY: "Cyprus",
+  CZ: "Czechia", DE: "Germany", DJ: "Djibouti", DK: "Denmark",
+  DM: "Dominica", DO: "Dominican Republic", DZ: "Algeria", EC: "Ecuador",
+  EE: "Estonia", EG: "Egypt", EH: "Western Sahara", ER: "Eritrea",
+  ES: "Spain", ET: "Ethiopia", FI: "Finland", FJ: "Fiji",
+  FK: "Falkland Islands", FM: "Micronesia", FO: "Faroe Islands",
+  FR: "France", GA: "Gabon", GB: "United Kingdom", GD: "Grenada",
+  GE: "Georgia", GF: "French Guiana", GG: "Guernsey", GH: "Ghana",
+  GI: "Gibraltar", GL: "Greenland", GM: "Gambia", GN: "Guinea",
+  GP: "Guadeloupe", GQ: "Equatorial Guinea", GR: "Greece",
+  GS: "South Georgia and the South Sandwich Islands", GT: "Guatemala",
+  GU: "Guam", GW: "Guinea-Bissau", GY: "Guyana", HK: "Hong Kong SAR",
+  HM: "Heard and McDonald Islands", HN: "Honduras", HR: "Croatia",
+  HT: "Haiti", HU: "Hungary", ID: "Indonesia", IE: "Ireland",
+  IL: "Israel", IM: "Isle of Man", IN: "India",
+  IO: "British Indian Ocean Territory", IQ: "Iraq", IR: "Iran",
+  IS: "Iceland", IT: "Italy", JE: "Jersey", JM: "Jamaica", JO: "Jordan",
+  JP: "Japan", KE: "Kenya", KG: "Kyrgyzstan", KH: "Cambodia",
+  KI: "Kiribati", KM: "Comoros", KN: "Saint Kitts and Nevis",
+  KP: "North Korea", KR: "South Korea", KW: "Kuwait", KY: "Cayman Islands",
+  KZ: "Kazakhstan", LA: "Laos", LB: "Lebanon", LC: "Saint Lucia",
+  LI: "Liechtenstein", LK: "Sri Lanka", LR: "Liberia", LS: "Lesotho",
+  LT: "Lithuania", LU: "Luxembourg", LV: "Latvia", LY: "Libya",
+  MA: "Morocco", MC: "Monaco", MD: "Moldova", ME: "Montenegro",
+  MF: "Saint Martin", MG: "Madagascar", MH: "Marshall Islands",
+  MK: "North Macedonia", ML: "Mali", MM: "Myanmar (Burma)", MN: "Mongolia",
+  MO: "Macao SAR", MP: "Northern Mariana Islands", MQ: "Martinique",
+  MR: "Mauritania", MS: "Montserrat", MT: "Malta", MU: "Mauritius",
+  MV: "Maldives", MW: "Malawi", MX: "Mexico", MY: "Malaysia",
+  MZ: "Mozambique", NA: "Namibia", NC: "New Caledonia", NE: "Niger",
+  NF: "Norfolk Island", NG: "Nigeria", NI: "Nicaragua", NL: "Netherlands",
+  NO: "Norway", NP: "Nepal", NR: "Nauru", NU: "Niue", NZ: "New Zealand",
+  OM: "Oman", PA: "Panama", PE: "Peru", PF: "French Polynesia",
+  PG: "Papua New Guinea", PH: "Philippines", PK: "Pakistan", PL: "Poland",
+  PM: "Saint Pierre and Miquelon", PN: "Pitcairn Islands",
+  PR: "Puerto Rico", PS: "Palestine", PT: "Portugal", PW: "Palau",
+  PY: "Paraguay", QA: "Qatar", RE: "Réunion", RO: "Romania", RS: "Serbia",
+  RU: "Russia", RW: "Rwanda", SA: "Saudi Arabia", SB: "Solomon Islands",
+  SC: "Seychelles", SD: "Sudan", SE: "Sweden", SG: "Singapore",
+  SH: "St. Helena", SI: "Slovenia", SJ: "Svalbard and Jan Mayen",
+  SK: "Slovakia", SL: "Sierra Leone", SM: "San Marino", SN: "Senegal",
+  SO: "Somalia", SR: "Suriname", SS: "South Sudan",
+  ST: "São Tomé and Príncipe", SV: "El Salvador", SX: "Sint Maarten",
+  SY: "Syria", SZ: "Eswatini", TC: "Turks and Caicos Islands", TD: "Chad",
+  TF: "French Southern Territories", TG: "Togo", TH: "Thailand",
+  TJ: "Tajikistan", TK: "Tokelau", TL: "Timor-Leste", TM: "Turkmenistan",
+  TN: "Tunisia", TO: "Tonga", TR: "Türkiye", TT: "Trinidad and Tobago",
+  TV: "Tuvalu", TW: "Taiwan", TZ: "Tanzania", UA: "Ukraine", UG: "Uganda",
+  UM: "U.S. Outlying Islands", US: "United States", UY: "Uruguay",
+  UZ: "Uzbekistan", VA: "Vatican City", VC: "Saint Vincent and the Grenadines",
+  VE: "Venezuela", VG: "British Virgin Islands", VI: "U.S. Virgin Islands",
+  VN: "Vietnam", VU: "Vanuatu", WF: "Wallis and Futuna", WS: "Samoa",
+  YE: "Yemen", YT: "Mayotte", ZA: "South Africa", ZM: "Zambia",
+  ZW: "Zimbabwe",
+};
+
+const COUNTRY_ALIASES: Record<string, string> = {
+  uk: "GB", "united kingdom": "GB", "great britain": "GB", britain: "GB",
+  england: "GB", scotland: "GB", wales: "GB", "northern ireland": "GB",
+  usa: "US", "u s a": "US", "united states of america": "US", america: "US",
+  "the netherlands": "NL", holland: "NL",
+  "south korea": "KR", "korea republic of": "KR", "republic of korea": "KR",
+  "north korea": "KP",
+  "russian federation": "RU", "czech republic": "CZ", turkey: "TR",
+  "ivory coast": "CI", swaziland: "SZ", macedonia: "MK", burma: "MM",
+  "vatican city state": "VA", "holy see": "VA", "cape verde": "CV",
+  "east timor": "TL", "hong kong": "HK", macau: "MO", macao: "MO",
+  "uae": "AE", "u a e": "AE", "viet nam": "VN", laos: "LA",
+  "syrian arab republic": "SY", "bolivia plurinational state of": "BO",
+  "venezuela bolivarian republic of": "VE", "moldova republic of": "MD",
+  "tanzania united republic of": "TZ", "congo democratic republic of the": "CD",
+  "brunei darussalam": "BN", "cocos islands": "CC", "keeling islands": "CC",
+};
+
+function foldName(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+const NAME_TO_CODE: Record<string, string> = (() => {
+  const map: Record<string, string> = {};
+  for (const [code, name] of Object.entries(COUNTRY_NAMES)) map[foldName(name)] = code;
+  for (const [alias, code] of Object.entries(COUNTRY_ALIASES)) map[foldName(alias)] = code;
+  return map;
+})();
+
+/** "GB" / "gb" / "United Kingdom" / "UK" → "GB". Unknown → null. */
+export function normalizeCountryCode(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const upper = trimmed.toUpperCase();
+  if (upper.length === 2 && upper in COUNTRY_NAMES) return upper;
+  return NAME_TO_CODE[foldName(trimmed)] ?? null;
+}
+
+export const COUNTRY_CODE_SET = new Set(Object.keys(COUNTRY_NAMES));


### PR DESCRIPTION
The enforcement half of THE SLICE. Pairs with parallelreturns#1171.

A merchant may run their pilot on part of their business — a set number of orders, certain **places**, certain products. A place is a **country** as readily as a US state (Sam: *"this is an international product"*).

## One decision, at the front door

In `webhooks.orders_create.ts`:

- **The order is enrolled either way.** ink's backend gets every order the store sends — Sam: *"just the orders from their cohort come through, but our backend gets all the orders."* Widening later reveals a history that was there all along.
- **An out-of-slice order gets no Shopify tag and no `ink.*` metafields.**

That second skip is the whole enforcement, and it needed no suppression logic anywhere else: everything a buyer could ever see hangs off `ink.proof_reference`, and the fulfillment webhooks already early-return 200 without it (`webhooks.fulfillments_create.tsx:69`, `webhooks.fulfillments_update.tsx:171`). No branded tracking link, no order door, no state email.

## Three questions, answered where each can be

**Ship-to** is answered early and free, off the raw webhook body Shopify already sent — which carries `country_code` beside `province_code`, so countries cost no query and no scope either. Places match with OR. **No new field on `ORDER_DETAIL_QUERY`** — one unauthorized selection there fails the whole query silently, which is how order #1019 died.

**Products** are answered off that same existing query, which already asks for `title` and `sku` — so no new Shopify permission and no new query. A real Shopify **collection** is on no wire we have and is deliberately absent.

**A cap cannot be answered from an order at all.** It is a running tally, so it gets its own file and its own transaction, with two properties it must have or it lies to a merchant:

1. **It must not double-count.** Shopify is at-least-once and this handler deliberately returns 500 to ask for redelivery, so the same order arrives again as routine. A marker doc per (shop, order) makes counting idempotent — and it remembers a **refusal** too, so an order turned away at 200/200 cannot be redelivered after the cap is raised and quietly become a page.
2. **It must not overshoot.** Read, decide and write happen in one transaction, so two orders landing together cannot both spend the last one.

The cap is spent **last**, after ship-to and products pass, so it is never burned on an order that was never going to get a page anyway.

Product and cap start **unknown**, and unknown never counts as yes — a merchant who narrowed either way is fail-closed until a real answer arrives. A merchant with neither is true from the start, so nothing about today's behaviour depends on the query succeeding.

## The tag moved, deliberately

It now sits after the enroll, because the product and cap answers only exist once the order has been read — and a tag promising a page we then withheld would be a lie in the merchant's own admin. An in-scope order whose enroll **failed** is still tagged, which is the recovery behaviour that code depends on.

## Ships neutral — and this is a production deploy

Merging here deploys. No merchant has a slice, so absent config activates everything and this diff is inert until someone sets one. Malformed, empty, or a country we do not understand all read as *not narrowed* rather than *narrowed to nothing*, so bad data can never dark a live store. An unreadable merchant doc, or a tally we cannot read, fails closed — captured, never announced.

Out-of-slice returns **200**: it is a decision, not a failure, and a 500 would have Shopify redeliver it forever.

## New surfaces

None — no routes and no UI. One gate inside the existing `orders/create` webhook, plus `app/services/activation-scope.server.ts` (a pure predicate), `app/services/activation-counter.server.ts` (the tally), and `app/services/countries.server.ts` (ISO 3166-1, generated from the app's table rather than retyped), each with tests.

## Verified

`npm run typecheck`, 120 tests, real `react-router build`.

**The legacy shape is read and dropped:** the US-only first cut stored `{ country: "US", states: [...] }`, where the country qualified the states rather than naming a place. Promoting it would widen a merchant's slice from California to all of America. Pinned by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

