### PR TITLE
The slice reads the record the workspace writes

### DIFF
--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -3,7 +3,7 @@ import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
 import { enrollOrder, createMerchant } from "../services/ink-api.server";
 import { attachProductUrls, productDetailFromLineItem } from "../services/order-line-item";
-import { findMerchantDocRef } from "../services/merchant-doc.server";
+import { findActivationDocRef } from "../services/merchant-doc.server";
 import {
   countryOfWebhookOrder,
   orderActivates,
@@ -270,11 +270,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   // Background enrollment: INK is hidden from checkout and never appears as a
   // customer-paid shipping option, so every order on this shop is eligible.
   const deliveryMode = await getMerchantDeliveryMode(shop);
-  // The merchant doc, through the ONE resolver — three doc-identity
-  // conventions coexist in this collection and a hand-rolled lookup is the
-  // §17.2 landmine (merchant-doc.server.ts). Never fatal: an unreadable
-  // merchant means no slice, which means today's behaviour.
-  const merchantForScope = await findMerchantDocRef(firestore, shop).catch((e) => {
+  // The merchant doc FOR THE SLICE, through the slice's own resolver. A
+  // connected store can hold TWO merchant docs, and the workspace's save can
+  // only ever reach the ACTIVE one — reading the api-key doc here (as
+  // findMerchantDocRef rightly does for enrolling) made a saved slice
+  // invisible to this webhook (merchant-doc.server.ts tells the story).
+  // Never fatal: an unreadable merchant means no slice, today's behaviour.
+  const merchantForScope = await findActivationDocRef(firestore, shop).catch((e) => {
     console.warn(`[orders/create] Could not read merchant doc for ${shop}:`, e);
     return null;
   });

--- a/app/services/activation-doc-ref.server.test.ts
+++ b/app/services/activation-doc-ref.server.test.ts
@@ -1,0 +1,128 @@
+// findActivationDocRef — the slice reads the record the workspace writes.
+//
+// A connected store can hold TWO merchant docs: the embed's own (keyed by
+// shop domain, carrying ink_api_key) and the backend-provisioned one
+// (`shop_…`, `status: "active"`). The backend's PATCH /activation-scope can
+// only write the ACTIVE doc, so a webhook reading the slice off the api-key
+// doc sees null forever — a saved slice silently ignored. Caught on the
+// Steve Madden rig 2026-08-28. These tests pin the choice.
+
+import { describe, expect, it } from "vitest";
+import { findActivationDocRef } from "./merchant-doc.server";
+
+type Doc = { id: string; data: Record<string, unknown> };
+
+/** Minimal firestore stub speaking the exact surface the resolver uses. */
+function stubFirestore(docs: Doc[]) {
+  return {
+    collection(name: string) {
+      if (name !== "merchants") throw new Error("unexpected collection " + name);
+      return {
+        doc(id: string) {
+          const hit = docs.find((d) => d.id === id);
+          const ref = { id, __isRef: true };
+          return {
+            ...ref,
+            async get() {
+              return {
+                exists: Boolean(hit),
+                data: () => hit?.data,
+                ref,
+              };
+            },
+          };
+        },
+        where(field: string, _op: string, value: unknown) {
+          return {
+            limit() {
+              return {
+                async get() {
+                  const matches = docs.filter((d) => d.data[field] === value);
+                  return {
+                    empty: matches.length === 0,
+                    docs: matches.map((d) => ({
+                      data: () => d.data,
+                      ref: { id: d.id, __isRef: true },
+                    })),
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  } as any;
+}
+
+describe("findActivationDocRef", () => {
+  it("the two-record store: prefers the ACTIVE doc over the api-key doc (the Steve Madden shape)", async () => {
+    const fs = stubFirestore([
+      {
+        id: "sm-test.myshopify.com",
+        data: {
+          shop: "sm-test.myshopify.com",
+          shopDomain: "sm-test.myshopify.com",
+          ink_api_key: "k1",
+        },
+      },
+      {
+        id: "shop_bb508e",
+        data: {
+          shop_id: "shop_bb508e",
+          shop_domain: "sm-test.myshopify.com",
+          status: "active",
+        },
+      },
+    ]);
+    const hit = await findActivationDocRef(fs, "sm-test.myshopify.com");
+    expect(hit).not.toBeNull();
+    expect(hit!.ref.id).toBe("shop_bb508e");
+    // The api key is still reported from whichever doc carries it.
+    expect(hit!.apiKey).toBe("k1");
+  });
+
+  it("a single-doc shop resolves exactly as before (no active flag, api-key doc wins)", async () => {
+    const fs = stubFirestore([
+      { id: "solo.myshopify.com", data: { shop: "solo.myshopify.com", ink_api_key: "k2" } },
+    ]);
+    const hit = await findActivationDocRef(fs, "solo.myshopify.com");
+    expect(hit).not.toBeNull();
+    expect(hit!.ref.id).toBe("solo.myshopify.com");
+    expect(hit!.apiKey).toBe("k2");
+  });
+
+  it("with no active doc, a doc already carrying a slice beats the api-key doc", async () => {
+    const fs = stubFirestore([
+      { id: "keyed", data: { shopDomain: "y.myshopify.com", ink_api_key: "k3" } },
+      {
+        id: "sliced",
+        data: {
+          shop_domain: "y.myshopify.com",
+          activation_scope: { ship_to: { states: ["CA"] } },
+        },
+      },
+    ]);
+    const hit = await findActivationDocRef(fs, "y.myshopify.com");
+    expect(hit).not.toBeNull();
+    expect(hit!.ref.id).toBe("sliced");
+  });
+
+  it("a doc matched by the direct read AND a field query is counted once", async () => {
+    const fs = stubFirestore([
+      {
+        id: "z.myshopify.com",
+        data: { shop: "z.myshopify.com", shopDomain: "z.myshopify.com", ink_api_key: "k4" },
+      },
+    ]);
+    const hit = await findActivationDocRef(fs, "z.myshopify.com");
+    expect(hit).not.toBeNull();
+    expect(hit!.ref.id).toBe("z.myshopify.com");
+  });
+
+  it("an unknown shop resolves to null", async () => {
+    const fs = stubFirestore([]);
+    const hit = await findActivationDocRef(fs, "ghost.myshopify.com");
+    expect(hit).toBeNull();
+  });
+});

--- a/app/services/merchant-doc.server.ts
+++ b/app/services/merchant-doc.server.ts
@@ -69,3 +69,67 @@ export async function findMerchantDoc(
   const hit = await findMerchantDocRef(firestore, shop);
   return hit ? { data: hit.data, apiKey: hit.apiKey } : null;
 }
+
+/** THE SLICE'S OWN RESOLVER — the record the workspace door actually writes.
+ *
+ *  findMerchantDocRef prefers the doc carrying `ink_api_key`, which is right
+ *  for enrolling (the key IS what that caller wants) and WRONG for the slice.
+ *  A connected store can hold TWO merchant docs — the embed's own, keyed by
+ *  shop domain and carrying the api key, and the backend-provisioned one
+ *  (`shop_…`, `status: "active"`). The backend's PATCH /activation-scope can
+ *  only ever write the ACTIVE doc (its auth refuses everything else), so a
+ *  slice read off the api-key doc is a slice that never existed — saved in
+ *  the workspace, invisible to the webhook, silently running on every order.
+ *  Caught on the Steve Madden rig, 2026-08-28, before any order ran.
+ *
+ *  So for the slice (and its tally, which must land where the workspace's
+ *  GET reads it): prefer the ACTIVE doc, then any doc already carrying
+ *  `activation_scope`, then fall back to exactly what findMerchantDocRef
+ *  would have chosen — a single-doc shop resolves identically either way. */
+export async function findActivationDocRef(
+  firestore: Firestore,
+  shop: string,
+): Promise<MerchantDocRefHit | null> {
+  const hits: Array<{ data: DocumentData; ref: DocumentReference }> = [];
+  const seen = new Set<string>();
+  const push = (data: DocumentData, ref: DocumentReference) => {
+    const id = ref.id ?? String(ref);
+    if (seen.has(id)) return;
+    seen.add(id);
+    hits.push({ data, ref });
+  };
+
+  try {
+    const direct = await firestore.collection("merchants").doc(shop).get();
+    if (direct.exists) push(direct.data() as DocumentData, direct.ref);
+  } catch { /* fall through to field queries */ }
+
+  // Every convention, no early exit — the active doc may sit behind a
+  // convention the api-key doc already satisfied.
+  for (const field of ["shop", "shopDomain", "shop_domain"]) {
+    try {
+      const snap = await firestore
+        .collection("merchants")
+        .where(field, "==", shop)
+        .limit(5)
+        .get();
+      snap.docs.forEach((d) => push(d.data(), d.ref));
+    } catch { /* keep trying the next convention */ }
+  }
+
+  if (hits.length === 0) return null;
+
+  const active = hits.find((h) => h.data?.status === "active");
+  const carriesScope = hits.find(
+    (h) => h.data?.activation_scope && typeof h.data.activation_scope === "object",
+  );
+  const withKey = hits.find(
+    (h) => typeof h.data?.ink_api_key === "string" && h.data.ink_api_key,
+  );
+  const hit = active ?? carriesScope ?? withKey ?? hits[0];
+  return {
+    data: hit.data,
+    ref: hit.ref,
+    apiKey: (withKey?.data.ink_api_key as string) ?? null,
+  };
+}


### PR DESCRIPTION
A connected store can hold **two** merchant records: the embed's own (keyed by shop domain, carrying `ink_api_key`) and the backend-provisioned **active** one. The workspace's slice save can only ever reach the active record — but the order webhook read the slice through `findMerchantDocRef`, which prefers the api-key record (correct for enrolling, wrong for the slice). Result: a merchant saves a slice, the workspace obeys it, and the store silently keeps giving every order a page. The cap tally would likewise have been kept on a record the workspace never reads, so the merchant's counter would never move.

Caught on the Steve Madden rig 2026-08-28 while preparing the live walk — before any order ran.

**Files:**
- `app/services/merchant-doc.server.ts` — new `findActivationDocRef`: gathers every doc-identity convention with no early exit, prefers active → carries-a-slice → api-key doc. A single-doc shop resolves identically to before.
- `app/routes/webhooks.orders_create.ts` — the slice read and the cap spend now go through it.
- `app/services/activation-doc-ref.server.test.ts` — pins the two-record shape, the unchanged single-doc case, dedup, and the null case.

No UI surfaces. Tests 132 pass · typecheck clean · production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)