### PR TITLE
HELD FOR ROUND FOUR — the discounts door: optional read/write_discounts, DISCOUNTS_* webhooks, the backfill on grant, and the order's money on enrol (Track C, PR-3)

### DIFF
--- a/app/components/settings/AccountSettings.tsx
+++ b/app/components/settings/AccountSettings.tsx
@@ -1,4 +1,5 @@
 import { useShop } from "../../contexts/ShopContext";
+import DiscountsSettings from "./DiscountsSettings";
 import { useNavigate, useRouteLoaderData } from "react-router";
 import {
   BlockStack,
@@ -82,6 +83,9 @@ const AccountSettings = () => {
             </BlockStack>
           </Card>
         </Layout.AnnotatedSection>
+
+        {/* The discounts door (Track C) — named in its PR as a new surface. */}
+        <DiscountsSettings />
       </Layout>
     </BlockStack>
   );

--- a/app/components/settings/DiscountsSettings.tsx
+++ b/app/components/settings/DiscountsSettings.tsx
@@ -1,0 +1,178 @@
+// SHOPIFY DISCOUNTS — the card that opens the door (Track C, 2026-09-04).
+//
+// One card on Settings › Account, beside "Connected Store" and "Cost". It
+// says whether this store has allowed the Ritualist to read its discounts
+// (and to create a campaign's code), and one button asks. The ask is App
+// Bridge's own grant modal — `shopify.scopes.request([...])` — so nothing
+// redirects and nobody but this merchant is asked; on "granted-all" the
+// store's discounts are walked into the backend right away.
+//
+// ⚠️ Every string here is PLACEHOLDER copy (Sam's rule: "ship yours").
+
+import { useCallback, useEffect, useState } from "react";
+import { BlockStack, Button, Card, InlineStack, Layout, Text } from "@shopify/polaris";
+import { toast } from "../../hooks/use-toast";
+
+interface DiscountsState {
+  granted: { read: boolean; write: boolean };
+  declared: boolean;
+  scopes_to_request: string[];
+  backfilled_at: string | null;
+  backfill_count: number | null;
+  partial: boolean;
+}
+
+/** App Bridge, as the Shopify admin injects it — only the two calls this
+ *  card makes. Typed here so nothing needs a ts-comment. */
+interface AppBridgeScopes {
+  request: (scopes: string[]) => Promise<{ result: "granted-all" | "declined-all" }>;
+}
+interface AppBridgeGlobal {
+  idToken?: () => Promise<string>;
+  scopes?: AppBridgeScopes;
+}
+function appBridge(): AppBridgeGlobal | undefined {
+  return (window as unknown as { shopify?: AppBridgeGlobal }).shopify;
+}
+function messageOf(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message ? err.message : fallback;
+}
+
+// App-Bridge-aware fetch (the DeliveryModeSettings pattern).
+async function fetchSecure(path: string, options: RequestInit = {}) {
+  const appUrl = window.location.origin;
+  let token = "";
+  try {
+    token = (await appBridge()?.idToken?.()) ?? "";
+  } catch (e) {
+    console.warn("Could not retrieve Shopify session token", e);
+  }
+  const headers = new Headers(options.headers);
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  if (options.body && !headers.has("Content-Type")) headers.set("Content-Type", "application/json");
+  const response = await fetch(`${appUrl}${path}`, { ...options, headers });
+  const contentType = response.headers.get("content-type") || "";
+  const data = contentType.includes("application/json") ? await response.json() : null;
+  if (!response.ok) {
+    throw new Error((data && data.error) || `Error: ${response.status}`);
+  }
+  return data;
+}
+
+function whenLine(state: DiscountsState): string {
+  if (!state.backfilled_at) return "Your discounts haven't been read in yet.";
+  const when = new Date(state.backfilled_at);
+  const stamp = Number.isNaN(when.getTime())
+    ? ""
+    : new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }).format(when);
+  const n = state.backfill_count ?? 0;
+  return `${n} discount${n === 1 ? "" : "s"} read in${stamp ? ` · ${stamp}` : ""}${state.partial ? " · more remain — press Read again" : ""}.`;
+}
+
+const DiscountsSettings = () => {
+  const [state, setState] = useState<DiscountsState | null>(null);
+  const [failed, setFailed] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchSecure("/app/api/settings/discounts");
+      setState(data);
+      setFailed(null);
+    } catch (err: unknown) {
+      setFailed(messageOf(err, "Couldn't read the discounts setting"));
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const backfill = useCallback(async () => {
+    setBusy(true);
+    try {
+      const r = await fetchSecure("/app/api/settings/discounts", {
+        method: "POST",
+        body: JSON.stringify({ action: "backfill" }),
+      });
+      setState(r);
+      toast({
+        title: "Discounts read in",
+        description: `${r.nodes} discount${r.nodes === 1 ? "" : "s"} from your store${r.partial ? " — more remain, press again" : ""}.`,
+      });
+    } catch (err: unknown) {
+      toast({ title: "Couldn't read your discounts", description: messageOf(err, "Try again in a moment."), variant: "destructive" });
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const allow = useCallback(async () => {
+    if (!state) return;
+    setBusy(true);
+    try {
+      // App Bridge's scopes API, present inside the Shopify admin.
+      const scopesApi = appBridge()?.scopes;
+      if (!scopesApi?.request) {
+        throw new Error("Open this page inside your Shopify admin to allow it.");
+      }
+      const response = await scopesApi.request(state.scopes_to_request);
+      if (response?.result !== "granted-all") {
+        toast({ title: "Not allowed", description: "No change — you can allow it any time." });
+        await load();
+        return;
+      }
+      toast({ title: "Allowed", description: "Reading your discounts in now…" });
+      await backfill();
+    } catch (err: unknown) {
+      toast({ title: "Couldn't ask Shopify", description: messageOf(err, "Try again in a moment."), variant: "destructive" });
+    } finally {
+      setBusy(false);
+    }
+  }, [state, load, backfill]);
+
+  const allowed = Boolean(state?.granted.read);
+
+  return (
+    <Layout.AnnotatedSection
+      title="Shopify discounts"
+      description="Let the Ritualist read the discounts you run, so a campaign carries your real sale — its dates, its terms, its code — and can create a campaign's code in your store."
+    >
+      <Card>
+        <BlockStack gap="300">
+          {failed ? (
+            <Text as="p" tone="critical">{failed}</Text>
+          ) : !state ? (
+            <Text as="p" tone="subdued">Checking…</Text>
+          ) : (
+            <>
+              <Text as="p" variant="bodyMd" fontWeight="semibold">
+                {allowed
+                  ? state.granted.write
+                    ? "Allowed — reading and creating discounts."
+                    : "Allowed — reading discounts."
+                  : "Not allowed yet."}
+              </Text>
+              <Text as="p" tone="subdued" variant="bodySm">
+                {allowed
+                  ? whenLine(state)
+                  : state.declared
+                    ? "Shopify will ask you once, here. Nothing changes for anyone else."
+                    : "This store's app version doesn't offer it yet."}
+              </Text>
+              <InlineStack gap="200">
+                {!allowed ? (
+                  <Button onClick={allow} disabled={busy || !state.declared} loading={busy}>Allow</Button>
+                ) : (
+                  <Button onClick={backfill} disabled={busy} loading={busy}>Read discounts again</Button>
+                )}
+              </InlineStack>
+            </>
+          )}
+        </BlockStack>
+      </Card>
+    </Layout.AnnotatedSection>
+  );
+};
+
+export default DiscountsSettings;

--- a/app/routes/app.api.settings.discounts.tsx
+++ b/app/routes/app.api.settings.discounts.tsx
@@ -1,0 +1,115 @@
+// SHOPIFY DISCOUNTS — the door's switch (Track C, 2026-09-04).
+//
+// GET  /app/api/settings/discounts → { granted: { read, write }, declared,
+//                                      backfilled_at, backfill_count, partial }
+// POST { action: "backfill" }      → walk every discount into the backend now
+//
+// The GRANT itself is not asked for here: an embedded page asks with App
+// Bridge (`shopify.scopes.request([...])`, a modal, no redirect) from the
+// Settings card, and the app/scopes_update webhook records it and runs a
+// bounded backfill. This route is the read of that state, and the
+// merchant-driven full backfill for when the webhook's walk was cut short
+// (or never ran). Optional scopes are per-installation — nobody else is
+// asked (https://shopify.dev/docs/api/app-bridge-library/apis/scopes).
+//
+// Every read here goes through authenticate.admin, like delivery-mode.
+
+import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
+import firestore from "../firestore.server";
+import { authenticate } from "../shopify.server";
+import { findMerchantDoc } from "../services/merchant-doc.server";
+import { getMerchant, updateMerchant } from "../services/merchant.server";
+import { reportShopifyDiscounts } from "../services/ink-api.server";
+import {
+  backfillDiscounts,
+  DISCOUNTS_READ_SCOPE,
+  DISCOUNTS_WRITE_SCOPE,
+} from "../services/shopify-discounts.server";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+const json = (data: unknown, init?: ResponseInit) =>
+  new Response(JSON.stringify(data), {
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+    ...init,
+  });
+
+async function stateFor(shop: string, granted: string[], optional: string[]) {
+  const doc = await getMerchant(shop);
+  return {
+    granted: {
+      read: granted.includes(DISCOUNTS_READ_SCOPE),
+      write: granted.includes(DISCOUNTS_WRITE_SCOPE),
+    },
+    // Whether the app's config even offers them — false until the toml with
+    // optional_scopes is pushed (`shopify app deploy`, Sam's act).
+    declared: optional.includes(DISCOUNTS_READ_SCOPE),
+    scopes_to_request: [DISCOUNTS_READ_SCOPE, DISCOUNTS_WRITE_SCOPE],
+    backfilled_at: doc?.discounts_backfilled_at ?? null,
+    backfill_count: doc?.discounts_backfill_count ?? null,
+    partial: doc?.discounts_backfill_partial === true,
+  };
+}
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  const { session, scopes } = await authenticate.admin(request);
+  try {
+    const detail = await scopes.query();
+    return json(await stateFor(session.shop, detail.granted, detail.optional));
+  } catch (err: unknown) {
+    console.error("[settings/discounts] GET error:", err instanceof Error ? err.message : err);
+    return json({ error: "Couldn't read the discounts setting" }, { status: 500 });
+  }
+};
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  if (request.method !== "POST") {
+    return json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const { session, scopes, admin } = await authenticate.admin(request);
+  try {
+    const body = (await request.json().catch(() => null)) as { action?: unknown } | null;
+    if (body?.action !== "backfill") {
+      return json({ error: 'Send { action: "backfill" }' }, { status: 400 });
+    }
+    const detail = await scopes.query();
+    if (!detail.granted.includes(DISCOUNTS_READ_SCOPE)) {
+      return json({ error: "scope_missing", ...(await stateFor(session.shop, detail.granted, detail.optional)) }, { status: 409 });
+    }
+    const merchant = await findMerchantDoc(firestore, session.shop);
+    const apiKey = merchant?.apiKey ?? null;
+    if (!apiKey) {
+      return json({ error: "This store isn't connected to the Ritualist yet — open the dashboard once, then try again." }, { status: 409 });
+    }
+    const r = await backfillDiscounts(admin, (entries) => reportShopifyDiscounts(apiKey, entries), {
+      label: "[settings/discounts backfill]",
+    });
+    await updateMerchant(session.shop, {
+      discounts_backfilled_at: new Date().toISOString(),
+      discounts_backfill_count: r.nodes,
+      discounts_backfill_partial: r.truncated,
+    });
+    // `partial` comes from stateFor — the doc just written above.
+    return json({
+      ok: r.errors.length === 0,
+      pages: r.pages,
+      nodes: r.nodes,
+      written: r.written,
+      errors: r.errors,
+      ...(await stateFor(session.shop, detail.granted, detail.optional)),
+    });
+  } catch (err: unknown) {
+    console.error("[settings/discounts] POST error:", err instanceof Error ? err.message : err);
+    return json({ error: "Couldn't read your discounts into the Ritualist" }, { status: 500 });
+  }
+};

--- a/app/routes/webhooks.app.scopes_update.tsx
+++ b/app/routes/webhooks.app.scopes_update.tsx
@@ -1,9 +1,23 @@
 import type { ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
+import { findMerchantDoc } from "../services/merchant-doc.server";
+import { updateMerchant } from "../services/merchant.server";
+import { reportShopifyDiscounts } from "../services/ink-api.server";
+import {
+  backfillDiscounts,
+  DISCOUNTS_READ_SCOPE,
+} from "../services/shopify-discounts.server";
+
+// A webhook-time backfill is bounded: Shopify retries a slow webhook, and a
+// store with thousands of discounts would be re-walked on every retry.
+// Three pages (150 discounts, newest-updated first) is the common case
+// whole; the rest is marked partial and the Settings "Allow" flow — an admin
+// request with a merchant waiting — runs it to the end.
+const WEBHOOK_BACKFILL_PAGE_CAP = 3;
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-    const { payload, session, topic, shop } = await authenticate.webhook(request);
+    const { payload, session, topic, shop, admin } = await authenticate.webhook(request);
     console.log(`Received ${topic} webhook for ${shop}`);
 
     const current = payload.current as string[];
@@ -11,6 +25,34 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         await firestore.collection("shopify_sessions").doc(session.id).update({
             scope: current.toString(),
         });
+    }
+
+    // THE GRANT (Track C). The merchant pressed Allow on "Shopify discounts"
+    // and read_discounts arrived here: walk their discounts once so the
+    // record is whole before the first webhook, and stamp the merchant doc so
+    // Settings can say so. Idempotent (the backend's door merges) and never
+    // fatal to the ack — a refused backfill is a logged line, and Settings
+    // will run it again on demand.
+    if (Array.isArray(current) && current.includes(DISCOUNTS_READ_SCOPE) && admin) {
+        try {
+            const merchant = await findMerchantDoc(firestore, shop);
+            const apiKey = merchant?.apiKey ?? null;
+            if (!apiKey) {
+                console.warn(`[${topic}] read_discounts granted for ${shop} but no ink_api_key — backfill skipped`);
+            } else {
+                const r = await backfillDiscounts(admin, (entries) => reportShopifyDiscounts(apiKey, entries), {
+                    pageCap: WEBHOOK_BACKFILL_PAGE_CAP,
+                    label: `[${topic} backfill]`,
+                });
+                await updateMerchant(shop, {
+                    discounts_backfilled_at: new Date().toISOString(),
+                    discounts_backfill_count: r.nodes,
+                    discounts_backfill_partial: r.truncated,
+                });
+            }
+        } catch (err: unknown) {
+            console.error(`[${topic}] discounts backfill failed for ${shop} (acking anyway):`, err instanceof Error ? err.message : err);
+        }
     }
     return new Response();
 };

--- a/app/routes/webhooks.discounts.ts
+++ b/app/routes/webhooks.discounts.ts
@@ -1,0 +1,66 @@
+import type { ActionFunctionArgs } from "react-router";
+import { authenticate } from "../shopify.server";
+import firestore from "../firestore.server";
+import { findMerchantDoc } from "../services/merchant-doc.server";
+import { reportShopifyDiscounts } from "../services/ink-api.server";
+import { fetchDiscountNode, type DiscountDoorEntry } from "../services/shopify-discounts.server";
+
+// discounts/* — THE DISCOUNTS DOOR (Track C, 2026-09-04).
+//
+// Five topics, one handler, one uri (shopify.app.toml): create · update ·
+// delete · redeemcode_added · redeemcode_removed. Their bodies are thin —
+// the gid and, at most, a title, a status and a code — so on create and
+// update the discount node is read back (needs read_discounts, which the
+// merchant granted or these never fire) and BOTH are handed to the backend's
+// door: the thin event lands even when the read is refused, the node lands
+// the words, the clock, the codes and the arithmetic. The backend owns the
+// record and merges every event onto one row, idempotently.
+//
+// Webhook discipline (fulfillments/create's): ALWAYS 200 once authenticated
+// — Shopify retries non-200s and disables flaky subscriptions — every
+// failure inside is logged and swallowed. Retrying would be safe anyway
+// (the door merges), it is just noise nobody needs.
+export const TOPICS = [
+  "DISCOUNTS_CREATE",
+  "DISCOUNTS_UPDATE",
+  "DISCOUNTS_DELETE",
+  "DISCOUNTS_REDEEMCODE_ADDED",
+  "DISCOUNTS_REDEEMCODE_REMOVED",
+] as const;
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { topic, shop, payload, admin } = await authenticate.webhook(request);
+  const label = `[${topic}]`;
+  const body = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const gid = typeof body.admin_graphql_api_id === "string" ? body.admin_graphql_api_id : undefined;
+
+  if (!(TOPICS as readonly string[]).includes(topic)) {
+    console.warn(`${label} not a discounts topic for ${shop}; acking.`);
+    return new Response("OK", { status: 200 });
+  }
+  if (!gid) {
+    // Malformed — a retry cannot fix it; ack rather than 400.
+    console.warn(`${label} no admin_graphql_api_id in the body for ${shop}; acking.`);
+    return new Response("OK", { status: 200 });
+  }
+
+  try {
+    const merchant = await findMerchantDoc(firestore, shop);
+    const apiKey = merchant?.apiKey ?? null;
+    if (!apiKey) {
+      console.warn(`${label} no ink_api_key for ${shop} — ${gid} not recorded.`);
+      return new Response("OK", { status: 200 });
+    }
+
+    const entries: DiscountDoorEntry[] = [{ topic, payload }];
+    if ((topic === "DISCOUNTS_CREATE" || topic === "DISCOUNTS_UPDATE") && admin) {
+      const node = await fetchDiscountNode(admin, gid, label);
+      if (node) entries.push({ node, source_event: "webhook" });
+    }
+    const r = await reportShopifyDiscounts(apiKey, entries);
+    console.log(`${label} ${shop} ${gid} → door written=${r.written}${r.skipped.length ? ` skipped=${r.skipped.join(",")}` : ""}`);
+  } catch (err: unknown) {
+    console.error(`${label} failed for ${shop} ${gid} (acking anyway):`, err instanceof Error ? err.message : err);
+  }
+  return new Response("OK", { status: 200 });
+};

--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -12,6 +12,7 @@ import {
   stateOfWebhookOrder,
 } from "../services/activation-scope.server";
 import { spendFromCap } from "../services/activation-counter.server";
+import { orderMoneyFromWebhook } from "../services/order-money";
 
 /**
  * Look up the merchant's verified-delivery mode preference.
@@ -484,7 +485,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
               finalPhone || order.customer?.phone || null,
               // The buyer's own order-status page on the merchant's site.
               // Shopify has always sent it in this body; we never read it.
-              { orderStatusUrl: data?.order_status_url || null, shopDomain: shop || null }
+              // And (Track C) the order's own money — total, currency, the
+              // codes the buyer typed — from the same body: no query, no
+              // scope, no cost, and a total the backend never has to guess.
+              {
+                orderStatusUrl: data?.order_status_url || null,
+                shopDomain: shop || null,
+                money: orderMoneyFromWebhook(data),
+              }
             );
 
           let inkData: any;

--- a/app/services/enroll-payload.test.ts
+++ b/app/services/enroll-payload.test.ts
@@ -1,0 +1,50 @@
+// The enrol body, pinned (Track C): the money lands inside order_details
+// beside the fields that were already there, only when the webhook carried
+// it; the two other call sites (warehouse, tagged shipments) pass no context
+// and their body is byte-identical to before.
+import { describe, expect, it } from "vitest";
+import { buildEnrollPayload } from "./enroll-payload";
+
+const base = {
+  orderId: "6001",
+  nfcToken: "nfc_x",
+  orderNumber: "#1026",
+  customerEmail: "dana@example.com",
+  shippingAddress: { name: "Dana", line1: "1 Main", city: "LA", state: "CA", zip: "90026", country: "US" },
+  productDetails: [{ name: "Boot", price: "149.95", quantity: 1 }],
+  carrierName: "USPS",
+  trackingNumber: "9400",
+  customerPhone: "+1555",
+};
+
+describe("buildEnrollPayload", () => {
+  it("stamps the money onto order_details when the webhook carried it", () => {
+    const p = buildEnrollPayload({
+      ...base,
+      orderContext: {
+        orderStatusUrl: "https://sm-test.myshopify.com/orders/abc",
+        shopDomain: "sm-test.myshopify.com",
+        money: { total_price: "119.96", currency: "USD", discount_codes: [{ code: "LABORDAY20" }] },
+      },
+    });
+    expect(p.order_details.total_price).toBe("119.96");
+    expect(p.order_details.currency).toBe("USD");
+    expect(p.order_details.discount_codes).toEqual([{ code: "LABORDAY20" }]);
+    expect(p.order_details.order_status_url).toBe("https://sm-test.myshopify.com/orders/abc");
+    expect(p.order_details.shop_domain).toBe("sm-test.myshopify.com");
+    expect(p.order_details.customer_name).toBe("Dana");
+    expect(p.carrier_name).toBe("USPS");
+    expect(p.tracking_number).toBe("9400");
+  });
+
+  it("no context, no money keys at all — the warehouse and tagged-shipments bodies are unchanged", () => {
+    const p = buildEnrollPayload(base);
+    expect(Object.keys(p.order_details).sort()).toEqual(
+      ["customer_email", "customer_name", "customer_phone", "order_number", "product_details", "shipping_address"],
+    );
+    expect(p.order_details.customer_phone).toBe("+1555");
+    const empty = buildEnrollPayload({ ...base, orderContext: { orderStatusUrl: null, shopDomain: null, money: {} } });
+    expect("total_price" in empty.order_details).toBe(false);
+    expect("order_status_url" in empty.order_details).toBe(false);
+  });
+});

--- a/app/services/enroll-payload.ts
+++ b/app/services/enroll-payload.ts
@@ -1,0 +1,107 @@
+/** The body POST /api/enroll receives — built here, pure, so a test can pin
+ *  its shape without importing ink-api.server.ts (which needs the app's
+ *  secrets at import time) or the webhook route (which needs the Shopify
+ *  app config). enrollOrder in ink-api.server.ts is the only caller.
+ *
+ *  Alan's API requires order details nested in an `order_details` JSON
+ *  object (verified in Cloud Run logs 2026-04-26); top-level operational
+ *  fields (order_id, nfc_token, photos, GPS, carrier) stay where they are.
+ */
+import type { OrderMoney } from "./order-money";
+
+export interface EnrollOrderContext {
+  orderStatusUrl?: string | null;
+  shopDomain?: string | null;
+  /** The order's own money, lifted from the orders/create body (Track C).
+   *  Absent on the warehouse and tagged-shipments call sites, which have no
+   *  Shopify body in hand — the backend rolls those up and says so. */
+  money?: OrderMoney | null;
+}
+
+/** The wire shape — order_details is an open record because the backend
+ *  spreads unknown keys onto the proof (and that is how the order door and
+ *  the money reach the buyer's page "for free"). */
+export interface EnrollPayload {
+  order_id: string;
+  nfc_token: string;
+  order_details: Record<string, unknown>;
+  warehouse_location?: { lat: number; lng: number };
+  nfc_uid?: string;
+  photo_urls?: string[];
+  photo_hashes?: string[];
+  carrier_name?: string;
+  tracking_number?: string;
+}
+
+export function buildEnrollPayload(args: {
+  orderId: string;
+  nfcToken: string;
+  orderNumber: string;
+  customerEmail: string | null;
+  shippingAddress: unknown;
+  productDetails: unknown[];
+  warehouseLocation?: { lat: number; lng: number };
+  nfcUid?: string;
+  photoUrls?: string[];
+  photoHashes?: string[];
+  carrierName?: string | null;
+  trackingNumber?: string | null;
+  customerPhone?: string | null;
+  orderContext?: EnrollOrderContext;
+}): EnrollPayload {
+  const {
+    orderId, nfcToken, orderNumber, customerEmail, shippingAddress, productDetails,
+    warehouseLocation, nfcUid, photoUrls, photoHashes, carrierName, trackingNumber,
+    customerPhone, orderContext,
+  } = args;
+  const payload: EnrollPayload = {
+    order_id: orderId, // numeric ID string
+    nfc_token: nfcToken,
+    order_details: {
+      order_number: orderNumber,
+      // Parallel renders order_details.customer_name (no fallback to
+      // shipping_address.name), so lift the recipient name up to it —
+      // otherwise "Customer"/"Ship To" stay blank in the dashboard.
+      customer_name:
+        (shippingAddress && typeof shippingAddress === "object"
+          ? String((shippingAddress as { name?: unknown }).name ?? "")
+          : "") || "",
+      customer_email: customerEmail || "",
+      customer_phone: customerPhone || "",
+      shipping_address: shippingAddress,
+      product_details: productDetails,
+    },
+  };
+
+  // Shopify's orders/create body has always carried `order_status_url` — the
+  // buyer's own order-status page, no login required. Only stamped when
+  // present — an absent field must stay absent rather than become an empty
+  // string, because the page hides the link on absence and "" would render a
+  // dead one (law 7).
+  if (orderContext?.orderStatusUrl) {
+    payload.order_details.order_status_url = orderContext.orderStatusUrl;
+  }
+  // The real shop domain, alongside it. `proof.merchant` and `proof.shop_id`
+  // are BOTH the merchant_id despite the comment on the former saying
+  // shop_domain, so nothing on the wire has ever carried the actual host.
+  if (orderContext?.shopDomain) {
+    payload.order_details.shop_domain = orderContext.shopDomain;
+  }
+  // THE MONEY (Track C): the store's total, currency and the codes the buyer
+  // typed, exactly as Shopify sent them. Same law as the two fields above —
+  // present means present, absent stays absent. The backend labels a total
+  // we sent "order" and never rolls it up.
+  if (orderContext?.money) {
+    for (const [key, value] of Object.entries(orderContext.money)) {
+      if (value !== undefined && value !== null) payload.order_details[key] = value;
+    }
+  }
+
+  if (warehouseLocation) payload.warehouse_location = warehouseLocation;
+  if (nfcUid) payload.nfc_uid = nfcUid;
+  if (photoUrls && photoUrls.length > 0) payload.photo_urls = photoUrls;
+  if (photoHashes && photoHashes.length > 0) payload.photo_hashes = photoHashes;
+  if (carrierName) payload.carrier_name = carrierName;
+  if (trackingNumber) payload.tracking_number = trackingNumber;
+  return payload;
+}

--- a/app/services/ink-api.server.ts
+++ b/app/services/ink-api.server.ts
@@ -1,4 +1,6 @@
 import { authenticate } from "../shopify.server";
+import { buildEnrollPayload, type EnrollOrderContext } from "./enroll-payload";
+import type { DiscountDoorEntry } from "./shopify-discounts.server";
 
 const INK_API_URL = process.env.INK_API_URL || "https://us-central1-inink-c76d3.cloudfunctions.net/api";
 const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET;
@@ -255,68 +257,23 @@ export const enrollOrder = async (
     carrierName?: string | null,
     trackingNumber?: string | null,
     customerPhone?: string | null,
-    // WHERE THE BUYER CAN SEE THIS ORDER ON THE MERCHANT'S OWN SITE.
-    // An options bag rather than two more positional args — this signature is
-    // already fourteen deep, and the two other enroll call sites (warehouse,
-    // tagged-shipments) simply don't pass it and are unaffected.
-    orderContext?: { orderStatusUrl?: string | null; shopDomain?: string | null }
+    // WHERE THE BUYER CAN SEE THIS ORDER ON THE MERCHANT'S OWN SITE, and (Track
+    // C) THE ORDER'S OWN MONEY. An options bag rather than more positional
+    // args — this signature is already fourteen deep, and the two other enroll
+    // call sites (warehouse, tagged-shipments) simply don't pass it and are
+    // unaffected. The body itself is built in enroll-payload.ts (pure, pinned
+    // by test); this function only sends it.
+    orderContext?: EnrollOrderContext
 ) => {
-    // Alan's API was changed to require order details nested in an
-    // `order_details` JSON object rather than as separate top-level fields.
-    // The v1.5 docs describe the old shape, but the live API rejects that
-    // with "order_details must be a JSON object" (verified in Cloud Run logs
-    // 2026-04-26). Nesting works around it without waiting on Alan to either
-    // revert or update docs. Top-level operational fields (order_id,
-    // nfc_token, photos, GPS, carrier) stay where they are.
-    const payload: any = {
-        order_id: orderId, // numeric ID string
-        nfc_token: nfcToken,
-        order_details: {
-            order_number: orderNumber,
-            // Parallel renders order_details.customer_name (no fallback to
-            // shipping_address.name), so lift the recipient name up to it —
-            // otherwise "Customer"/"Ship To" stay blank in the dashboard.
-            customer_name:
-                (shippingAddress && typeof shippingAddress === "object"
-                    ? shippingAddress.name
-                    : "") || "",
-            customer_email: customerEmail || "",
-            customer_phone: customerPhone || "",
-            shipping_address: shippingAddress,
-            product_details: productDetails,
-        },
-    };
-
-    // Shopify's orders/create body has always carried `order_status_url` — the
-    // buyer's own order-status page, no login required. We simply never read
-    // it, so no proof has ever held one and the tap page has had no honest way
-    // to say "view your order". Nothing downstream needs changing to accept it:
-    // the backend's validation spreads unknown keys and the serializer emits
-    // the whole object, so it reaches the customer wire for free.
-    //
-    // Only stamped when present — an absent field must stay absent rather than
-    // become an empty string, because the page hides the link on absence and
-    // "" would render a dead one (law 7).
-    if (orderContext?.orderStatusUrl) {
-        payload.order_details.order_status_url = orderContext.orderStatusUrl;
-    }
-    // The real shop domain, alongside it. `proof.merchant` and `proof.shop_id`
-    // are BOTH the merchant_id despite the comment on the former saying
-    // shop_domain, so nothing on the wire has ever carried the actual host.
-    if (orderContext?.shopDomain) {
-        payload.order_details.shop_domain = orderContext.shopDomain;
-    }
-
-    if (warehouseLocation) payload.warehouse_location = warehouseLocation;
-    if (nfcUid) payload.nfc_uid = nfcUid;
-    if (photoUrls && photoUrls.length > 0) payload.photo_urls = photoUrls;
-    if (photoHashes && photoHashes.length > 0) payload.photo_hashes = photoHashes;
-    if (carrierName) payload.carrier_name = carrierName;
-    if (trackingNumber) payload.tracking_number = trackingNumber;
+    const payload = buildEnrollPayload({
+        orderId, nfcToken, orderNumber, customerEmail, shippingAddress, productDetails,
+        warehouseLocation, nfcUid, photoUrls, photoHashes, carrierName, trackingNumber,
+        customerPhone, orderContext,
+    });
 
     const enrollUrl = getAlanUrl('/api/enroll');
     console.log("[ink-api] enrollOrder →", enrollUrl);
-    console.log("[ink-api] enrollOrder payload (no sensitive):", JSON.stringify({ order_id: payload.order_id, nfc_token: payload.nfc_token, order_number: payload.order_number }));
+    console.log("[ink-api] enrollOrder payload (no sensitive):", JSON.stringify({ order_id: payload.order_id, nfc_token: payload.nfc_token, order_number: payload.order_details.order_number }));
     const response = await fetch(enrollUrl, {
         method: "POST",
         headers: {
@@ -333,6 +290,34 @@ export const enrollOrder = async (
         throw new Error(`Enrollment failed: ${errText}`);
     }
     return await response.json();
+};
+
+// THE DISCOUNTS DOOR (Track C). Hands Shopify's discount events — the thin
+// webhook bodies verbatim, and the DiscountNodes read back — to the backend,
+// which owns the record and merges every event onto one row. Bearer
+// ink_api_key on purpose: that names the exact merchant record enrol writes
+// (a connected store can hold TWO — the two-record trap), so a discount can
+// never land on the demo twin. Throws on refusal; callers log and, in a
+// webhook, still return 200.
+export const reportShopifyDiscounts = async (
+    apiKey: string,
+    entries: DiscountDoorEntry[],
+): Promise<{ written: number; skipped: number[] }> => {
+    if (!entries.length) return { written: 0, skipped: [] };
+    const response = await fetch(getAlanUrl('/api/promos/shopify'), {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({ discounts: entries }),
+    });
+    if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        throw new Error(`promos/shopify ${response.status} ${errorText}`.trim());
+    }
+    const data = await response.json().catch(() => ({}));
+    return { written: Number(data?.written) || 0, skipped: Array.isArray(data?.skipped) ? data.skipped : [] };
 };
 
 export const getProof = async (apiKey: string, nfcToken: string) => {

--- a/app/services/merchant.server.ts
+++ b/app/services/merchant.server.ts
@@ -15,6 +15,12 @@ export interface MerchantData {
   /** First provision. Settings renders this as the install date — it was
    *  never written, so that row read "Not available" forever. */
   createdAt?: string;
+  /** The discounts door (Track C): when this store's discounts were last
+   *  walked into the backend after the read_discounts grant, how many, and
+   *  whether the walk was cut short (a webhook-time backfill is bounded). */
+  discounts_backfilled_at?: string;
+  discounts_backfill_count?: number;
+  discounts_backfill_partial?: boolean;
 }
 
 export const getMerchant = async (shop: string): Promise<MerchantData | null> => {

--- a/app/services/order-money.test.ts
+++ b/app/services/order-money.test.ts
@@ -1,0 +1,54 @@
+// The money rides the enrol (Track C): lifted from the orders/create body
+// Shopify already sent, kept as Shopify sent it, and ABSENT when absent —
+// never "" or 0, because the backend must be able to tell "the store said
+// nothing" from "the store said zero".
+import { describe, expect, it } from "vitest";
+import { orderMoneyFromWebhook } from "./order-money";
+
+const ORDER = {
+  id: 6001,
+  total_price: "119.96",
+  subtotal_price: "149.95",
+  total_discounts: "29.99",
+  currency: "usd",
+  discount_codes: [{ code: "LABORDAY20", amount: "29.99", type: "percentage" }],
+  discount_applications: [
+    { target_type: "line_item", type: "discount_code", value: "20.0", value_type: "percentage", allocation_method: "across", target_selection: "all", code: "LABORDAY20" },
+    { target_type: "line_item", type: "automatic", value: "5.0", value_type: "fixed_amount", allocation_method: "across", target_selection: "all", title: "Fall automatic" },
+  ],
+};
+
+describe("orderMoneyFromWebhook", () => {
+  it("lifts the total, currency, subtotal, discounts, the codes and the applications, as sent", () => {
+    const m = orderMoneyFromWebhook(ORDER);
+    expect(m).toEqual({
+      total_price: "119.96",
+      currency: "USD",
+      subtotal_price: "149.95",
+      total_discounts: "29.99",
+      discount_codes: [{ code: "LABORDAY20", amount: "29.99", type: "percentage" }],
+      discount_applications: [
+        { type: "discount_code", code: "LABORDAY20", value: "20.0", value_type: "percentage", target_type: "line_item" },
+        { type: "automatic", title: "Fall automatic", value: "5.0", value_type: "fixed_amount", target_type: "line_item" },
+      ],
+    });
+  });
+
+  it("absent stays absent — an order with no money fields yields an empty object, never zeros", () => {
+    expect(orderMoneyFromWebhook({ id: 1 })).toEqual({});
+    expect(orderMoneyFromWebhook(null)).toEqual({});
+    expect(orderMoneyFromWebhook({ total_price: "", currency: "", discount_codes: [], discount_applications: [] })).toEqual({});
+  });
+
+  it("junk is dropped, not carried: a NaN total, a non-list codes field, an empty code", () => {
+    const m = orderMoneyFromWebhook({ total_price: "abc", currency: "dollars", discount_codes: "x", discount_applications: [{ code: "" }, null] });
+    expect(m.total_price).toBeUndefined();
+    expect(m.currency).toBe("DOL");
+    expect(m.discount_codes).toBeUndefined();
+    expect(m.discount_applications).toBeUndefined();
+  });
+
+  it("a zero total is a declared zero, and rides", () => {
+    expect(orderMoneyFromWebhook({ total_price: "0.00", currency: "USD" })).toEqual({ total_price: "0.00", currency: "USD" });
+  });
+});

--- a/app/services/order-money.ts
+++ b/app/services/order-money.ts
@@ -1,0 +1,108 @@
+/** The money on an order, lifted from the orders/create body Shopify already
+ *  sent — no query, no scope, no cost (Track C).
+ *
+ *  A pure mapper, like order-line-item.ts, so it can be tested without
+ *  standing up the Shopify app config. Every field is OPTIONAL and omitted
+ *  when absent: the backend settles the total (utils/orderMoney.js there
+ *  labels it "order" when we send one and rolls up from line items when we
+ *  do not), and an absent field must stay absent — never "" or 0 — so the
+ *  backend cannot mistake our silence for a declared zero.
+ *
+ *  Shopify's REST order body carries `total_price`, `currency`,
+ *  `subtotal_price`, `total_discounts`, `discount_codes` ([{code, amount,
+ *  type}]) and `discount_applications` ([{type, title, code?, value,
+ *  value_type, target_type, description?, allocation_method,
+ *  target_selection}]). Strings are kept exactly as Shopify sends them.
+ */
+export interface OrderMoney {
+  total_price?: string;
+  currency?: string;
+  subtotal_price?: string;
+  total_discounts?: string;
+  discount_codes?: Array<{ code: string; amount?: string; type?: string }>;
+  discount_applications?: Array<{
+    type?: string;
+    title?: string;
+    code?: string;
+    value?: string;
+    value_type?: string;
+    target_type?: string;
+    description?: string;
+  }>;
+}
+
+const MAX_ENTRIES = 20;
+
+function moneyOf(v: unknown): string | undefined {
+  if (v == null || v === "") return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) && n >= 0 ? String(v) : undefined;
+}
+
+function str(v: unknown, max = 200): string | undefined {
+  if (v == null) return undefined;
+  const s = String(v).trim();
+  return s ? s.slice(0, max) : undefined;
+}
+
+type Loose = Record<string, unknown>;
+function loose(v: unknown): Loose {
+  return v && typeof v === "object" ? (v as Loose) : {};
+}
+
+export function orderMoneyFromWebhook(body: unknown): OrderMoney {
+  const data = loose(body);
+  const out: OrderMoney = {};
+  const total = moneyOf(data.total_price);
+  if (total !== undefined) out.total_price = total;
+  const currency = str(data.currency, 3);
+  if (currency) out.currency = currency.toUpperCase();
+  const subtotal = moneyOf(data.subtotal_price);
+  if (subtotal !== undefined) out.subtotal_price = subtotal;
+  const discounts = moneyOf(data.total_discounts);
+  if (discounts !== undefined) out.total_discounts = discounts;
+
+  if (Array.isArray(data.discount_codes)) {
+    const codes: NonNullable<OrderMoney["discount_codes"]> = [];
+    for (const raw of data.discount_codes as unknown[]) {
+      if (codes.length >= MAX_ENTRIES) break;
+      const entry = loose(raw);
+      const code = str(typeof raw === "string" ? raw : entry.code, 64);
+      if (!code) continue;
+      const row: { code: string; amount?: string; type?: string } = { code };
+      const amount = moneyOf(entry.amount);
+      if (amount !== undefined) row.amount = amount;
+      const type = str(entry.type, 40);
+      if (type) row.type = type;
+      codes.push(row);
+    }
+    if (codes.length) out.discount_codes = codes;
+  }
+
+  if (Array.isArray(data.discount_applications)) {
+    const apps: NonNullable<OrderMoney["discount_applications"]> = [];
+    for (const raw of data.discount_applications as unknown[]) {
+      if (apps.length >= MAX_ENTRIES) break;
+      if (!raw || typeof raw !== "object") continue;
+      const entry = loose(raw);
+      const row: NonNullable<OrderMoney["discount_applications"]>[number] = {};
+      const type = str(entry.type, 40);
+      if (type) row.type = type;
+      const title = str(entry.title, 200);
+      if (title) row.title = title;
+      const code = str(entry.code, 64);
+      if (code) row.code = code;
+      const value = str(entry.value, 40);
+      if (value) row.value = value;
+      const valueType = str(entry.value_type, 40);
+      if (valueType) row.value_type = valueType;
+      const targetType = str(entry.target_type, 40);
+      if (targetType) row.target_type = targetType;
+      const description = str(entry.description, 200);
+      if (description) row.description = description;
+      if (Object.keys(row).length) apps.push(row);
+    }
+    if (apps.length) out.discount_applications = apps;
+  }
+  return out;
+}

--- a/app/services/shopify-discounts.server.test.ts
+++ b/app/services/shopify-discounts.server.test.ts
@@ -1,0 +1,162 @@
+// The discounts door, embed side (Track C): the backfill walks every page
+// and hands each to the door; a refused read is a logged line, never a
+// throw; the toml declares the five topics and both optional scopes; the
+// handler and the grant hook exist and keep the webhook discipline.
+import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  backfillDiscounts,
+  fetchDiscountNode,
+  DISCOUNT_NODE_QUERY,
+  DISCOUNT_NODES_QUERY,
+  scopeListHas,
+} from "./shopify-discounts.server";
+
+function src(rel: string): string {
+  return readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+}
+
+type Admin = Parameters<typeof backfillDiscounts>[0];
+function fakeAdmin(pages: unknown[], { failOn }: { failOn?: number } = {}): Admin {
+  let call = 0;
+  return {
+    graphql: async () => {
+      const i = call++;
+      if (failOn === i) throw new Error("boom");
+      const body = pages[i] ?? { data: { discountNodes: null } };
+      return { json: async () => body };
+    },
+  };
+}
+
+const NODE = (id: string) => ({ id, discount: { __typename: "DiscountCodeBasic", title: `T ${id}`, status: "ACTIVE" } });
+
+describe("backfillDiscounts", () => {
+  it("walks the pages newest-updated first, posts each page as {node} entries, sums what the door wrote", async () => {
+    const admin = fakeAdmin([
+      { data: { discountNodes: { pageInfo: { hasNextPage: true, endCursor: "c1" }, nodes: [NODE("gid://shopify/DiscountCodeNode/1"), NODE("gid://shopify/DiscountAutomaticNode/2")] } } },
+      { data: { discountNodes: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [NODE("gid://shopify/DiscountCodeNode/3")] } } },
+    ]);
+    const post = vi.fn(async (entries: unknown[]) => ({ written: entries.length }));
+    const r = await backfillDiscounts(admin, post, { label: "[t]" });
+    expect(r).toEqual({ pages: 2, nodes: 3, written: 3, truncated: false, errors: [] });
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(post.mock.calls[0][0]).toEqual([
+      { node: NODE("gid://shopify/DiscountCodeNode/1"), source_event: "backfill" },
+      { node: NODE("gid://shopify/DiscountAutomaticNode/2"), source_event: "backfill" },
+    ]);
+  });
+
+  it("a page cap marks the walk partial instead of pretending it finished; a refused read is an error line, not a throw", async () => {
+    const page = { data: { discountNodes: { pageInfo: { hasNextPage: true, endCursor: "c" }, nodes: [NODE("gid://shopify/DiscountCodeNode/1")] } } };
+    const capped = await backfillDiscounts(fakeAdmin([page, page, page]), async (e) => ({ written: e.length }), { pageCap: 2, label: "[t]" });
+    expect(capped.pages).toBe(2);
+    expect(capped.truncated).toBe(true);
+    const refused = await backfillDiscounts(fakeAdmin([{ errors: [{ message: "Access denied for discountNodes field. Required access: `read_discounts`" }] }]), async (e) => ({ written: e.length }), { label: "[t]" });
+    expect(refused.pages).toBe(0);
+    expect(refused.errors[0]).toMatch(/read_discounts/);
+    const threw = await backfillDiscounts(fakeAdmin([], { failOn: 0 }), async (e) => ({ written: e.length }), { label: "[t]" });
+    expect(threw.errors).toEqual(["boom"]);
+  });
+
+  it("a door that refuses one page is recorded and the walk continues", async () => {
+    const page1 = { data: { discountNodes: { pageInfo: { hasNextPage: true, endCursor: "c" }, nodes: [NODE("a")] } } };
+    const page2 = { data: { discountNodes: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [NODE("b")] } } };
+    let n = 0;
+    const r = await backfillDiscounts(fakeAdmin([page1, page2]), async (e) => { if (n++ === 0) throw new Error("promos/shopify 401"); return { written: e.length }; }, { label: "[t]" });
+    expect(r.pages).toBe(2);
+    expect(r.written).toBe(1);
+    expect(r.errors).toEqual(["page 1: promos/shopify 401"]);
+  });
+});
+
+describe("fetchDiscountNode", () => {
+  it("returns the node, or null with a logged reason — never throws", async () => {
+    const ok = await fetchDiscountNode(fakeAdmin([{ data: { discountNode: NODE("gid://shopify/DiscountCodeNode/1") } }]), "gid://shopify/DiscountCodeNode/1");
+    expect(ok?.id).toBe("gid://shopify/DiscountCodeNode/1");
+    const missing = await fetchDiscountNode(fakeAdmin([{ data: { discountNode: null } }]), "gid://x");
+    expect(missing).toBeNull();
+    const threw = await fetchDiscountNode(fakeAdmin([], { failOn: 0 }), "gid://x");
+    expect(threw).toBeNull();
+  });
+});
+
+describe("the queries select only what the 2025-10 schema carries (introspected 2026-09-04)", () => {
+  it("summary is never asked of the two App members; codes never of an automatic member; every member is present", () => {
+    for (const q of [DISCOUNT_NODE_QUERY, DISCOUNT_NODES_QUERY]) {
+      const app = q.match(/\.\.\. on DiscountCodeApp \{([^}]*)\}/)?.[1] ?? "";
+      expect(app).not.toContain("summary");
+      const autoApp = q.match(/\.\.\. on DiscountAutomaticApp \{([^}]*)\}/)?.[1] ?? "";
+      expect(autoApp).not.toContain("summary");
+      expect(autoApp).not.toContain("codes");
+      for (const member of ["DiscountCodeBasic", "DiscountCodeBxgy", "DiscountCodeFreeShipping", "DiscountCodeApp", "DiscountAutomaticBasic", "DiscountAutomaticBxgy", "DiscountAutomaticFreeShipping", "DiscountAutomaticApp"]) {
+        expect(q).toContain(`... on ${member} {`);
+      }
+      expect(q).not.toContain("customerSelection");
+    }
+    expect(DISCOUNT_NODES_QUERY).toContain("sortKey: UPDATED_AT");
+  });
+});
+
+describe("the door is wired end to end", () => {
+  it("the toml declares the five discounts topics on one uri and both optional scopes", () => {
+    const toml = src("../../shopify.app.toml");
+    for (const t of ["discounts/create", "discounts/update", "discounts/delete", "discounts/redeemcode_added", "discounts/redeemcode_removed"]) {
+      expect(toml).toContain(`"${t}"`);
+    }
+    expect(toml).toMatch(/uri = "https:\/\/shopify-app-250065525755\.us-central1\.run\.app\/webhooks\/discounts"/);
+    expect(toml).toMatch(/optional_scopes = \[ "read_discounts", "write_discounts" \]/);
+    // The required scopes did not move — that would be a re-consent event.
+    expect(toml).not.toMatch(/scopes = "[^"]*discounts/);
+  });
+
+  it("the handler answers the five topics, always acks, and reads the node back only on create/update", () => {
+    const handler = src("../routes/webhooks.discounts.ts");
+    for (const t of ["DISCOUNTS_CREATE", "DISCOUNTS_UPDATE", "DISCOUNTS_DELETE", "DISCOUNTS_REDEEMCODE_ADDED", "DISCOUNTS_REDEEMCODE_REMOVED"]) {
+      expect(handler).toContain(`"${t}"`);
+    }
+    expect(handler).toContain("authenticate.webhook(request)");
+    expect(handler).toContain("reportShopifyDiscounts(apiKey, entries)");
+    expect(handler).toMatch(/catch[\s\S]*acking anyway[\s\S]*return new Response\("OK", \{ status: 200 \}\)/);
+    expect(handler).not.toContain("status: 500");
+    expect(handler).toMatch(/topic === "DISCOUNTS_CREATE" \|\| topic === "DISCOUNTS_UPDATE"/);
+  });
+
+  it("the grant hook backfills on read_discounts, bounded, and records it on the merchant doc", () => {
+    const hook = src("../routes/webhooks.app.scopes_update.tsx");
+    expect(hook).toContain("current.includes(DISCOUNTS_READ_SCOPE)");
+    expect(hook).toContain("backfillDiscounts(admin");
+    expect(hook).toMatch(/WEBHOOK_BACKFILL_PAGE_CAP = 3/);
+    expect(hook).toContain("discounts_backfilled_at");
+    // The scope record it always wrote is still written first.
+    expect(hook).toContain('scope: current.toString()');
+  });
+
+  it("the settings card asks with App Bridge's modal, never a redirect", () => {
+    const card = src("../components/settings/DiscountsSettings.tsx");
+    expect(card).toContain("scopes.request");
+    expect(card).not.toContain("window.location.href");
+    expect(card).not.toContain("location.assign");
+    expect(card).not.toContain("window.open");
+    const route = src("../routes/app.api.settings.discounts.tsx");
+    expect(route).toContain("authenticate.admin(request)");
+    expect(route).not.toMatch(/await scopes\.request\(/);
+  });
+
+  it("the enroll-critical query is untouched — the money comes from the webhook body, not a selection", () => {
+    const route = src("../routes/webhooks.orders_create.ts");
+    expect(route).toContain("money: orderMoneyFromWebhook(data)");
+    const critical = route.slice(route.indexOf("ORDER_DETAIL_QUERY = `"), route.indexOf("`;", route.indexOf("ORDER_DETAIL_QUERY = `") + 22));
+    expect(critical).not.toContain("discountCodes");
+    expect(critical).not.toContain("discountApplications");
+  });
+});
+
+describe("scopeListHas", () => {
+  it("reads Shopify's comma list", () => {
+    expect(scopeListHas("read_orders,read_discounts", "read_discounts")).toBe(true);
+    expect(scopeListHas("read_orders, write_discounts", "read_discounts")).toBe(false);
+    expect(scopeListHas(null, "read_discounts")).toBe(false);
+  });
+});

--- a/app/services/shopify-discounts.server.ts
+++ b/app/services/shopify-discounts.server.ts
@@ -1,0 +1,192 @@
+// THE DISCOUNTS DOOR, embed side (Track C, 2026-09-04).
+//
+// Shopify's DISCOUNTS_* webhook bodies are THIN — create/update carry only
+// the gid, title, status and the clock; delete carries the gid and
+// deleted_at; redeemcode_added/removed carry the gid and one code
+// (https://shopify.dev/docs/api/webhooks?reference=toml). Everything a
+// merchant would recognise as "the sale" — the dates, Shopify's own summary
+// in their words, the codes, the arithmetic — lives on the DiscountNode and
+// needs `read_discounts` (https://shopify.dev/docs/api/admin-graphql/2025-10/queries/discountNodes).
+//
+// So this module does two things and nothing else: reads a node back (one
+// on a webhook, every one on a backfill) and hands what Shopify said to the
+// backend's door, POST /api/promos/shopify, which owns the record shape and
+// merges every event onto one row. The embed never re-words a discount.
+//
+// Field names below were checked against the 2025-10 schema (introspected
+// 2026-09-04): `summary` exists on the Basic/Bxgy/FreeShipping members and
+// NOT on the two App members; `codes` on the four Code* members;
+// `customerGets` on Basic and Bxgy; `minimumRequirement` on Basic and
+// FreeShipping. An unauthorized or unknown field fails the WHOLE query
+// (order #1019), which is why this query rides its own wire and fails open.
+
+export type DiscountDoorEntry =
+  | { topic: string; payload: unknown }
+  | { node: Record<string, unknown>; source_event?: "webhook" | "backfill" };
+
+type GraphqlAdmin = {
+  graphql: (query: string, options?: { variables?: Record<string, unknown> }) => Promise<{ json(): Promise<unknown> }>;
+};
+
+type Loose = Record<string, unknown>;
+function loose(v: unknown): Loose {
+  return v && typeof v === "object" ? (v as Loose) : {};
+}
+function firstErrorMessage(json: unknown): string | null {
+  const errors = loose(json).errors;
+  if (!Array.isArray(errors) || !errors.length) return null;
+  const m = loose(errors[0]).message;
+  return typeof m === "string" ? m : null;
+}
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+const VALUE = `value {
+  __typename
+  ... on DiscountPercentage { percentage }
+  ... on DiscountAmount { amount { amount currencyCode } appliesOnEachItem }
+  ... on DiscountOnQuantity {
+    quantity { quantity }
+    effect {
+      __typename
+      ... on DiscountPercentage { percentage }
+      ... on DiscountAmount { amount { amount currencyCode } appliesOnEachItem }
+    }
+  }
+}`;
+
+const MINIMUM = `minimumRequirement {
+  __typename
+  ... on DiscountMinimumSubtotal { greaterThanOrEqualToSubtotal { amount currencyCode } }
+  ... on DiscountMinimumQuantity { greaterThanOrEqualToQuantity }
+}`;
+
+const CODES = `codes(first: 25) { nodes { code } }`;
+const CLOCK = `title status startsAt endsAt asyncUsageCount createdAt updatedAt`;
+const LIMITS = `usageLimit appliesOncePerCustomer`;
+
+/** The one selection every discount read shares. */
+export const DISCOUNT_SELECTION = `
+  id
+  discount {
+    __typename
+    ... on DiscountCodeBasic { ${CLOCK} summary ${CODES} customerGets { ${VALUE} } ${MINIMUM} ${LIMITS} }
+    ... on DiscountCodeBxgy { ${CLOCK} summary ${CODES} customerGets { ${VALUE} } ${LIMITS} }
+    ... on DiscountCodeFreeShipping { ${CLOCK} summary ${CODES} ${MINIMUM} ${LIMITS} }
+    ... on DiscountCodeApp { ${CLOCK} ${CODES} ${LIMITS} }
+    ... on DiscountAutomaticBasic { ${CLOCK} summary customerGets { ${VALUE} } ${MINIMUM} }
+    ... on DiscountAutomaticBxgy { ${CLOCK} summary customerGets { ${VALUE} } }
+    ... on DiscountAutomaticFreeShipping { ${CLOCK} summary ${MINIMUM} }
+    ... on DiscountAutomaticApp { ${CLOCK} }
+  }
+`;
+
+export const DISCOUNT_NODE_QUERY = `#graphql
+  query InkDiscountNode($id: ID!) {
+    discountNode(id: $id) { ${DISCOUNT_SELECTION} }
+  }
+`;
+
+export const DISCOUNT_NODES_QUERY = `#graphql
+  query InkDiscountNodes($cursor: String) {
+    discountNodes(first: 50, after: $cursor, sortKey: UPDATED_AT, reverse: true) {
+      pageInfo { hasNextPage endCursor }
+      nodes { ${DISCOUNT_SELECTION} }
+    }
+  }
+`;
+
+/** Read one discount back. Null on ANY failure — a revoked scope, a deleted
+ *  node, a network blip — and the refusal is LOGGED, naming the gid, so
+ *  "why is this discount thin" is answerable from the logs (TECH law 32). */
+export async function fetchDiscountNode(
+  admin: GraphqlAdmin,
+  gid: string,
+  label = "[discounts]",
+): Promise<Record<string, unknown> | null> {
+  try {
+    const res = await admin.graphql(DISCOUNT_NODE_QUERY, { variables: { id: gid } });
+    const json = await res.json();
+    const node = loose(loose(loose(json).data).discountNode);
+    if (!node.id) {
+      const why = firstErrorMessage(json) || "no discountNode in response";
+      console.warn(`${label} node unavailable for ${gid} — the thin event still lands: ${why}`);
+      return null;
+    }
+    return node;
+  } catch (err: unknown) {
+    console.warn(`${label} node read failed for ${gid} — the thin event still lands:`, messageOf(err));
+    return null;
+  }
+}
+
+export interface BackfillResult {
+  pages: number;
+  nodes: number;
+  written: number;
+  /** More pages remained past the cap — the caller says "partial". */
+  truncated: boolean;
+  errors: string[];
+}
+
+/** Walk every discount on the store, newest-updated first, and hand each
+ *  page to the door. `pageCap` bounds a webhook-time run (Shopify retries a
+ *  slow webhook); the Settings "Allow" flow runs uncapped. Idempotent:
+ *  the door merges, so re-running lands the same rows. */
+export async function backfillDiscounts(
+  admin: GraphqlAdmin,
+  post: (entries: DiscountDoorEntry[]) => Promise<{ written: number }>,
+  { pageCap = 40, label = "[discounts backfill]" }: { pageCap?: number; label?: string } = {},
+): Promise<BackfillResult> {
+  const result: BackfillResult = { pages: 0, nodes: 0, written: 0, truncated: false, errors: [] };
+  let cursor: string | null = null;
+  for (;;) {
+    if (result.pages >= pageCap) {
+      result.truncated = true;
+      break;
+    }
+    let page: Loose;
+    try {
+      const res = await admin.graphql(DISCOUNT_NODES_QUERY, { variables: { cursor } });
+      const json = await res.json();
+      const found = loose(loose(json).data).discountNodes;
+      if (!found || typeof found !== "object") {
+        result.errors.push(firstErrorMessage(json) || "no discountNodes in response");
+        break;
+      }
+      page = loose(found);
+    } catch (err: unknown) {
+      result.errors.push(messageOf(err));
+      break;
+    }
+    result.pages += 1;
+    const nodes: Loose[] = Array.isArray(page.nodes)
+      ? (page.nodes as unknown[]).map(loose).filter((n) => Boolean(n.id))
+      : [];
+    result.nodes += nodes.length;
+    if (nodes.length) {
+      try {
+        const r = await post(nodes.map((node) => ({ node, source_event: "backfill" as const })));
+        result.written += Number(r?.written) || 0;
+      } catch (err: unknown) {
+        result.errors.push(`page ${result.pages}: ${messageOf(err)}`);
+      }
+    }
+    const pageInfo = loose(page.pageInfo);
+    const endCursor = typeof pageInfo.endCursor === "string" ? pageInfo.endCursor : null;
+    if (!pageInfo.hasNextPage || !endCursor) break;
+    cursor = endCursor;
+  }
+  console.log(`${label} pages=${result.pages} nodes=${result.nodes} written=${result.written}${result.truncated ? " (partial)" : ""}${result.errors.length ? ` errors=${result.errors.join(" | ")}` : ""}`);
+  return result;
+}
+
+/** The scope the door needs, as Shopify names it on the session. */
+export const DISCOUNTS_READ_SCOPE = "read_discounts";
+export const DISCOUNTS_WRITE_SCOPE = "write_discounts";
+
+export function scopeListHas(scope: string | null | undefined, wanted: string): boolean {
+  if (!scope) return false;
+  return scope.split(",").map((s) => s.trim()).includes(wanted);
+}

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -62,6 +62,16 @@ api_version = "2025-10"
   topics = [ "orders/fulfilled" ]
   uri = "https://shopify-app-250065525755.us-central1.run.app/webhooks/orders_fulfilled"
 
+  # THE DISCOUNTS DOOR (Track C, 2026-09-04). App-level and declarative like
+  # orders/*, never ALSO registered imperatively (§17.8: two registrations =
+  # two deliveries). These topics need `read_discounts`, which is OPTIONAL
+  # below: a shop that never granted it simply never hears them, and Shopify
+  # forces no re-consent on anyone. One handler, webhooks.discounts.ts,
+  # switches on the topic — the five bodies differ only in what they carry.
+  [[webhooks.subscriptions]]
+  topics = [ "discounts/create", "discounts/update", "discounts/delete", "discounts/redeemcode_added", "discounts/redeemcode_removed" ]
+  uri = "https://shopify-app-250065525755.us-central1.run.app/webhooks/discounts"
+
   # GDPR compliance topics — MANDATORY for App Store review (auto-fail if
   # missing). Handlers already existed; this registers them. HMAC is verified
   # by authenticate.webhook(), which 401s invalid signatures (also required).
@@ -116,7 +126,14 @@ api_version = "2025-10"
 # a store that has not re-consented still enrolls normally and simply carries
 # no product link. This scope is what turns that link on.
 scopes = "read_assigned_fulfillment_orders,write_assigned_fulfillment_orders,read_merchant_managed_fulfillment_orders,write_merchant_managed_fulfillment_orders,read_third_party_fulfillment_orders,write_third_party_fulfillment_orders,read_customers,read_files,write_files,read_fulfillments,write_fulfillments,read_metaobjects,write_metaobjects,read_online_store_pages,write_online_store_pages,read_orders,write_orders,read_products,write_shipping,write_themes"
-optional_scopes = [ ]
+# OPTIONAL scopes are per-installation (Track C, 2026-09-04): only the
+# merchant who presses "Allow" on Settings › Account › Shopify discounts is
+# asked, in a modal, and nobody else re-consents. `read_discounts` is the
+# discounts door (the webhooks above + the backfill on grant);
+# `write_discounts` lets the Ritualist create a campaign's code in the store
+# so the code on the page is real. A config push (`shopify app deploy`) is
+# still Sam's act — but it is not a re-consent event.
+optional_scopes = [ "read_discounts", "write_discounts" ]
 use_legacy_install_flow = false
 
 [auth]


### PR DESCRIPTION
**HELD FOR ROUND FOUR — do not merge, do not deploy, until Shopify answers the review (resubmitted 2026-09-04).** Merging auto-deploys Cloud Run; the toml part also needs a `shopify app deploy` — both Sam's acts.

## What a person sees

- **Settings › Account** gains a third card, **"Shopify discounts"**: *Not allowed yet · [Allow]*. Allow opens Shopify's own grant modal for this store only (App Bridge `scopes.request`, no redirect, nobody else is asked). After the grant: *"Allowed — reading and creating discounts." · "12 discounts read in · Sep 4, 3:10 PM"* and a *[Read discounts again]* button. All copy is placeholder.
- Nothing else visible. Behind it: every discount the merchant creates, edits, ends or deletes in Shopify reaches the backend's promotions record within seconds (the door: ink-backend #79), and every new order carries its total, currency and the codes the buyer typed to the backend's enrol (ink-backend #78) — so "Sales after" can be the store's own number instead of a line-item guess.

## What changes

- `shopify.app.toml` — `optional_scopes = [ "read_discounts", "write_discounts" ]` (per-installation; not a re-consent event — https://shopify.dev/docs/api/app-bridge-library/apis/scopes) and one app-level `[[webhooks.subscriptions]]` for `discounts/create · update · delete · redeemcode_added · redeemcode_removed` → `/webhooks/discounts`. Declarative like `orders/*`, never also registered imperatively (§17.8). Required scopes untouched.
- `app/routes/webhooks.discounts.ts` (new) — one handler for the five topics: `authenticate.webhook` → the merchant's ink api key → hand the thin body to the door; on create/update also read the node back (`discountNode`, fail-open, logged) and hand that too. Always 200 once authenticated (the fulfillments/create discipline).
- `app/services/shopify-discounts.server.ts` (new) — `DISCOUNT_NODE_QUERY` / `DISCOUNT_NODES_QUERY` (selections checked against the 2025-10 schema by introspection on 2026-09-04: `summary` on the six Basic/Bxgy/FreeShipping members, never on the two App members; `codes` on the four Code members), `fetchDiscountNode` (null on any refusal), `backfillDiscounts` (pages of 50 newest-updated first, `pageCap`, `truncated`, per-page errors).
- `app/routes/webhooks.app.scopes_update.tsx` — still records the scope first; when `read_discounts` arrives, runs a bounded backfill (3 pages) and stamps `discounts_backfilled_at` / `_count` / `_partial` on the merchant doc.
- `app/routes/app.api.settings.discounts.tsx` (new) — GET the state (`scopes.query()` + the stamps); POST `{action:"backfill"}` walks everything (409 `scope_missing` before the grant). Never calls the server-side `scopes.request` (that one redirects).
- `app/components/settings/DiscountsSettings.tsx` (new) + one line in `AccountSettings.tsx` — the card.
- `app/services/order-money.ts` (new) — the order's money from the orders/create body, kept as sent, absent when absent (never "" or 0). `app/services/enroll-payload.ts` (new) — the enrol body, extracted pure from `enrollOrder` and pinned; `ink-api.server.ts` builds through it and gains `reportShopifyDiscounts` (Bearer = the merchant's own api key, so a discount lands on the record enrol writes — the two-record trap). `webhooks.orders_create.ts` passes `money: orderMoneyFromWebhook(data)`. The enroll-critical query is untouched (test-pinned).
- `merchant.server.ts` — the three stamp fields on the embed's own doc.

## Tests

```
npm run typecheck   → exit 0
npx vitest run      → exit 0   (Test Files 18 passed · Tests 149 passed; was 132)
npm run build       → exit 0
npx eslint <new files> → exit 0 (3 warnings: the repo's existing `firestore` default-import pattern)
```
Pre-existing lint debt in `ink-api.server.ts` (15) and `webhooks.orders_create.ts` (13) is unchanged. New: `order-money.test.ts` (4), `enroll-payload.test.ts` (2), `shopify-discounts.server.test.ts` (11: paging, cap, refusals, the query selections, the toml, the handler's discipline, the grant hook, the card, the untouched critical query).

## Six facts

written ✅ · committed ✅ · pushed ✅ · merged ❌ **HELD** · deployed ❌ **HELD** · verified how: unit + source pins only. **Unverifiable until re-consent**: no store can grant `read_discounts` before the toml is pushed, so no webhook, backfill, or Allow has run on the wire. The money-on-enrol half is verifiable the moment this deploys (the next Steve Madden order's proof carries `order_details.total_price_source: "order"`).

## For Sam

1. After round four: merge (Cloud Run auto-deploys) → `shopify app deploy` from `shopify.app.toml` (the `8da1…` app, never the `45cc…` one). The CLI should report the scope change as OPTIONAL only; if it says required scopes changed, stop — that would re-consent every store.
2. Resubmitting: new webhook topics and optional scopes change the listing's config; whether to resubmit once is yours.
3. The webhook-time backfill stops at 150 discounts (3 pages); the card's "Read discounts again" walks the rest. Raise the cap if you'd rather.
4. Placeholder copy throughout the card.

## New surfaces

- **"Shopify discounts" card** on Settings › Account (embed) — status line + Allow / Read-discounts-again. Asked for by Track C step 3 (the grant has to be asked somewhere inside the Shopify admin; App Bridge is the only place that can ask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
