### PR TITLE
Settings stops promising texts, reminders, and a team that never existed

### DIFF
--- a/app/components/settings/CommunicationSettings.tsx
+++ b/app/components/settings/CommunicationSettings.tsx
@@ -375,15 +375,6 @@ const CommunicationSettings = ({ shopDomain }: { shopDomain?: string }) => {
               title="Email"
               description="Send notifications by email."
             />
-            <Divider />
-            <ToggleRow
-              checked={false}
-              onToggle={() => {}}
-              disabled
-              title="SMS"
-              suffix={<Badge>Pending verification</Badge>}
-              description="Our sending number is going through carrier verification. Text notifications turn on here once it clears."
-            />
           </BlockStack>
         </Card>
       </Layout.AnnotatedSection>
@@ -413,40 +404,6 @@ const CommunicationSettings = ({ shopDomain }: { shopDomain?: string }) => {
               onToggle={() => toggle("delivery", "deliveryConfirmed", "Delivery confirmed")}
               title="Delivery confirmed"
               description="Sent after the customer opens their page."
-            />
-          </BlockStack>
-        </Card>
-      </Layout.AnnotatedSection>
-
-      {/* Kept visible, plainly marked: the toggles round-trip but nothing
-          sends them yet — the scheduler is its own build. Showing them ON
-          while nothing sends is the exact dishonesty this page had. */}
-      <Layout.AnnotatedSection
-        title="Return Window Reminders"
-        description="Sent as a customer's return window approaches closing."
-      >
-        <Card>
-          <BlockStack gap="400">
-            <InlineStack gap="200" blockAlign="center">
-              <Badge>Coming soon</Badge>
-              <Text as="p" tone="subdued" variant="bodySm">
-                Not sending yet.
-              </Text>
-            </InlineStack>
-            <ToggleRow
-              checked={settings.returnReminders.days7}
-              onToggle={() => {}}
-              disabled
-              title="7 days before the window closes"
-              description="Early reminder, with the return link."
-            />
-            <Divider />
-            <ToggleRow
-              checked={settings.returnReminders.hours48}
-              onToggle={() => {}}
-              disabled
-              title="48 hours before the window closes"
-              description="Last call."
             />
           </BlockStack>
         </Card>

--- a/app/components/settings/Settings.tsx
+++ b/app/components/settings/Settings.tsx
@@ -7,7 +7,6 @@ import TagsSettings from "./TagsSettings";
 import { FEATURE_NFC } from "../../flags";
 import BrandingSettings from "./BrandingSettings";
 import CommunicationSettings from "./CommunicationSettings";
-import UserManagementSettings from "./UserManagementSettings";
 import DeliveryModeSettings from "./DeliveryModeSettings";
 
 const tabs = [
@@ -17,7 +16,6 @@ const tabs = [
   ...(FEATURE_NFC ? [{ id: "tags", content: "Inventory" }] : []),
   { id: "branding", content: "Media" },
   { id: "communication", content: "Notifications" },
-  { id: "users", content: "Users" },
 ];
 
 const Settings = ({ initialData }: { initialData?: any }) => {
@@ -42,7 +40,6 @@ const Settings = ({ initialData }: { initialData?: any }) => {
       // shopDomain builds the deep link into THIS store's Shopify notification
       // settings — the merchant shouldn't have to go find it.
       case "communication": return <CommunicationSettings shopDomain={initialData?.shopDomain} />;
-      case "users": return <UserManagementSettings />;
       default: return <AccountSettings />;
     }
   };


### PR DESCRIPTION
Three things a merchant — or the App Store reviewer — could see under Settings that were not true of the installed app. Removed, not reworded.

- **The Users tab.** A team-member system left over from the warehouse iPhone app. Its two buttons opened an App Store page that 404s and a sign-in page for a different product. Nothing in the app reads its users.
- **The SMS row** — "Pending verification: our sending number is going through carrier verification." There is no sending number; texts cannot turn on here.
- **"Return Window Reminders — Coming soon."** The job behind it has never been scheduled (its own header says so). A visible unfinished feature is requirement 2.1.x material.

Untouched: the *Your page in Shopify's emails* block, the order-status switch, the Email channel, the delivery toggles, the return window. The settings document keeps `channels.sms` and `returnReminders`; only the UI stopped showing controls that cannot act.

Review round 4 is in progress. The submitted walk touches Account and Billing only; the written steps reference Dashboard and Shipments. Nothing on the reviewer's path moves.

## New surfaces
None. Deletions only.

## Gates
typecheck clean · 132/132 tests · `react-router build` — run on this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)