### PR TITLE
HELD FOR ROUND FOUR — The order carries its page, so the shipping email opens it

### DIFF
--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -344,6 +344,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     let proofReference = "";
     let inkToken = "";
     let verificationStatus = "pending";
+    // The backend's merchant identity off the enrol response — how the page's
+    // address finds its brand (page-url-on-the-order.server.ts).
+    let proofShopId = "";
     try {
       const apiKey = await getMerchantApiKey(shop);
       if (!apiKey) {
@@ -528,6 +531,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
             }
           }
           proofReference = inkData?.proof_id || "";
+          proofShopId = String(inkData?.shop_id || "");
           verificationStatus = proofReference ? "enrolled" : "pending";
           if (inkData?.already_enrolled && inkData?.nfc_token) {
             // Backend deduped on (shop_id, order_id) — this delivery was a
@@ -659,6 +663,53 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         console.error(`[orders/create] metafieldsSet userErrors:`, metaErrors);
       } else {
         console.log(`✅ [orders/create] Metafields initialized for ${orderName}`);
+      }
+
+      // THE PAGE ON THE ORDER — so the FIRST shipping email opens it. The
+      // tracking-URL rewrite runs after Shopify has composed that email and
+      // never re-sends it (rule 4 of branded-tracking-link.server.ts), so the
+      // page's address has to be on the order before any fulfilment exists.
+      // Its own wire, its own mutation, never fatal
+      // (page-url-on-the-order.server.ts); the Shipping confirmation /
+      // Shipping update templates read it as `metafields.ink.page_url`.
+      // Out-of-slice orders never reach here — no ink.* metafield, no page,
+      // nothing for a buyer to see.
+      if (proofReference && inkToken) {
+        try {
+          const { pageUrlForEnrolledOrder, stampPageUrlOnOrder } = await import(
+            "../services/page-url-on-the-order.server"
+          );
+          const page = await pageUrlForEnrolledOrder({
+            shopId: proofShopId,
+            nfcToken: inkToken,
+            merchantData: merchantForScope?.data ?? {},
+            label: "[orders/create] page-url",
+          });
+          await stampPageUrlOnOrder({
+            admin,
+            orderGid,
+            orderName,
+            pageUrl: page.pageUrl,
+            reason:
+              page.reason === "no_slug"
+                ? "no brand_slug on the merchant doc (never a derived host)"
+                : page.reason,
+            label: "[orders/create] page-url",
+          });
+        } catch (stampErr: unknown) {
+          console.error(
+            `🔗 [orders/create] page-url: ${orderName} failed (non-fatal) — ` +
+              `${stampErr instanceof Error ? stampErr.message : String(stampErr)}`
+          );
+        }
+      } else {
+        // A redelivery of an already-enrolled order carries no token here —
+        // the delivery that enrolled it stamped the page. An order with no
+        // proof has no page to name.
+        console.log(
+          `🔗 [orders/create] page-url: ${orderName} skipped_no_token — ` +
+            `${proofReference ? "redelivery of an already-enrolled order; the enrolling delivery stamped it" : "no proof"}`
+        );
       }
     }
   } catch (error: any) {

--- a/app/services/page-url-on-the-order.server.ts
+++ b/app/services/page-url-on-the-order.server.ts
@@ -1,0 +1,336 @@
+// THE PAGE ON THE ORDER — stamped at enrol, so the shipping email can open it.
+//
+// Shopify composes the shipping-confirmation email at the instant of
+// fulfilment, and by then it has already filled `fulfillment.tracking_url`
+// with the carrier's own link for every carrier it recognises. Our rewrite of
+// that URL (branded-tracking-link.server.ts) runs on the fulfillments/update
+// that follows, and it is `notifyCustomer:false` by rule 4 — never a second
+// shipping email — so the ONE email the buyer gets was rendered with ups.com
+// in it. Measured on Steve Madden order #1027, 2026-09-05: Shopify's record of
+// the fulfilment carried our page as its tracking URL, and the email's primary
+// button opened UPS. The 2026-08-07 milestone worked only because the mutation
+// then sent the mail itself.
+//
+// So the page's address goes on the ORDER, at enrol, before any fulfilment
+// exists: `ink.page_url`. Shopify's notification variable reference reads an
+// order's metafields as `metafields.NAMESPACE.KEY` in email templates
+// (https://help.shopify.com/en/manual/fulfillment/setup/notifications/email-variables),
+// so line 1 of the Shipping confirmation / Shipping update template can point
+// `order_status_url` at the page for every carrier, in the first email.
+//
+// THE TIMING LAW (notification-snippet.ts): a notification can only carry what
+// Shopify knows WHILE COMPOSING. The enrol lands ~5 s after the order is
+// created — too late for the Order confirmation email, which is why that
+// template keeps the order-door line. A fulfilment is never that fast, so for
+// the shipping emails a metafield written at enrol is old news by the time
+// Shopify composes them. This stamp is for those two templates and no other.
+//
+// THREE RULES, each paid for elsewhere:
+//
+//  1. THE SLUG COMES FROM THE ONE AUTHOR. `merchants/{shop_id}.brand_slug` on
+//     the backend doc, merged over the embed's own doc — the same resolution
+//     the tracking rewrite and the order door use. brand_slug ONLY: a
+//     domain-derived guess mints `sm-test-hhawzn52.in.ink`, a host that looks
+//     right and 404s (#1016), and this URL becomes the primary button of a
+//     buyer's email. No slug ⇒ no stamp, and the template falls back to the
+//     carrier link — today's behaviour, never a dead door (the Clare-V law).
+//  2. ITS OWN WIRE, ITS OWN MUTATION. metafieldsSet is atomic — "no changes
+//     are persisted if an error is encountered"
+//     (https://shopify.dev/docs/api/admin-graphql/2025-10/mutations/metafieldsSet)
+//     — so this never rides the enrol-critical batch (proof_reference,
+//     ink_token): a `url`-typed value Shopify refused would take the proof
+//     reference down with it. One guard read, one write, idempotent (the same
+//     value is never rewritten), and a one-time fallback to
+//     `single_line_text_field` if the `url` type is refused.
+//  3. NEVER FATAL. This runs on the orders/create webhook, where a non-200
+//     for any reason but the enrol itself is the one unforgivable outcome.
+//     Every ending is a named outcome, logged with the order name and the
+//     reason and never PII; a missing scope is `skipped_scope_missing`, not
+//     a throw. (Order metafields need `write_orders` — the same access as
+//     mutating the order, held since the first install:
+//     https://shopify.dev/docs/api/admin-graphql/2025-10/mutations/orderUpdate.)
+
+import { brandSlugFromDomain } from "./email.server";
+
+export const PAGE_URL_NAMESPACE = "ink";
+export const PAGE_URL_KEY = "page_url";
+/** Shopify's `url` type validates the scheme (https/http/mailto/sms/tel) and
+ *  renders as a string in Liquid; the text type is the fallback if a store
+ *  refuses it (an existing metafield of the other type, say). */
+export const PAGE_URL_TYPE = "url";
+export const PAGE_URL_FALLBACK_TYPE = "single_line_text_field";
+
+/** THE LINE SAM PASTES — line 1 of the body of "Shipping confirmation" and
+ *  "Shipping update" (Settings → Notifications → the template → Edit code).
+ *
+ *  Shopify's own variable reference reads an order's metafields as
+ *  `metafields.NAMESPACE.KEY` in email templates and says the order object
+ *  is not referenced by name there
+ *  (https://help.shopify.com/en/manual/fulfillment/setup/notifications/email-variables);
+ *  the `order.` form is kept as the second reading because it is the one most
+ *  published examples use, and Liquid treats an unknown path as blank rather
+ *  than an error. The old tracking_url line stays as the fallback, so an
+ *  order enrolled before this deployed behaves exactly as it does today.
+ *  Built from the same namespace and key the stamp writes, so the reader and
+ *  the writer cannot drift apart silently. */
+export const SHIPPING_TEMPLATE_LINE =
+  `{% if metafields.${PAGE_URL_NAMESPACE}.${PAGE_URL_KEY} != blank %}` +
+  `{% assign order_status_url = metafields.${PAGE_URL_NAMESPACE}.${PAGE_URL_KEY} %}` +
+  `{% elsif order.metafields.${PAGE_URL_NAMESPACE}.${PAGE_URL_KEY} != blank %}` +
+  `{% assign order_status_url = order.metafields.${PAGE_URL_NAMESPACE}.${PAGE_URL_KEY} %}` +
+  `{% elsif fulfillment.tracking_url %}{% assign order_status_url = fulfillment.tracking_url %}{% endif %}`;
+
+/** The two templates this line belongs in — and only these. Order
+ *  confirmation is composed before the enrol lands (notification-snippet.ts,
+ *  attempt 2) and keeps the order-door line. */
+export const SHIPPING_TEMPLATES = ["Shipping confirmation", "Shipping update"] as const;
+
+/** Every way the stamp can end, so the webhook logs the truth, not a guess. */
+export type PageUrlStampOutcome =
+  | "written"
+  | "unchanged"
+  | "skipped_no_page_url"
+  | "skipped_scope_missing"
+  | "failed";
+
+export interface PageUrlStampResult {
+  outcome: PageUrlStampOutcome;
+  value?: string;
+  /** The metafield type that landed — `url`, or the text fallback. */
+  type?: string;
+  detail?: string;
+}
+
+export type PageUrlSkipReason = "no_token" | "no_slug";
+
+export interface PageUrlResolution {
+  /** The buyer's page, or null with the reason it could not be named. */
+  pageUrl: string | null;
+  reason?: PageUrlSkipReason;
+  brandSlug: string;
+}
+
+/** The one shape of Shopify admin this needs — the real `admin.graphql` and
+ *  a test's fake both satisfy it. */
+export interface GraphqlAdmin {
+  graphql: (query: string, opts?: { variables?: Record<string, unknown> }) => Promise<Response>;
+}
+
+const GUARD_QUERY = `#graphql
+  query InkPageUrlGuard($id: ID!) {
+    order(id: $id) {
+      id
+      metafield(namespace: "ink", key: "page_url") { id value type }
+    }
+  }
+`;
+
+const SET_MUTATION = `#graphql
+  mutation InkPageUrlSet($metafields: [MetafieldsSetInput!]!) {
+    metafieldsSet(metafields: $metafields) {
+      metafields { id type value }
+      userErrors { field message code }
+    }
+  }
+`;
+
+type Loose = Record<string, unknown>;
+function loose(v: unknown): Loose {
+  return v && typeof v === "object" ? (v as Loose) : {};
+}
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** The message of a top-level GraphQL error, when Shopify sent one. */
+function firstGraphqlError(json: unknown): string | null {
+  const errors = loose(json).errors;
+  if (!Array.isArray(errors) || errors.length === 0) return null;
+  const first = loose(errors[0]);
+  const m = first.message ?? loose(first.extensions).code;
+  return m ? String(m) : null;
+}
+
+/** Shopify's own words for a scope the app does not hold — the body form
+ *  ("Access denied for metafieldsSet field. Required access: `write_orders`
+ *  access scope.") and the thrown form the client library may raise. */
+function isScopeRefusal(text: string | null | undefined): boolean {
+  return /access denied|required access|access scope|ACCESS_DENIED/i.test(String(text || ""));
+}
+
+/** THE BUYER'S PAGE FOR ONE ENROLLED ORDER — with no proof fetch.
+ *
+ *  Right after an enrol the webhook already holds the two halves of the
+ *  address: the token it minted (or the backend's aligned one on a replay)
+ *  and the backend's `shop_id` off the enrol response. Only the brand's own
+ *  subdomain label is missing, and that has one author: `brand_slug` on the
+ *  backend merchant doc, merged over the embed's (brand-page-url.server.ts).
+ *
+ *  Fail-soft: a backend doc that cannot be read leaves the embed's own doc to
+ *  answer; a doc with no brand_slug answers "no" — never a derived host. */
+export async function pageUrlForEnrolledOrder({
+  shopId,
+  nfcToken,
+  merchantData,
+  readBackendMerchantDoc = defaultReadBackendMerchantDoc,
+  label = "page-url",
+}: {
+  /** The backend's merchant identity — `shop_id` on the enrol response. */
+  shopId?: string | null;
+  nfcToken?: string | null;
+  /** The embed's own merchant doc (the activation doc the webhook read). */
+  merchantData: Record<string, unknown> | null | undefined;
+  /** Injected for tests; defaults to the app's Firestore. */
+  readBackendMerchantDoc?: (shopId: string) => Promise<Record<string, unknown> | null>;
+  label?: string;
+}): Promise<PageUrlResolution> {
+  const token = String(nfcToken || "").trim();
+  if (!token) return { pageUrl: null, reason: "no_token", brandSlug: "" };
+
+  let brandDoc: Record<string, unknown> = { ...(merchantData || {}) };
+  const backendId = String(shopId || "").trim();
+  if (backendId) {
+    try {
+      const backend = await readBackendMerchantDoc(backendId);
+      if (backend) brandDoc = { ...brandDoc, ...backend };
+    } catch (e: unknown) {
+      console.warn(
+        `🔗 ${label}: backend merchant doc ${backendId} unreadable (${messageOf(e)}) — using the embed doc for the brand.`,
+      );
+    }
+  }
+
+  // brand_slug ONLY. `brandSlugFromDoc` would fall through to the myshopify
+  // domain, and a plausible wrong host in a buyer's email is worse than the
+  // carrier link the template falls back to.
+  const brandSlug = brandSlugFromDomain(
+    typeof brandDoc.brand_slug === "string" ? brandDoc.brand_slug : "",
+  );
+  if (!brandSlug) return { pageUrl: null, reason: "no_slug", brandSlug: "" };
+
+  return { pageUrl: `https://${brandSlug}.in.ink/r/${token}`, brandSlug };
+}
+
+async function defaultReadBackendMerchantDoc(shopId: string): Promise<Record<string, unknown> | null> {
+  const { default: firestore } = await import("../firestore.server");
+  const snap = await firestore.collection("merchants").doc(shopId).get();
+  return snap.exists ? (snap.data() as Record<string, unknown> | undefined) ?? null : null;
+}
+
+/** Stamp `ink.page_url` on one order. Idempotent, typed `url` with a text
+ *  fallback, and never a throw — see the header. */
+export async function stampPageUrlOnOrder({
+  admin,
+  orderGid,
+  orderName,
+  pageUrl,
+  reason,
+  label = "page-url",
+}: {
+  admin: GraphqlAdmin;
+  orderGid: string;
+  /** For the log line only — the order's name, never the buyer's. */
+  orderName: string;
+  pageUrl: string | null | undefined;
+  /** Why there is no page URL, when there is none — named in the skip. */
+  reason?: string | null;
+  label?: string;
+}): Promise<PageUrlStampResult> {
+  const value = String(pageUrl || "").trim();
+  if (!value) {
+    console.log(
+      `🔗 ${label}: ${orderName} skipped_no_page_url — ${reason || "no page URL to stamp"}; ` +
+        `the shipping email falls back to the carrier link.`,
+    );
+    return { outcome: "skipped_no_page_url", detail: reason || undefined };
+  }
+
+  try {
+    // 1 · What does the order carry right now? Same value ⇒ done, no write.
+    const guardRes = await admin.graphql(GUARD_QUERY, { variables: { id: orderGid } });
+    const guard: unknown = await guardRes.json();
+    const guardError = firstGraphqlError(guard);
+    if (guardError && isScopeRefusal(guardError)) {
+      console.warn(`🔗 ${label}: ${orderName} skipped_scope_missing — ${guardError}`);
+      return { outcome: "skipped_scope_missing", detail: guardError };
+    }
+    const current = loose(loose(loose(loose(guard).data).order).metafield);
+    const currentValue = String(current.value || "");
+    const currentType = typeof current.type === "string" && current.type ? current.type : undefined;
+    if (currentValue === value) {
+      console.log(`🔗 ${label}: ${orderName} unchanged — the order already carries ${value}`);
+      return { outcome: "unchanged", value, type: currentType };
+    }
+
+    // 2 · Write. An existing metafield keeps its type (Shopify refuses a
+    //     type change); a new one is `url`, falling back to text once.
+    type Attempt =
+      | { ok: true }
+      | {
+          ok: false;
+          detail: string;
+          scope: boolean;
+          /** A userError is Shopify judging the INPUT — the only refusal the
+           *  type fallback answers. A top-level GraphQL error (throttled,
+           *  internal, malformed) says nothing about the type and is never
+           *  retried as one. */
+          userError: boolean;
+        };
+    const attempt = async (type: string): Promise<Attempt> => {
+      const res = await admin.graphql(SET_MUTATION, {
+        variables: {
+          metafields: [
+            { ownerId: orderGid, namespace: PAGE_URL_NAMESPACE, key: PAGE_URL_KEY, type, value },
+          ],
+        },
+      });
+      const json: unknown = await res.json();
+      const graphqlError = firstGraphqlError(json);
+      if (graphqlError) {
+        return { ok: false, detail: graphqlError, scope: isScopeRefusal(graphqlError), userError: false };
+      }
+      const userErrors = loose(loose(loose(json).data).metafieldsSet).userErrors;
+      if (Array.isArray(userErrors) && userErrors.length > 0) {
+        const detail = userErrors
+          .map((e) => {
+            const u = loose(e);
+            const field = Array.isArray(u.field) ? u.field.join(".") : "";
+            return `${field || String(u.code || "?")}: ${String(u.message)}`;
+          })
+          .join("; ");
+        return { ok: false, detail, scope: isScopeRefusal(detail), userError: true };
+      }
+      return { ok: true };
+    };
+
+    let type = currentType ?? PAGE_URL_TYPE;
+    let result = await attempt(type);
+    if (!result.ok && result.userError && !result.scope && type !== PAGE_URL_FALLBACK_TYPE) {
+      console.warn(
+        `🔗 ${label}: ${orderName} — Shopify refused type "${type}" (${result.detail}); retrying as ${PAGE_URL_FALLBACK_TYPE}.`,
+      );
+      type = PAGE_URL_FALLBACK_TYPE;
+      result = await attempt(type);
+    }
+    if (!result.ok) {
+      if (result.scope) {
+        console.warn(`🔗 ${label}: ${orderName} skipped_scope_missing — ${result.detail}`);
+        return { outcome: "skipped_scope_missing", detail: result.detail };
+      }
+      console.error(`🔗 ${label}: ${orderName} failed — Shopify refused the stamp: ${result.detail}`);
+      return { outcome: "failed", detail: result.detail };
+    }
+    console.log(`✅ ${label}: ${orderName} carries its page → ${value} (${type})`);
+    return { outcome: "written", value, type };
+  } catch (e: unknown) {
+    // Webhook discipline: a missing stamp is a carrier link in one email,
+    // never a non-200. A thrown scope refusal still says its own name.
+    const message = messageOf(e);
+    if (isScopeRefusal(message)) {
+      console.warn(`🔗 ${label}: ${orderName} skipped_scope_missing — ${message}`);
+      return { outcome: "skipped_scope_missing", detail: message };
+    }
+    console.error(`🔗 ${label}: ${orderName} failed (non-fatal) — ${message}`);
+    return { outcome: "failed", detail: message };
+  }
+}

--- a/app/services/page-url-on-the-order.test.ts
+++ b/app/services/page-url-on-the-order.test.ts
@@ -1,0 +1,418 @@
+// THE PAGE-ON-THE-ORDER CANARY — the promise that the FIRST shipping email
+// opens the buyer's page, for every carrier, with no second email.
+//
+// WHAT BROKE. Steve Madden order #1027, 2026-09-05: Shopify's record of the
+// fulfilment carried our page as its tracking URL (the rewrite ran), and the
+// shipping-confirmation email's primary button still opened ups.com — the
+// email was composed at the instant of fulfilment, when the tracking URL was
+// UPS's, and the rewrite is `notifyCustomer:false` by rule, so no email ever
+// carried the rewritten link. The 2026-08-07 milestone had worked only because
+// the mutation then sent the mail itself.
+//
+// WHAT THIS GUARDS. `stampPageUrlOnOrder` writes `ink.page_url` on the order
+// at enrol, before any fulfilment exists; `pageUrlForEnrolledOrder` names the
+// page without a proof fetch. Every branch runs against an injected
+// `admin.graphql` — no Shopify login, no network, no store — so it runs on
+// every push. The source pins at the end hold the webhook to the right place
+// and keep rule 4 (never a second shipping email) where it is.
+//
+// WHAT IT CANNOT GUARD, stated plainly: this tests that we ASK Shopify
+// correctly and that the Liquid line reads what the stamp writes. It cannot
+// tell you a buyer's inbox opened the page — that needs the embed deployed
+// after round four, one fulfilment on the Steve Madden rig with any carrier,
+// and Sam opening the email. Unit-green plus that walk is the pair.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  type GraphqlAdmin,
+  PAGE_URL_FALLBACK_TYPE,
+  PAGE_URL_KEY,
+  PAGE_URL_NAMESPACE,
+  PAGE_URL_TYPE,
+  SHIPPING_TEMPLATES,
+  SHIPPING_TEMPLATE_LINE,
+  pageUrlForEnrolledOrder,
+  stampPageUrlOnOrder,
+} from "./page-url-on-the-order.server";
+
+const ORDER = "gid://shopify/Order/6001027";
+const PAGE = "https://stevemadden.in.ink/r/nfc_mtnbfgn1_7zfyv3g3";
+
+/** A fake Shopify admin that answers the guard read and the set mutation the
+ *  way the real one does, and records every call. The recording IS the
+ *  assertion for the mutation shape. */
+function fakeAdmin(opts: {
+  /** What the order carries before we act. */
+  current?: { value: string; type?: string } | null;
+  /** Successive bodies for InkPageUrlSet; a missing one answers success. */
+  setResponses?: unknown[];
+  guardResponse?: unknown;
+  throwWith?: string;
+} = {}) {
+  const calls: Array<{ query: string; variables: Record<string, unknown> }> = [];
+  let setIndex = 0;
+  const admin: GraphqlAdmin = {
+    graphql: vi.fn(async (query: string, o?: { variables?: Record<string, unknown> }) => {
+      calls.push({ query, variables: o?.variables ?? {} });
+      if (opts.throwWith) throw new Error(opts.throwWith);
+      let body: unknown;
+      if (query.includes("InkPageUrlGuard")) {
+        body = opts.guardResponse ?? {
+          data: {
+            order: {
+              id: ORDER,
+              metafield: opts.current
+                ? { id: "gid://shopify/Metafield/1", value: opts.current.value, type: opts.current.type ?? "url" }
+                : null,
+            },
+          },
+        };
+      } else {
+        const asked = metafieldOf(o?.variables ?? {});
+        body = opts.setResponses?.[setIndex++] ?? {
+          data: {
+            metafieldsSet: {
+              metafields: [{ id: "gid://shopify/Metafield/2", type: asked.type, value: asked.value }],
+              userErrors: [],
+            },
+          },
+        };
+      }
+      return { json: async () => body } as unknown as Response;
+    }),
+  };
+  const sets = () => calls.filter((c) => c.query.includes("InkPageUrlSet"));
+  return { admin, calls, sets };
+}
+
+/** The one metafield a set call carries — the shape the assertions read. */
+function metafieldOf(variables: Record<string, unknown>): Record<string, unknown> {
+  const list = variables.metafields;
+  return Array.isArray(list) && list[0] && typeof list[0] === "object" ? (list[0] as Record<string, unknown>) : {};
+}
+
+const stamp = (admin: GraphqlAdmin, over: Record<string, unknown> = {}) =>
+  stampPageUrlOnOrder({ admin, orderGid: ORDER, orderName: "#1027", pageUrl: PAGE, ...over });
+
+let logs: string[] = [];
+beforeEach(() => {
+  logs = [];
+  vi.spyOn(console, "log").mockImplementation((...a) => void logs.push(a.join(" ")));
+  vi.spyOn(console, "warn").mockImplementation((...a) => void logs.push(a.join(" ")));
+  vi.spyOn(console, "error").mockImplementation((...a) => void logs.push(a.join(" ")));
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("the stamp — the happy path writes exactly what the template reads", () => {
+  it("puts the page on the order as ink.page_url, typed url, and says so", async () => {
+    const { admin, sets } = fakeAdmin({ current: null });
+    const out = await stamp(admin);
+
+    expect(out).toMatchObject({ outcome: "written", value: PAGE, type: "url" });
+    expect(sets()).toHaveLength(1);
+    expect(sets()[0].variables.metafields).toEqual([
+      { ownerId: ORDER, namespace: "ink", key: "page_url", type: "url", value: PAGE },
+    ]);
+    expect(metafieldOf(sets()[0].variables)).toMatchObject({ namespace: PAGE_URL_NAMESPACE, key: PAGE_URL_KEY });
+    expect(logs.join("\n")).toContain("#1027");
+  });
+
+  it("guards on the same namespace and key it writes", async () => {
+    const { admin, calls } = fakeAdmin({ current: null });
+    await stamp(admin);
+    const guard = calls.find((c) => c.query.includes("InkPageUrlGuard"));
+    expect(guard?.variables).toEqual({ id: ORDER });
+    expect(guard?.query).toContain(`namespace: "${PAGE_URL_NAMESPACE}", key: "${PAGE_URL_KEY}"`);
+  });
+});
+
+describe("the stamp — idempotent, one order at a time", () => {
+  it("the same value is never rewritten: one read, no write", async () => {
+    const { admin, calls, sets } = fakeAdmin({ current: { value: PAGE } });
+    const out = await stamp(admin);
+
+    expect(out.outcome).toBe("unchanged");
+    expect(calls).toHaveLength(1);
+    expect(sets()).toHaveLength(0);
+  });
+
+  it("a different value is rewritten (a brand renamed, a page re-minted)", async () => {
+    const { admin, sets } = fakeAdmin({ current: { value: "https://old.in.ink/r/nfc_old" } });
+    const out = await stamp(admin);
+
+    expect(out.outcome).toBe("written");
+    expect(metafieldOf(sets()[0].variables).value).toBe(PAGE);
+  });
+
+  it("an existing text-typed metafield keeps its type — no wasted refusal", async () => {
+    // Shopify refuses a type change on an existing metafield; asking for
+    // `url` first would cost a round trip that always fails.
+    const { admin, sets } = fakeAdmin({ current: { value: "https://old.in.ink/r/x", type: PAGE_URL_FALLBACK_TYPE } });
+    const out = await stamp(admin);
+
+    expect(out).toMatchObject({ outcome: "written", type: PAGE_URL_FALLBACK_TYPE });
+    expect(sets()).toHaveLength(1);
+    expect(metafieldOf(sets()[0].variables).type).toBe(PAGE_URL_FALLBACK_TYPE);
+  });
+});
+
+describe("the stamp — Shopify's refusals are outcomes, never exceptions", () => {
+  const refusedUrl = {
+    data: {
+      metafieldsSet: {
+        metafields: [],
+        userErrors: [{ field: ["metafields", "0", "type"], message: "Type is invalid", code: "INVALID_TYPE" }],
+      },
+    },
+  };
+
+  it("a refused `url` type falls back to single_line_text_field, once", async () => {
+    const { admin, sets } = fakeAdmin({ current: null, setResponses: [refusedUrl] });
+    const out = await stamp(admin);
+
+    expect(out).toMatchObject({ outcome: "written", type: PAGE_URL_FALLBACK_TYPE, value: PAGE });
+    expect(sets().map((c) => metafieldOf(c.variables).type)).toEqual([PAGE_URL_TYPE, PAGE_URL_FALLBACK_TYPE]);
+    expect(logs.join("\n")).toContain("retrying as single_line_text_field");
+  });
+
+  it("both types refused ⇒ failed, in Shopify's own words, and the webhook lives", async () => {
+    const { admin, sets } = fakeAdmin({ current: null, setResponses: [refusedUrl, refusedUrl] });
+    const out = await stamp(admin);
+
+    expect(out.outcome).toBe("failed");
+    expect(out.detail).toContain("Type is invalid");
+    expect(sets()).toHaveLength(2);
+    expect(logs.join("\n")).toContain("#1027 failed");
+  });
+
+  it("a scope the app does not hold is skipped_scope_missing — named, not retried", async () => {
+    const denied = {
+      errors: [
+        {
+          message: "Access denied for metafieldsSet field. Required access: `write_orders` access scope.",
+          extensions: { code: "ACCESS_DENIED" },
+        },
+      ],
+      data: null,
+    };
+    const { admin, sets } = fakeAdmin({ current: null, setResponses: [denied] });
+    const out = await stamp(admin);
+
+    expect(out.outcome).toBe("skipped_scope_missing");
+    expect(out.detail).toContain("write_orders");
+    expect(sets()).toHaveLength(1);
+    expect(logs.join("\n")).toContain("skipped_scope_missing");
+  });
+
+  it("a scope refusal on the guard read is the same skip, and writes nothing", async () => {
+    const { admin, sets } = fakeAdmin({
+      guardResponse: {
+        errors: [{ message: "Access denied for order field. Required access: `read_orders` access scope." }],
+        data: null,
+      },
+    });
+    const out = await stamp(admin);
+
+    expect(out.outcome).toBe("skipped_scope_missing");
+    expect(sets()).toHaveLength(0);
+  });
+
+  it("a thrown request is non-fatal — the webhook must still return 200", async () => {
+    const { admin } = fakeAdmin({ throwWith: "socket hang up" });
+    const out = await stamp(admin);
+
+    expect(out.outcome).toBe("failed");
+    expect(out.detail).toContain("socket hang up");
+  });
+
+  it("a thrown scope refusal (the client library's form) still says its own name", async () => {
+    const { admin } = fakeAdmin({ throwWith: "GraphQL query returned errors: Access denied for metafieldsSet field. Required access: `write_orders` access scope." });
+    const out = await stamp(admin);
+
+    expect(out.outcome).toBe("skipped_scope_missing");
+  });
+
+  it("an unexpected GraphQL error on the write is failed, not silently green", async () => {
+    const { admin } = fakeAdmin({
+      current: null,
+      setResponses: [{ errors: [{ message: "Internal error. Looks like something went wrong on our end." }] }],
+    });
+    const out = await stamp(admin);
+
+    expect(out.outcome).toBe("failed");
+    expect(out.detail).toContain("Internal error");
+  });
+});
+
+describe("the stamp — nothing to stamp is a named skip, and Shopify is left alone", () => {
+  it("no page URL ⇒ skipped_no_page_url, zero calls, the reason in the log", async () => {
+    const { admin, calls } = fakeAdmin();
+    const out = await stamp(admin, { pageUrl: null, reason: "no brand_slug on the merchant doc" });
+
+    expect(out).toMatchObject({ outcome: "skipped_no_page_url", detail: "no brand_slug on the merchant doc" });
+    expect(calls).toHaveLength(0);
+    expect(logs.join("\n")).toContain("skipped_no_page_url — no brand_slug on the merchant doc");
+  });
+});
+
+describe("the resolver — the page's address without a proof fetch", () => {
+  const EMBED_DOC = { shop: "sm-test-hhawzn52.myshopify.com", ink_api_key: "ink_x", shop_domain: "sm-test-hhawzn52.myshopify.com" };
+
+  it("the backend doc's brand_slug names the host — the one author", async () => {
+    const read = vi.fn(async () => ({ brand_slug: "stevemadden", status: "active" }));
+    const out = await pageUrlForEnrolledOrder({
+      shopId: "shop_bb508e5ca47a1036",
+      nfcToken: "nfc_mtnbfgn1_7zfyv3g3",
+      merchantData: EMBED_DOC,
+      readBackendMerchantDoc: read,
+    });
+
+    expect(out).toEqual({ pageUrl: PAGE, brandSlug: "stevemadden" });
+    expect(read).toHaveBeenCalledWith("shop_bb508e5ca47a1036");
+  });
+
+  it("no brand_slug anywhere ⇒ no page — NEVER the myshopify domain (#1016)", async () => {
+    const out = await pageUrlForEnrolledOrder({
+      shopId: "shop_1",
+      nfcToken: "nfc_tok",
+      merchantData: EMBED_DOC,
+      readBackendMerchantDoc: async () => ({ status: "active" }),
+    });
+
+    expect(out.pageUrl).toBeNull();
+    expect(out.reason).toBe("no_slug");
+    expect(JSON.stringify(out)).not.toContain("sm-test-hhawzn52");
+  });
+
+  it("no token ⇒ no page, and the backend doc is never read", async () => {
+    const read = vi.fn();
+    const out = await pageUrlForEnrolledOrder({ shopId: "shop_1", nfcToken: "", merchantData: EMBED_DOC, readBackendMerchantDoc: read });
+
+    expect(out.reason).toBe("no_token");
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("a backend doc that cannot be read leaves the embed doc to answer (fail-soft)", async () => {
+    const out = await pageUrlForEnrolledOrder({
+      shopId: "shop_1",
+      nfcToken: "nfc_tok",
+      merchantData: { ...EMBED_DOC, brand_slug: "clarev" },
+      readBackendMerchantDoc: async () => {
+        throw new Error("DEADLINE_EXCEEDED");
+      },
+    });
+
+    expect(out.pageUrl).toBe("https://clarev.in.ink/r/nfc_tok");
+    expect(logs.join("\n")).toContain("DEADLINE_EXCEEDED");
+  });
+
+  it("no backend identity on the enrol response ⇒ the embed doc alone, no read", async () => {
+    const read = vi.fn();
+    const out = await pageUrlForEnrolledOrder({
+      shopId: null,
+      nfcToken: "nfc_tok",
+      merchantData: { brand_slug: "clarev" },
+      readBackendMerchantDoc: read,
+    });
+
+    expect(out.pageUrl).toBe("https://clarev.in.ink/r/nfc_tok");
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("the slug is normalised the way every other builder normalises it", async () => {
+    const out = await pageUrlForEnrolledOrder({
+      nfcToken: "nfc_tok",
+      merchantData: { brand_slug: "https://www.StéveMadden.com/" },
+      readBackendMerchantDoc: async () => null,
+    });
+    expect(out.pageUrl).toBe("https://stevemadden.in.ink/r/nfc_tok");
+  });
+});
+
+// ── The Liquid line Sam pastes reads what the stamp writes ──────────────────
+describe("the template line and the stamp are one contract", () => {
+  it("reads metafields.ink.page_url first, in Shopify's documented email form", () => {
+    expect(SHIPPING_TEMPLATE_LINE.startsWith(`{% if metafields.${PAGE_URL_NAMESPACE}.${PAGE_URL_KEY} != blank %}`)).toBe(true);
+    expect(SHIPPING_TEMPLATE_LINE).toContain(`{% assign order_status_url = metafields.${PAGE_URL_NAMESPACE}.${PAGE_URL_KEY} %}`);
+  });
+
+  it("keeps the order. form as the second reading", () => {
+    expect(SHIPPING_TEMPLATE_LINE).toContain(`{% elsif order.metafields.${PAGE_URL_NAMESPACE}.${PAGE_URL_KEY} != blank %}`);
+  });
+
+  it("keeps the 2026-08-07 tracking_url line as the fallback AFTER the page", () => {
+    const page = SHIPPING_TEMPLATE_LINE.indexOf("metafields.ink.page_url");
+    const fallback = SHIPPING_TEMPLATE_LINE.indexOf("{% elsif fulfillment.tracking_url %}{% assign order_status_url = fulfillment.tracking_url %}{% endif %}");
+    expect(page).toBeGreaterThan(-1);
+    expect(fallback).toBeGreaterThan(page);
+    expect(SHIPPING_TEMPLATE_LINE.endsWith("{% endif %}")).toBe(true);
+  });
+
+  it("is one line — it is pasted as line 1 of the body", () => {
+    expect(SHIPPING_TEMPLATE_LINE).not.toContain("\n");
+  });
+
+  it("belongs in the two shipping templates and no other (the timing law)", () => {
+    expect([...SHIPPING_TEMPLATES]).toEqual(["Shipping confirmation", "Shipping update"]);
+  });
+});
+
+// ── The webhook wires it in the right place ─────────────────────────────────
+//
+// Read from the route's source, the way enroll-survives-enrichment.test.ts
+// does: the stamp must sit AFTER the enrol, INSIDE the activates branch, on
+// its own wire, and never be able to fail the webhook.
+describe("webhooks/orders_create carries the stamp where the slice allows it", () => {
+  const ROUTE_SRC = readFileSync(
+    fileURLToPath(new URL("../routes/webhooks.orders_create.ts", import.meta.url)),
+    "utf8",
+  );
+
+  it("resolves the page and stamps it after a successful enrol", () => {
+    expect(ROUTE_SRC).toContain("pageUrlForEnrolledOrder(");
+    expect(ROUTE_SRC).toContain("stampPageUrlOnOrder(");
+    expect(ROUTE_SRC).toMatch(/proofShopId = String\(inkData\?\.shop_id/);
+  });
+
+  it("sits inside the activates branch, after the enrol-critical batch", () => {
+    const batchEnd = ROUTE_SRC.indexOf('Metafields initialized for ${orderName}');
+    const stampAt = ROUTE_SRC.indexOf("stampPageUrlOnOrder(");
+    const outerCatch = ROUTE_SRC.indexOf("} catch (error: any) {");
+    expect(batchEnd).toBeGreaterThan(-1);
+    expect(stampAt).toBeGreaterThan(batchEnd);
+    expect(stampAt).toBeLessThan(outerCatch);
+  });
+
+  it("never rides the atomic enrol-critical batch", () => {
+    // metafieldsSet is atomic: a refused page_url would take proof_reference
+    // down with it. The batch's own variables must not know the key.
+    const start = ROUTE_SRC.indexOf('key: "verification_status"');
+    const end = ROUTE_SRC.indexOf('.filter((m) => m.value !== "")');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(ROUTE_SRC.slice(start, end)).not.toContain("page_url");
+  });
+
+  it("cannot fail the webhook — wrapped, and a skip says its own name", () => {
+    const block = ROUTE_SRC.slice(ROUTE_SRC.indexOf("if (proofReference && inkToken) {"), ROUTE_SRC.indexOf("} catch (error: any) {"));
+    expect(block).toContain("catch (stampErr");
+    expect(block).toContain("skipped_no_token");
+  });
+});
+
+// ── Rule 4 stays: never a second shipping email ─────────────────────────────
+describe("the tracking rewrite is untouched — belt and braces, and still silent", () => {
+  const REWRITE_SRC = readFileSync(
+    fileURLToPath(new URL("./branded-tracking-link.server.ts", import.meta.url)),
+    "utf8",
+  );
+
+  it("keeps notifyCustomer:false — the fix is the stamp, not a re-send", () => {
+    expect(REWRITE_SRC).toContain("notifyCustomer: false");
+    expect(REWRITE_SRC).not.toContain("notifyCustomer: true");
+  });
+});


### PR DESCRIPTION
> **HELD FOR ROUND FOUR.** Open, never merged, never deployed until Shopify answers the 2026-09-04 resubmission. Merging deploys Cloud Run automatically.

## What a person sees

A buyer's shipping-confirmation email opens their page — `https://{brand}.in.ink/r/{token}` — from its primary button, for every carrier, in the first email, with no second email. Today that button opens ups.com (measured on Steve Madden order #1027, 2026-09-05): Shopify composes the email at the instant of fulfilment, when `fulfillment.tracking_url` is still the carrier's, and our rewrite of that URL runs afterwards with `notifyCustomer:false` by rule, so no email ever carried it. The 2026-08-07 milestone worked only because the mutation then sent the mail itself.

## What changes

- **The page is stamped on the order at enrol**, before any fulfilment exists: order metafield `ink.page_url`, type `url` (falls back to `single_line_text_field` if a store refuses the type), value `https://{brand_slug}.in.ink/r/{nfc_token}`. New service `app/services/page-url-on-the-order.server.ts`; wired into `app/routes/webhooks.orders_create.ts` right after a successful enrol, inside the slice gate (an out-of-slice order gets no `ink.*` metafield, as before).
- **One author for the host.** The brand slug comes from `merchants/{shop_id}.brand_slug` on the backend doc (the `shop_id` off the enrol response) merged over the embed's doc — the same resolution the tracking rewrite and the order door use. `brand_slug` only: no slug means no stamp and the template falls back to the carrier link, never a derived host that 404s (#1016).
- **Its own wire, its own mutation.** `metafieldsSet` is atomic, so the stamp never rides the enrol-critical batch (a refused value would take `proof_reference` down with it). One guard read, one write; the same value is never rewritten.
- **Never fatal, every skip named:** `written` · `unchanged` · `skipped_no_page_url` (with `no_slug` / `no_token`) · `skipped_scope_missing` · `failed`, each logged with the order name and Shopify's own words, no PII. A redelivery of an already-enrolled order logs `skipped_no_token` (the enrolling delivery stamped it).
- **`branded-tracking-link.server.ts` is untouched** — belt and braces for the "Track shipment" link on the order status page, still `notifyCustomer:false` (a test pins it).
- **Scope: nothing new.** Setting a metafield needs the same access as mutating its owner (https://shopify.dev/docs/api/admin-graphql/2025-10/mutations/metafieldsSet), and mutating an order is `write_orders` (https://shopify.dev/docs/api/admin-graphql/2025-10/mutations/orderUpdate). `write_orders` is already in `shopify.app.toml` and `app/shopify.server.ts`, and this webhook already writes `ink.*` order metafields with it, so #103's optional-scope pattern is not needed, no merchant re-consents, and the reviewed scope set is unchanged. Shopify's validator confirms the guard read needs `read_orders` (held).
- **Liquid, verified against the docs.** Shopify's notification variable reference reads an order's metafields as `metafields.NAMESPACE.KEY` in email templates and says the order object is not referenced by name there (https://help.shopify.com/en/manual/fulfillment/setup/notifications/email-variables); the Liquid `order` object also exposes `metafields` (https://shopify.dev/docs/api/liquid/objects/order), so the line below reads both forms. Metafields in a plain namespace like `ink` are merchant-owned and accessible in Liquid regardless of storefront access settings (https://shopify.dev/docs/apps/build/custom-data/permissions), so **no metafield definition is created or required**. The `url` type accepts `https` (https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types).
- **Why this works for shipping emails and not order confirmation:** the repo's own timing law (`notification-snippet.ts`): a notification can only carry what Shopify knows while composing. The enrol lands ~5 s after the order is created — too late for the Order confirmation email, which keeps the order-door line from the Notifications card. A fulfilment is never that fast, so the stamp is old news by the time the shipping emails compose. The Notifications card's paste is unchanged.
- **Backfill: none.** Orders enrolled before this deploys carry no stamp; their shipping emails keep today's behaviour through the fallback.

## Tests

`app/services/page-url-on-the-order.test.ts`, mirroring the branded-tracking canary: 29 tests against a fake `admin.graphql` — happy path writes the right owner/namespace/key/type/value · idempotent on the same value (one read, no write) · a changed value rewrites · an existing text-typed metafield keeps its type · `url` refused → one retry as text · both refused → `failed`, never a throw · scope missing on the write or the guard read → `skipped_scope_missing` · thrown request → `failed` · thrown scope refusal still names itself · unexpected GraphQL error is `failed`, not retried as a type (this test went red before the fix and caught a real gap) · no page URL → named skip, zero calls · the resolver (backend `brand_slug` wins, never the myshopify domain, fail-soft backend read, slug normalisation) · the Liquid line reads what the stamp writes · source pins on the webhook (after the enrol, inside the slice gate, off the atomic batch, wrapped) and on the rewrite's `notifyCustomer:false`. Both GraphQL blocks validated against the 2025-10 Admin schema with Shopify's dev MCP validator.

Gates on the branch, each as `cmd > log 2>&1; code=$?`:

| Gate | Exit |
|---|---|
| `npm run typecheck` | 0 |
| `npm run build` | 0 |
| `npm test` (vitest) | 0 — 16 files, 161 tests (132 existing + 29 new) |
| `npm run lint` (whole repo) | 1 — 469 problems, identical to `origin/main`'s 469 (lint is not a CI gate here by design) |
| `npx eslint` on the three touched files | 1 — 13 problems, all pre-existing in `webhooks.orders_create.ts` (13 on main too); both new files: 0 |

## Six facts

written ✓ · committed ✓ (`9871d77`) · pushed ✓ · **not merged** · **not deployed** · **verified by tests only** — the wire cannot be proven until the embed deploys after round four; no shipping email has been opened with this code running.

## New surfaces

None.

## For Sam

**The one line, pasted by hand (no API can edit a notification template).** Shopify admin → Settings → Notifications → Customer notifications → **Shipping confirmation** → Edit code → paste this as **line 1 of the body**, above everything else — and replace the old line from 2026-08-07 (`{% if fulfillment.tracking_url %}…`) if it is there. Then the same for **Shipping update**.

```liquid
{% if metafields.ink.page_url != blank %}{% assign order_status_url = metafields.ink.page_url %}{% elsif order.metafields.ink.page_url != blank %}{% assign order_status_url = order.metafields.ink.page_url %}{% elsif fulfillment.tracking_url %}{% assign order_status_url = fulfillment.tracking_url %}{% endif %}
```

- It reads the page first, in both spellings Shopify documents, and falls back to the old tracking-URL line, so an order from before the deploy behaves exactly as today.
- **Do not paste it into Order confirmation** — that email is composed before the page exists; that template keeps the order-door line from the app's Notifications card. The same line does also work in Out for delivery and Delivered.
- **Scope: no change**, so this PR alone does not need a resubmission and nobody presses Allow. If round four changes the reviewed scope set for another reason (#103 / #104), that is theirs, not this PR's.

**After round four, in order:** merge this PR (Cloud Run deploys itself, ~5–6 min; confirm the serving revision flipped) → no `shopify app deploy` is needed for this PR (nothing in the app config changed; if it runs for #103/#104 anyway, this PR is unaffected) → paste the line into the two templates → place a **new** order on Steve Madden (the stamp lands at enrol, so an order created before the deploy carries none) → fulfil it with any carrier, "Send shipment details to your customer" on → open the email → the primary button opens `stevemadden.in.ink/r/…`. The Cloud Run log line for the order reads `✅ [orders/create] page-url: #10xx carries its page → https://stevemadden.in.ink/r/…`.

**Addendum, 2026-09-05 (Sam asked for a fix that does not wait).** The order-door line the app's Notifications card already generates works in the two shipping templates today, with no deploy: it is built from `order_number`, which Shopify knows while composing, and the door lands on the page at tap time (measured: `https://stevemadden.in.ink/o/1027` → 302 → the page, 1.5 s). Sam is pasting it now as line 1 of Shipping confirmation and Shipping update:

```liquid
{% assign order_status_url = "https://stevemadden.in.ink/o/" | append: order_number %}
```

**After this PR deploys, replace that door line with this one** (Steve Madden's; another store swaps the host). It reads the page's own address first and keeps the door as the fallback, so nothing pasted today is undone and the carrier link never wins:

```liquid
{% if metafields.ink.page_url != blank %}{% assign order_status_url = metafields.ink.page_url %}{% elsif order.metafields.ink.page_url != blank %}{% assign order_status_url = order.metafields.ink.page_url %}{% else %}{% assign order_status_url = "https://stevemadden.in.ink/o/" | append: order_number %}{% endif %}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

