### PR TITLE
HELD FOR ROUND FOUR — tier billing: the three locked plans through Shopify Billing, chosen here, approved on Shopify's screen (Track C, PR-6)

### DIFF
--- a/app/components/billing/PlanCard.tsx
+++ b/app/components/billing/PlanCard.tsx
@@ -1,38 +1,51 @@
-// This app is FREE at App Store submission. The Partner Dashboard exposes one
-// public Free plan, so there is no charge to approve and no invoice. This card
-// must not imply otherwise: paid plan language rendered here
-// while the listing's pricing field reads "Free" is exactly the inconsistency
-// that got the app rejected (requirement 1.2.1).
+// The plan this store is on, read from Shopify (Track C, tier billing).
 //
-// If paid tiers are ever configured, they run through Shopify (Managed
-// Pricing) and this card gains a link to SHOPIFY's own plan picker — built
-// from a VERIFIED app handle, never a guessed one. Do not resurrect the
-// hardcoded `ink-verified-delivery` fallback: it was never measured against
-// the Partner Dashboard, SHOPIFY_APP_HANDLE is set in no environment, and it
-// would have put a Shopify 404 in front of the reviewer.
+// With no plan chosen this card says what it always said — there is no
+// charge — because that is still true: nothing starts until a merchant
+// chooses one on /app/billing and approves it on Shopify's screen. With one
+// chosen it names the plan, the price and the order cap, from the locked
+// numbers in services/billing-plans.ts. The words and the listing's pricing
+// must match (requirement 1.2.1); this card never invents a number.
 import { CreditCard } from "lucide-react";
+import type { ActivePlan } from "../../services/billing-plans";
 
-const PlanCard = () => {
+const PlanCard = ({ plan = null }: { plan?: ActivePlan | null }) => {
   return (
     <div className="bg-card border border-border rounded-sm p-5">
       <div className="flex items-center gap-2 mb-2">
         <CreditCard className="h-4 w-4 text-foreground" aria-hidden="true" />
         <p className="text-sm font-medium text-foreground">Cost</p>
       </div>
-      <p className="text-sm font-medium text-foreground mb-1">
-        Your Shopify plan is Free.
-      </p>
-      {/* PROSE, not the mark: parallelreturns #644 is the naming authority —
-          "The Ritualist" sentence-initial, "the Ritualist" mid-sentence, bare
-          "Ritualist" adjectival. Only the app-name field and the wordmark are
-          lowercase `the ritualist`. The two cases are both correct and must
-          not be flattened into each other. */}
-      <p className="text-sm text-muted-foreground">
-        There is no subscription charge, trial, usage fee, or off-platform
-        invoice. Installing the app creates no charge. If paid plans are
-        introduced later, you&rsquo;ll choose and approve one inside Shopify
-        &mdash; nothing will start on its own.
-      </p>
+      {plan ? (
+        <>
+          <p className="text-sm font-medium text-foreground mb-1">
+            Your plan is {plan.key} — ${plan.amount.toLocaleString("en-US")}/mo, up to{" "}
+            {plan.ordersPerMonth.toLocaleString("en-US")} orders a month.
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Approved inside Shopify and billed on your regular Shopify invoice.
+            {plan.test ? " This is a test subscription — no money moves." : ""}{" "}
+            Change or cancel it any time on the Billing page.
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="text-sm font-medium text-foreground mb-1">
+            No plan chosen — there is no charge.
+          </p>
+          {/* PROSE, not the mark: parallelreturns #644 is the naming authority —
+              "The Ritualist" sentence-initial, "the Ritualist" mid-sentence, bare
+              "Ritualist" adjectival. Only the app-name field and the wordmark are
+              lowercase `the ritualist`. The two cases are both correct and must
+              not be flattened into each other. */}
+          <p className="text-sm text-muted-foreground">
+            There is no subscription charge, trial, usage fee, or off-platform
+            invoice. Installing the app creates no charge. When you choose a plan
+            on the Billing page, Shopify asks you to approve it &mdash; nothing
+            starts on its own.
+          </p>
+        </>
+      )}
     </div>
   );
 };

--- a/app/components/settings/AccountSettings.tsx
+++ b/app/components/settings/AccountSettings.tsx
@@ -24,6 +24,9 @@ const AccountSettings = () => {
   // construction until the merchant record started stamping createdAt.)
   const storeEmail = shopData?.contactEmail || "";
   const installedDate = shopData?.installedDate || "";
+  // The plan Shopify says this store is on (app.settings loader → billing-read);
+  // null = none chosen, and the card says there is no charge, which is true.
+  const plan = shopData?.plan as { key: string; amount: number; ordersPerMonth: number; test?: boolean } | null | undefined;
   const displayDomain = shopData?.primaryDomain || shopData?.shopDomain || currentShop?.domain || "";
 
   if (loading) {
@@ -67,15 +70,29 @@ const AccountSettings = () => {
         <Layout.AnnotatedSection title="Cost">
           <Card>
             <BlockStack gap="300">
-              <Text as="p" variant="bodyMd" fontWeight="semibold">
-                Your Shopify plan is Free.
-              </Text>
-              <Text as="p" variant="bodyMd">
-                There is no subscription charge, trial, usage fee, or
-                off-platform invoice. Installing the app creates no charge. If
-                paid plans are introduced later, you&rsquo;ll choose and approve
-                one inside Shopify &mdash; nothing will start on its own.
-              </Text>
+              {plan ? (
+                <>
+                  <Text as="p" variant="bodyMd" fontWeight="semibold">
+                    Your plan is {plan.key} &mdash; ${plan.amount.toLocaleString("en-US")}/mo, up to {plan.ordersPerMonth.toLocaleString("en-US")} orders a month.
+                  </Text>
+                  <Text as="p" variant="bodyMd">
+                    Approved inside Shopify and billed on your regular Shopify invoice.
+                    {plan.test ? " This is a test subscription — no money moves." : ""}
+                  </Text>
+                </>
+              ) : (
+                <>
+                  <Text as="p" variant="bodyMd" fontWeight="semibold">
+                    No plan chosen &mdash; there is no charge.
+                  </Text>
+                  <Text as="p" variant="bodyMd">
+                    There is no subscription charge, trial, usage fee, or
+                    off-platform invoice. Installing the app creates no charge.
+                    When you choose a plan, you approve it inside Shopify &mdash;
+                    nothing starts on its own.
+                  </Text>
+                </>
+              )}
               <div>
                 <Button onClick={() => navigate("/app/billing")}>View details</Button>
               </div>

--- a/app/routes/app.billing.tsx
+++ b/app/routes/app.billing.tsx
@@ -1,29 +1,65 @@
 import { authenticate } from "../shopify.server";
-import type { LoaderFunctionArgs, HeadersFunction } from "react-router";
-import { useRouteError } from "react-router";
+import type { ActionFunctionArgs, LoaderFunctionArgs, HeadersFunction } from "react-router";
+import { Form, useLoaderData, useNavigation, useRouteError } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
-import { Page, BlockStack, Card, Text } from "@shopify/polaris";
+import { Page, BlockStack, Card, Text, Button, InlineStack, Badge } from "@shopify/polaris";
 import PolarisAppLayout from "../components/PolarisAppLayout";
 import PlanCard from "../components/billing/PlanCard";
+import { BILLING_PLANS, BILLING_PLAN_KEYS, isBillingPlanKey, planCapLine, planPriceLine } from "../services/billing-plans";
+import { BILLING_IS_TEST } from "../services/billing-mode.server";
+import { readActivePlan } from "../services/billing-read.server";
 
-// The honest billing page. The previous version rendered three mock cards
-// (hardcoded $233.22/$500 cap, a fabricated 47/31 cycle, and a fake usage
-// ledger of orders that never existed) — all tabled unreferenced in
-// components/billing/.
+// The billing page (Track C, tier billing — HELD until Shopify answers round
+// four AND the listing's pricing matches these three tiers exactly).
 //
-// The app is FREE at App Store submission: the Partner Dashboard exposes one
-// public Free plan, so nothing can be charged. This page says that plainly.
-// It is deliberately kept (rather than deleted) because /app/payment and
-// /app/payment/callback redirect here, and because an explicit "there is
-// nothing to pay" screen is the cheapest possible proof of requirement 1.2.1
-// for a reviewer who goes looking for billing.
+// Three locked tiers, chosen here, approved on SHOPIFY'S screen: Choose →
+// the action asks billing.request, which sends the merchant to Shopify's
+// confirmation page (appSubscriptionCreate under the hood); approved charges
+// land on the regular Shopify invoice; decline brings them back here with
+// nothing started. Shopify owns approval, decline, cancellation and the
+// reinstall re-approval. The active plan is READ from Shopify on every
+// visit, never from our own records — no internal "paid" flag exists.
+//
+// Still the honest page when nothing is chosen: "there is no charge" stays
+// true until a merchant approves one. Requirement 2.1.1's boundary and
+// headers stay exactly as they were.
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  await authenticate.admin(request);
-  return {};
+  const { billing } = await authenticate.admin(request);
+  const active = await readActivePlan(billing, "[billing page]");
+  return {
+    active,
+    isTest: BILLING_IS_TEST,
+    plans: BILLING_PLAN_KEYS.map((key) => ({
+      key,
+      price: planPriceLine(BILLING_PLANS[key]),
+      cap: planCapLine(BILLING_PLANS[key]),
+    })),
+  };
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const { billing } = await authenticate.admin(request);
+  const form = await request.formData();
+  const plan = form.get("plan");
+  if (!isBillingPlanKey(plan)) {
+    return { error: "Choose one of the three plans." };
+  }
+  const appUrl = process.env.SHOPIFY_APP_URL || "";
+  // Redirects to Shopify's approval screen; the library throws the redirect.
+  await billing.request({
+    plan,
+    isTest: BILLING_IS_TEST,
+    returnUrl: `${appUrl}/app/billing`,
+  });
+  return { error: null };
 }
 
 export default function BillingPage() {
+  const { active, isTest, plans } = useLoaderData<typeof loader>();
+  const navigation = useNavigation();
+  const choosing = navigation.state !== "idle" ? String(navigation.formData?.get("plan") ?? "") : "";
+
   return (
     <PolarisAppLayout>
       <Page
@@ -31,18 +67,53 @@ export default function BillingPage() {
         backAction={{ content: "Settings", url: "/app/settings" }}
       >
         <BlockStack gap="400">
-          <PlanCard />
+          <PlanCard plan={active} />
+          <Card>
+            <BlockStack gap="300">
+              <Text as="h2" variant="headingSm">
+                Plans
+              </Text>
+              <Text as="p" tone="subdued">
+                Priced on orders, not on opens — clicks and page opens are never metered.
+                Choose a plan and Shopify will ask you to approve it; the charge lands on
+                your regular Shopify invoice. Nothing starts until you approve.
+              </Text>
+              {plans.map((p) => {
+                const isActive = active?.key === p.key;
+                return (
+                  <InlineStack key={p.key} align="space-between" blockAlign="center" gap="400" wrap={false}>
+                    <BlockStack gap="050">
+                      <InlineStack gap="200" blockAlign="center">
+                        <Text as="p" variant="bodyMd" fontWeight="semibold">{p.key}</Text>
+                        {isActive ? <Badge tone="success">Current plan</Badge> : null}
+                      </InlineStack>
+                      <Text as="p" tone="subdued" variant="bodySm">{p.price} · {p.cap}</Text>
+                    </BlockStack>
+                    <Form method="post">
+                      <input type="hidden" name="plan" value={p.key} />
+                      <Button submit disabled={isActive} loading={choosing === p.key}>
+                        {isActive ? "Chosen" : `Choose ${p.key}`}
+                      </Button>
+                    </Form>
+                  </InlineStack>
+                );
+              })}
+              {isTest ? (
+                <Text as="p" tone="subdued" variant="bodySm">
+                  Test mode: Shopify shows the approval screen and no money moves.
+                </Text>
+              ) : null}
+            </BlockStack>
+          </Card>
           <Card>
             <BlockStack gap="200">
               <Text as="h2" variant="headingSm">
                 Billing stays in Shopify
               </Text>
               <Text as="p" tone="subdued">
-                Your current Shopify plan is Free. There is no subscription
-                charge, trial, usage fee, card on file, or off-platform
-                invoice. If paid plans are introduced later, Shopify will
-                present them for approval and add approved charges to your
-                regular Shopify invoice.
+                Approval, decline, invoicing and cancellation all happen inside Shopify.
+                There is no card on file here, no trial, no usage fee, and no off-platform
+                invoice. Returns are priced separately, on your own carrier account.
               </Text>
             </BlockStack>
           </Card>

--- a/app/routes/app.dashboard.tsx
+++ b/app/routes/app.dashboard.tsx
@@ -1,6 +1,6 @@
 import { boundary } from "@shopify/shopify-app-react-router/server";
 import { useEffect, useRef, useState } from "react";
-import { useFetcher, type ActionFunctionArgs, useRouteError, type HeadersFunction } from "react-router";
+import { useFetcher, useLoaderData, type ActionFunctionArgs, type LoaderFunctionArgs, useRouteError, type HeadersFunction } from "react-router";
 import {
   Page,
   Card,
@@ -13,6 +13,7 @@ import {
 } from "@shopify/polaris";
 import { authenticate } from "../shopify.server";
 import { mintMagicToken } from "../services/ink-api.server";
+import { readActivePlan } from "../services/billing-read.server";
 import PolarisAppLayout from "~/components/PolarisAppLayout";
 import RecentActivity from "~/components/RecentActivity";
 import EngagementFunnel from "~/components/EngagementFunnel";
@@ -27,6 +28,14 @@ import { FEATURE_NFC } from "~/flags";
 // Removed from render (kept in tree, unreferenced): TimeToEngagement +
 // CommunicationsUsage rendered hardcoded fictional numbers. Nothing on this
 // dashboard may show a number that isn't the merchant's own.
+
+// The plan this store is on, from Shopify, for the PlanCard below. A plain
+// object (React Router 7 serialises it); readActivePlan never throws.
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { billing } = await authenticate.admin(request);
+  const plan = await readActivePlan(billing, "[dashboard]");
+  return { plan };
+};
 
 // Mint a single-use magic-login token for this shop and hand back a
 // www.in.ink/welcome URL the merchant can open already signed in.
@@ -56,6 +65,7 @@ const Dashboard = () => {
   // embed leads with the lightweight engagement cards + handoff, not a second
   // comprehensive dashboard to keep in sync.
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const { plan } = useLoaderData<typeof loader>();
 
   const fetcher = useFetcher<typeof action>();
   const pendingWindow = useRef<Window | null>(null);
@@ -134,7 +144,7 @@ const Dashboard = () => {
             <RecentActivity />
             <div className="flex flex-col gap-4">
               <CommsCard />
-              <PlanCard />
+              <PlanCard plan={plan} />
             </div>
           </div>
 

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -4,10 +4,14 @@ import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
 import { getInventory, getInventoryByShopDomain, getShopIdByDomain } from "../services/ink-api.server";
 import Settings from "../components/settings/Settings";
+import { readActivePlan } from "../services/billing-read.server";
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { admin, session } = await authenticate.admin(request);
-  
+  const { admin, session, billing } = await authenticate.admin(request);
+
+  // 0. The plan this store is on, from Shopify — never throws (billing-read).
+  const plan = await readActivePlan(billing, "[settings]");
+
   // 1. Get shop details from Shopify — NEVER let this throw.
   //
   // THIS IS THE "200 ERROR PAGE". When a call cannot be authorised,
@@ -99,6 +103,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
      primaryDomain: shop?.primaryDomain?.host || session.shop,
      contactEmail: shop?.contactEmail || "",
      installedDate,
+     plan,
      inventoryData: {
        current: inventoryStr,
        usedThisPeriod: usedStr

--- a/app/services/billing-mode.server.ts
+++ b/app/services/billing-mode.server.ts
@@ -1,0 +1,6 @@
+// Server-only: whether Shopify billing runs in TEST mode (no money moves;
+// the merchant still walks the approval screen). Set SHOPIFY_BILLING_TEST=true
+// in Cloud Run env for the dev-store walk; unset (or anything else) charges
+// for real. Default is REAL on purpose: a silent test default would let a
+// paying merchant approve a plan that never bills.
+export const BILLING_IS_TEST = process.env.SHOPIFY_BILLING_TEST === "true";

--- a/app/services/billing-plans.test.ts
+++ b/app/services/billing-plans.test.ts
@@ -1,0 +1,97 @@
+// The locked pricing, pinned (Track C, tier billing — HELD). $299 / $599 /
+// $999 at 1,000 / 2,500 / 4,000 — never any other number, on any surface;
+// the plan shown is always the one Shopify says is ACTIVE; and the 2.1.1
+// fixes on the billing route stay in place.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { BILLING_PLANS, BILLING_PLAN_KEYS, activePlanFrom, isBillingPlanKey, planCapLine, planPriceLine } from "./billing-plans";
+
+function src(rel: string): string {
+  return readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+}
+
+describe("the three locked tiers", () => {
+  it("are exactly $299 / $599 / $999 at 1,000 / 2,500 / 4,000 orders, USD, in that order", () => {
+    expect(BILLING_PLAN_KEYS).toEqual(["Starter", "Growth", "Pro"]);
+    expect(BILLING_PLANS.Starter).toEqual({ key: "Starter", amount: 299, currencyCode: "USD", ordersPerMonth: 1000 });
+    expect(BILLING_PLANS.Growth).toEqual({ key: "Growth", amount: 599, currencyCode: "USD", ordersPerMonth: 2500 });
+    expect(BILLING_PLANS.Pro).toEqual({ key: "Pro", amount: 999, currencyCode: "USD", ordersPerMonth: 4000 });
+    expect(planPriceLine(BILLING_PLANS.Growth)).toBe("$599/mo");
+    expect(planCapLine(BILLING_PLANS.Growth)).toBe("up to 2,500 orders a month");
+  });
+
+  it("the dead numbers never appear on any billing surface", () => {
+    const surfaces = [
+      src("./billing-plans.ts"),
+      src("../shopify.server.ts"),
+      src("../routes/app.billing.tsx"),
+      src("../components/billing/PlanCard.tsx"),
+      src("../components/settings/AccountSettings.tsx"),
+    ].join("\n");
+    for (const dead of ["1,299", "1299", "$2.50", "2.50 per", "$2.00 per", "$0.05", "$49", "Stripe", "stripe"]) {
+      expect(surfaces).not.toContain(dead);
+    }
+  });
+
+  it("shopify.server.ts declares the three plans from the locked data, every 30 days, and nothing else", () => {
+    const s = src("../shopify.server.ts");
+    const block = s.slice(s.indexOf("billing: {"), s.indexOf("...(process.env.SHOP_CUSTOM_DOMAIN"));
+    for (const key of BILLING_PLAN_KEYS) {
+      expect(block).toContain(`${key}: {`);
+      expect(block).toContain(`BILLING_PLANS.${key}.amount`);
+    }
+    expect((block.match(/BillingInterval\.Every30Days/g) || []).length).toBe(3);
+    expect(block).not.toMatch(/amount:\s*\d/);
+    expect(block).not.toContain("Usage");
+    expect(block).not.toContain("trialDays");
+  });
+});
+
+describe("activePlanFrom", () => {
+  it("picks the ACTIVE subscription named like a plan; ignores the rest", () => {
+    expect(activePlanFrom([
+      { id: "gid://shopify/AppSubscription/1", name: "Growth", status: "CANCELLED" },
+      { id: "gid://shopify/AppSubscription/2", name: "Pro", status: "ACTIVE", test: true },
+    ])).toEqual({ key: "Pro", amount: 999, ordersPerMonth: 4000, subscriptionId: "gid://shopify/AppSubscription/2", test: true });
+    expect(activePlanFrom([{ name: "Legacy $49", status: "ACTIVE" }])).toBeNull();
+    expect(activePlanFrom([])).toBeNull();
+    expect(activePlanFrom(null)).toBeNull();
+    expect(isBillingPlanKey("Starter")).toBe(true);
+    expect(isBillingPlanKey("starter")).toBe(false);
+  });
+});
+
+describe("the billing route keeps the 2.1.1 fixes and never charges on its own", () => {
+  it("every billing-touching route keeps Shopify's boundary and headers", () => {
+    for (const rel of ["../routes/app.billing.tsx", "../routes/app.settings.tsx", "../routes/app.dashboard.tsx"]) {
+      const s = src(rel);
+      expect(s).toContain("boundary.error(useRouteError())");
+      expect(s).toContain("boundary.headers(args)");
+    }
+  });
+
+  it("a plan starts only from the merchant's own Choose: billing.request lives in the action, behind a plan-key check, with isTest from the env and a returnUrl back here", () => {
+    const s = src("../routes/app.billing.tsx");
+    const action = s.slice(s.indexOf("export async function action"), s.indexOf("export default function"));
+    expect(action).toContain("isBillingPlanKey(plan)");
+    expect(action).toContain("billing.request({");
+    expect(action).toContain("isTest: BILLING_IS_TEST");
+    expect(action).toContain("returnUrl: `${appUrl}/app/billing`");
+    const loader = s.slice(s.indexOf("export async function loader"), s.indexOf("export async function action"));
+    expect(loader).not.toContain("billing.request");
+    expect(loader).not.toContain("billing.require");
+    expect(src("../routes/app.tsx")).not.toContain("billing.request");
+    expect(src("../services/billing-mode.server.ts")).toContain('process.env.SHOPIFY_BILLING_TEST === "true"');
+  });
+
+  it("the plan every surface shows is READ from Shopify through one never-throwing read", () => {
+    const read = src("../services/billing-read.server.ts");
+    expect(read).toContain("billing.check({ isTest: BILLING_IS_TEST })");
+    expect(read).toContain("return null;");
+    for (const rel of ["../routes/app.billing.tsx", "../routes/app.settings.tsx", "../routes/app.dashboard.tsx"]) {
+      expect(src(rel)).toContain("readActivePlan(billing");
+    }
+    expect(src("../components/billing/PlanCard.tsx")).not.toMatch(/\$\d/);
+  });
+});

--- a/app/services/billing-plans.ts
+++ b/app/services/billing-plans.ts
@@ -1,0 +1,68 @@
+// THE LOCKED PRICING, as data (Track C, tier billing — HELD).
+//
+// Sam's lock of 2026-07-05, amended by him 2026-08-23: $299 / $599 / $999 a
+// month at 1,000 / 2,500 / 4,000 orders a month. NEVER any other number —
+// two stale docs still carry an older Pro price and a per-return line; both
+// are dead (memory: the locked pricing and its stale twin).
+// Clicks and page opens are free and never metered. Returns are priced
+// separately, on the merchant's own carrier account, and are NOT a line
+// here. The order caps are what the tier is FOR; nothing meters them yet
+// ("the clock is ours, the billing is Shopify's").
+//
+// Pure: no env, no Shopify. shopify.server.ts turns these into the billing
+// config; app.billing.tsx renders them; both are pinned by test to THESE
+// numbers so the listing, the Partner Dashboard and the app cannot drift
+// apart silently (requirement 1.2.1 — the listing price MUST match).
+
+export interface BillingPlan {
+  key: "Starter" | "Growth" | "Pro";
+  amount: number;
+  currencyCode: "USD";
+  ordersPerMonth: number;
+}
+
+export const BILLING_PLANS: Record<BillingPlan["key"], BillingPlan> = {
+  Starter: { key: "Starter", amount: 299, currencyCode: "USD", ordersPerMonth: 1000 },
+  Growth: { key: "Growth", amount: 599, currencyCode: "USD", ordersPerMonth: 2500 },
+  Pro: { key: "Pro", amount: 999, currencyCode: "USD", ordersPerMonth: 4000 },
+};
+
+export const BILLING_PLAN_KEYS: BillingPlan["key"][] = ["Starter", "Growth", "Pro"];
+
+export function isBillingPlanKey(v: unknown): v is BillingPlan["key"] {
+  return typeof v === "string" && (BILLING_PLAN_KEYS as string[]).includes(v);
+}
+
+/** "$599/mo" · "2,500 orders a month" — the words every surface uses. */
+export function planPriceLine(plan: BillingPlan): string {
+  return `$${plan.amount.toLocaleString("en-US")}/mo`;
+}
+export function planCapLine(plan: BillingPlan): string {
+  return `up to ${plan.ordersPerMonth.toLocaleString("en-US")} orders a month`;
+}
+
+export interface ActivePlan {
+  key: BillingPlan["key"];
+  amount: number;
+  ordersPerMonth: number;
+  /** Shopify's subscription id (gid). */
+  subscriptionId: string | null;
+  test: boolean;
+}
+
+/** The plan Shopify says is ACTIVE for this store, from billing.check()'s
+ *  appSubscriptions — or null. Only a subscription NAMED like one of the
+ *  three counts; anything else (a legacy charge, a test remnant with
+ *  another name) is not a plan we sell. */
+export function activePlanFrom(
+  subscriptions: Array<{ id?: string; name?: string; status?: string; test?: boolean }> | null | undefined,
+): ActivePlan | null {
+  for (const sub of subscriptions || []) {
+    if (!sub || sub.status !== "ACTIVE") continue;
+    const key = sub.name;
+    if (!isBillingPlanKey(key)) continue;
+    const plan = BILLING_PLANS[key];
+    return { key, amount: plan.amount, ordersPerMonth: plan.ordersPerMonth, subscriptionId: sub.id ?? null, test: sub.test === true };
+  }
+  return null;
+}

--- a/app/services/billing-read.server.ts
+++ b/app/services/billing-read.server.ts
@@ -1,0 +1,21 @@
+// The one read of "which plan is this store on", for every surface that shows
+// it (the billing page, the dashboard's PlanCard, Settings › Cost). NEVER
+// throws: a Shopify hiccup costs the plan line, never the page — the "200
+// error page" rejection came from exactly one loader that could throw.
+import type { ActivePlan } from "./billing-plans";
+import { activePlanFrom } from "./billing-plans";
+import { BILLING_IS_TEST } from "./billing-mode.server";
+
+type BillingContext = {
+  check: (options?: { isTest?: boolean }) => Promise<{ hasActivePayment: boolean; appSubscriptions: unknown[] }>;
+};
+
+export async function readActivePlan(billing: BillingContext, label = "[billing]"): Promise<ActivePlan | null> {
+  try {
+    const result = await billing.check({ isTest: BILLING_IS_TEST });
+    return activePlanFrom(result.appSubscriptions as Array<{ id?: string; name?: string; status?: string; test?: boolean }>);
+  } catch (err: unknown) {
+    console.warn(`${label} plan read failed; rendering without it:`, err instanceof Error ? err.message : err);
+    return null;
+  }
+}

--- a/app/shopify.server.ts
+++ b/app/shopify.server.ts
@@ -2,10 +2,12 @@ import "@shopify/shopify-app-react-router/adapters/node";
 import {
   ApiVersion,
   AppDistribution,
+  BillingInterval,
   shopifyApp,
 } from "@shopify/shopify-app-react-router/server";
 import { FirestoreSessionStorage } from "./firestore-session-storage.server";
 import { DeliveryMethod } from "@shopify/shopify-api"; // ✅ Added import
+import { BILLING_PLANS } from "./services/billing-plans";
 
 const shopify = shopifyApp({
   apiKey: process.env.SHOPIFY_API_KEY,
@@ -35,6 +37,25 @@ const shopify = shopifyApp({
   authPathPrefix: "/auth",
   sessionStorage: new FirestoreSessionStorage(),
   distribution: AppDistribution.AppStore,
+
+  // THE THREE LOCKED TIERS, through the Shopify Billing API
+  // (appSubscriptionCreate under the hood — https://shopify.dev/docs/api/admin-graphql/2025-10/mutations/appSubscriptionCreate).
+  // Shopify owns approval, decline, invoicing, cancellation and the
+  // reinstall re-approval (requirements 1.2.1 / 1.2.2, docs/billing-compliance).
+  // Nothing here charges on its own: a plan starts only when the merchant
+  // chooses one on /app/billing and approves it on Shopify's screen. The
+  // numbers are services/billing-plans.ts — never typed here.
+  billing: {
+    Starter: {
+      lineItems: [{ amount: BILLING_PLANS.Starter.amount, currencyCode: BILLING_PLANS.Starter.currencyCode, interval: BillingInterval.Every30Days }],
+    },
+    Growth: {
+      lineItems: [{ amount: BILLING_PLANS.Growth.amount, currencyCode: BILLING_PLANS.Growth.currencyCode, interval: BillingInterval.Every30Days }],
+    },
+    Pro: {
+      lineItems: [{ amount: BILLING_PLANS.Pro.amount, currencyCode: BILLING_PLANS.Pro.currencyCode, interval: BillingInterval.Every30Days }],
+    },
+  },
   
   // ✅ Webhook definitions with proper DeliveryMethod enum
   webhooks: {


### PR DESCRIPTION
**HELD FOR ROUND FOUR — do not merge, do not deploy, until (a) Shopify answers the review resubmitted 2026-09-04 and (b) the App Store listing's pricing and the Partner Dashboard plans match these three tiers exactly.** The listing says "Free" today; merging this while it does is the 1.2.1 mismatch that was rejected before (docs/billing-compliance-2026-07-07.md).

## What a person sees

- **Billing** (`/app/billing`): the Cost card, then a **Plans** card listing the three locked tiers — *Starter $299/mo · up to 1,000 orders a month*, *Growth $599/mo · up to 2,500*, *Pro $999/mo · up to 4,000* — each with a **Choose** button. Choose sends the merchant to **Shopify's own approval screen**; an approved charge lands on their regular Shopify invoice; declining brings them back with nothing started. The current plan carries a "Current plan" badge and its button reads "Chosen". A test-mode line appears only when the env switch is on.
- **The Cost card** (dashboard and the Billing page) and **Settings › Account › Cost**: with a plan, *"Your plan is Growth — $599/mo, up to 2,500 orders a month."*; with none, *"No plan chosen — there is no charge."* and the sentence that was already there. Never a number the store did not approve.
- No plan starts on its own. Nothing meters the order caps yet (the tiers are what the plan is FOR; "the clock is ours, the billing is Shopify's").

## What changes

- `app/services/billing-plans.ts` (new, pure) — the locked numbers as data, `activePlanFrom(appSubscriptions)` (only an **ACTIVE** subscription named like one of the three counts), the price/cap words.
- `app/services/billing-mode.server.ts` (new) — `BILLING_IS_TEST = process.env.SHOPIFY_BILLING_TEST === "true"`; default REAL on purpose (a silent test default would let a paying merchant approve a plan that never bills).
- `app/services/billing-read.server.ts` (new) — `readActivePlan(billing)`: one `billing.check({isTest})`, never throws (the "200 error page" came from one loader that could).
- `app/shopify.server.ts` — `billing: { Starter, Growth, Pro }`, each one `EVERY_30_DAYS` line item built from the data module (`appSubscriptionCreate` under the library — https://shopify.dev/docs/api/admin-graphql/2025-10/mutations/appSubscriptionCreate).
- `app/routes/app.billing.tsx` — loader reads the plan; action validates the plan key and calls `billing.request({plan, isTest, returnUrl: …/app/billing})`; Polaris `Form method="post"` (client-side navigation — Polaris urls stay on React Router's Link, the 2.1.1 fix); boundary + headers unchanged.
- `app/components/billing/PlanCard.tsx` — takes the active plan; `app/routes/app.dashboard.tsx` gains a loader that reads it; `app/routes/app.settings.tsx` loader passes `plan`; `AccountSettings.tsx` Cost card renders it.

## Tests

```
npm run typecheck   → exit 0
npx vitest run      → exit 0   (Test Files 16 passed · Tests 139 passed; was 132)
npm run build       → exit 0
npx eslint <new/rewritten files> → exit 0
```
New: `billing-plans.test.ts` (7) — the three numbers and caps, the dead numbers absent from every billing surface, `shopify.server.ts` declares exactly three `Every30Days` plans from the data module (no literal amounts, no usage, no trial), `activePlanFrom` picks ACTIVE only, every billing-touching route keeps `boundary.error` + `boundary.headers`, `billing.request` lives only in the action behind the key check with `isTest` from the env, the plan is read through the one never-throwing read.

## Six facts

written ✅ · committed ✅ · pushed ✅ · merged ❌ **HELD** · deployed ❌ **HELD** · verified how: unit + source pins. **Not verified on the wire**: no dev-store walk (Choose → Shopify's approval screen → return) has been run; the docs/billing-compliance checklist (approve · decline · uninstall/reinstall re-approval) is owed on `sm-test-hhawzn52` with `SHOPIFY_BILLING_TEST=true` before this could ever ship.

## For Sam

1. Order of operations, all yours: round four answers → set the listing's pricing and the Partner Dashboard plans to exactly these three tiers → set `SHOPIFY_BILLING_TEST=true` on Cloud Run for the dev-store walk → merge → walk approve/decline/reinstall on Steve Madden → flip the env off → resubmit if Shopify wants the pricing change reviewed.
2. The order caps are displayed, not enforced — no metering, by design, until you say otherwise.
3. Placeholder copy throughout ("ship yours").

## New surfaces

- The **Plans** card on `/app/billing` (three tiers, Choose) — asked for by Track C step 6 ("the plan surfaced where the embed already shows the plan"; the choosing has to live somewhere, and Billing is that page). The Cost card and Settings › Cost are existing surfaces re-worded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
