### PR TITLE
HELD FOR ROUND FOUR — The block on the order status page, proven, and why it cannot read the order's page

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -89,6 +89,18 @@ module.exports = {
         node: true,
       },
     },
+
+    // Extension tests. The extension itself runs in Shopify's sandbox off the
+    // `shopify` and `document` globals; its tests run under vitest in node and
+    // swap those globals in and out, so they need `globalThis` — an ES2020
+    // name the base `es6` env does not know.
+    {
+      files: ["extensions/**/*.test.{js,ts}"],
+      env: {
+        node: true,
+        es2022: true,
+      },
+    },
   ],
   globals: {
     shopify: "readonly"

--- a/app/services/order-door-metafield.test.ts
+++ b/app/services/order-door-metafield.test.ts
@@ -8,13 +8,17 @@
 //  · a webhook path that throws
 //  · the writer and the extension disagreeing about what a door looks like
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 
 const resolveBrandPageUrl = vi.hoisted(() => vi.fn());
 vi.mock("./brand-page-url.server", () => ({ resolveBrandPageUrl }));
 
 import { assertOrderDoorMetafield, orderDoorBase } from "./order-door-metafield.server";
+// The other half of the contract, imported rather than scraped.
+import {
+  DOOR_KEY,
+  isOrderDoorBase,
+  linkForOrder,
+} from "../../extensions/order-page-block/src/order-page-block.js";
 
 /** An admin.graphql that answers the guard query and records every call. */
 function fakeAdmin(opts: { current?: string | null; failWith?: string }) {
@@ -140,31 +144,49 @@ describe("assertOrderDoorMetafield", () => {
 
 // ── The writer and the extension are one contract ───────────────────────────
 //
-// The extension trusts only values matching its own regex; the writer mints
+// The extension trusts only values passing its own gate; the writer mints
 // values from orderDoorBase. If either side moves alone, the block silently
 // renders nothing on every store — this is the test that refuses that.
+//
+// It used to scrape the extension's source for its regex literal. It now
+// imports the extension's own functions and runs them: the same contract,
+// pinned by behaviour instead of by text, so a rewrite that keeps the meaning
+// stays green and a rewrite that loses it goes red. The block's own tests are
+// extensions/order-page-block/src/order-page-block.test.js.
 describe("the extension trusts exactly what the writer writes", () => {
-  const SRC = readFileSync(
-    resolve(process.cwd(), "extensions/order-page-block/src/order-page-block.js"),
-    "utf8",
-  );
-
   it("the writer's value passes the extension's own gate", () => {
-    const m = SRC.match(/\/\^https:[^/]*\\\/\\\/(.+?)\/\.test\(base\)/);
-    expect(m, "extension no longer gates door values with a regex").toBeTruthy();
-    const gate = new RegExp(`^https:\\/\\/${m![1]}`);
-    expect(gate.test(orderDoorBase("stevemadden"))).toBe(true);
+    expect(isOrderDoorBase(orderDoorBase("stevemadden"))).toBe(true);
+    expect(isOrderDoorBase(orderDoorBase("betsey-johnson"))).toBe(true);
     // And the gate still refuses what it exists to refuse.
-    expect(gate.test("http://stevemadden.in.ink/o/")).toBe(false);
-    expect(gate.test("https://evil.example.com/o/")).toBe(false);
+    expect(isOrderDoorBase("http://stevemadden.in.ink/o/")).toBe(false);
+    expect(isOrderDoorBase("https://evil.example.com/o/")).toBe(false);
   });
 
-  it("the block renders nothing without a door, and never fetches", () => {
-    expect(SRC).toContain("if (!base || !digits) return");
-    expect(SRC).not.toContain("fetch(");
+  it("the writer's door and this order's number make the link the block renders", () => {
+    expect(
+      linkForOrder({
+        appMetafields: [{ metafield: { key: DOOR_KEY, value: orderDoorBase("stevemadden") } }],
+        orderName: "#1027",
+      }),
+    ).toBe("https://stevemadden.in.ink/o/1027");
   });
 
-  it("the block appends digits only — the door compares on digits alone", () => {
-    expect(SRC).toContain('.replace(/\\D/g, "")');
+  it("a writer that stopped minting doors takes the surface down, not a wrong link", () => {
+    // The one failure mode this pairing exists to catch: the writer changing
+    // shape (a trailing slash lost, a scheme downgraded, a host derived) while
+    // the extension keeps its gate. The block goes dark; it never guesses.
+    for (const drifted of [
+      "https://stevemadden.in.ink/o",
+      "http://stevemadden.in.ink/o/",
+      "https://sm-test-hhawzn52.myshopify.com/o/",
+    ]) {
+      expect(
+        linkForOrder({
+          appMetafields: [{ metafield: { key: DOOR_KEY, value: drifted } }],
+          orderName: "#1027",
+        }),
+        `a drifted writer value reached a buyer: ${drifted}`,
+      ).toBeNull();
+    }
   });
 });

--- a/extensions/order-page-block/shopify.extension.toml
+++ b/extensions/order-page-block/shopify.extension.toml
@@ -37,7 +37,23 @@ handle = "order-page-block"
 
   # The one piece of app data the block needs: the brand's own door base,
   # e.g. https://stevemadden.in.ink/o/ — written on the SHOP by the embed at
-  # enroll time. Declared here so the runtime delivers it via appMetafields.
+  # enroll time. Declared here so the runtime delivers it via appMetafields;
+  # "Only metafields declared in your shopify.extension.toml are available"
+  # (shopify.dev, customer-account-ui-extensions → order-apis/metafields-api).
+  #
+  # ⚠️ DO NOT ADD `ink / page_url` HERE. The order's own exact page address is
+  # stamped on the ORDER at enrol (page-url-on-the-order.server.ts) and reading
+  # it here would spare the redirect hop — it cannot be read, and adding the
+  # declaration would silently deliver nothing. Measured 2026-09-05:
+  # `AppMetafieldEntryTarget.type` on this target is customer · product · shop
+  # · shopUser · variant · company · companyLocation · cart — there is no
+  # `order`; the separate `metafields` property that 2025-10 documented as
+  # "The metafields associated with the order" is gone in 2026-07; and `ink`
+  # is a merchant-owned namespace, so Customer Account access is "Hidden from
+  # Customer Accounts API (default)" and "can only be configured through the
+  # Shopify admin" — per store, by hand, i.e. the Liquid paste again.
+  # `shop` is an owner type, so the door below is the mechanism, not a
+  # consolation. Full reasoning in src/order-page-block.js's header.
   [[extensions.metafields]]
   namespace = "ink"
   key = "order_door"

--- a/extensions/order-page-block/src/order-page-block.js
+++ b/extensions/order-page-block/src/order-page-block.js
@@ -2,7 +2,37 @@
 //
 // The buyer clicked "View your order" in Shopify's own email. This block is
 // standing on the page that button opens, holding the one link the email
-// itself could not carry: {brand}.in.ink/o/{order_number}.
+// itself could not carry: {brand}.in.ink/o/{order_number}, which 302s to the
+// buyer's page.
+//
+// WHY IT COMPOSES THE DOOR INSTEAD OF READING THE PAGE'S OWN ADDRESS.
+// The exact address — https://{brand}.in.ink/r/{token} — is stamped on the
+// ORDER at enrol as `ink.page_url` (page-url-on-the-order.server.ts), and
+// reading it here would spare the redirect and the order-number match. It
+// cannot be read. Measured against shopify.dev on 2026-09-05, three walls,
+// any one of them fatal:
+//
+//   1. NO ORDER OWNER. `appMetafields` is the only metafields property this
+//      target has on api_version 2026-07, and `AppMetafieldEntryTarget.type`
+//      is customer · product · shop · shopUser · variant · company ·
+//      companyLocation · cart. There is no `order`.
+//      (customer-account-ui-extensions/2026-07/target-apis/order-apis/
+//      metafields-api)
+//   2. THE ORDER-METAFIELD ACCESSOR IS GONE. 2025-10 documented a second
+//      root property, `metafields` — "The metafields associated with the
+//      order." 2026-07 documents `appMetafields` and nothing else.
+//   3. AN UNRESERVED NAMESPACE IS HIDDEN ANYWAY. `ink` is merchant-owned, so
+//      its Customer Account API access is "Hidden from Customer Accounts API
+//      (default)" and "can only be configured through the Shopify admin"
+//      (apps/custom-data/metafields/definitions/access-controls). No app-side
+//      mutation can grant it — a merchant would have to switch it on by hand,
+//      per store, which is the Liquid paste wearing a different hat.
+//
+// So the shop's door is not a fallback here. It is the mechanism: one
+// metafield on the SHOP (`shop` IS an appMetafields owner), the order number
+// the page already knows, zero merchant work, every store. `ink.page_url`
+// stays on the order for Shopify's own notification templates, which read it
+// in Liquid where none of the three walls apply.
 //
 // TWO REFUSALS, both load-bearing:
 //
@@ -19,36 +49,67 @@
 // The order number arrives as `order.name` ("#1023"); the door compares on
 // digits alone (worker order-door law), so digits are what we append.
 
-const DOOR_KEY = "order_door";
+export const DOOR_NAMESPACE = "ink";
+export const DOOR_KEY = "order_door";
 
-/** The door base from OUR declared shop metafield, or null. Only an
- *  https://{label}.in.ink/o/ base is a door; anything else renders nothing. */
-function doorBase() {
-  const entries = (shopify.appMetafields && shopify.appMetafields.value) || [];
-  for (const entry of entries) {
+/** The only shape of door this block will send a buyer to: the brand's own
+ *  host, path exactly /o/. Deliberately narrow — no query, no fragment, no
+ *  userinfo, no port, no uppercase host. */
+const DOOR_BASE_GATE = /^https:\/\/[a-z0-9][a-z0-9-]*\.in\.ink\/o\/$/;
+
+/** True only for a door base of the shape the embed's writer produces. */
+export function isOrderDoorBase(value) {
+  return DOOR_BASE_GATE.test(String(value || "").trim());
+}
+
+/** Unwrap a runtime signal (`{value}`) or take a plain array as it comes.
+ *  appMetafields arrives as a signal that may fill after first paint;
+ *  reading both shapes means neither can silently blank the block. */
+function listOf(source) {
+  if (!source) return [];
+  const raw = Array.isArray(source) ? source : source.value;
+  return Array.isArray(raw) ? raw : [];
+}
+
+/** The door base from OUR declared shop metafield, or null. Only the shop's
+ *  own entry counts: an app metafield on any other owner is not this brand's
+ *  door. */
+export function doorBaseFromAppMetafields(appMetafields) {
+  for (const entry of listOf(appMetafields)) {
     const m = entry && entry.metafield;
     const target = entry && entry.target;
     if (!m || m.key !== DOOR_KEY) continue;
     if (target && target.type && target.type !== "shop") continue;
     const base = String(m.value || "").trim();
-    if (/^https:\/\/[a-z0-9][a-z0-9-]*\.in\.ink\/o\/$/.test(base)) return base;
+    if (isOrderDoorBase(base)) return base;
   }
   return null;
 }
 
-function orderDigits() {
-  const order = shopify.order && shopify.order.value;
-  return String((order && order.name) || "").replace(/\D/g, "");
+/** "#1023" → "1023". The door compares on digits alone. */
+export function orderDigitsFromName(name) {
+  return String(name || "").replace(/\D/g, "");
+}
+
+/** The one link this block will render, or null for no surface at all. */
+export function linkForOrder({ appMetafields, orderName } = {}) {
+  const base = doorBaseFromAppMetafields(appMetafields);
+  const digits = orderDigitsFromName(orderName);
+  if (!base || !digits) return null; // no door, no surface
+  return base + digits;
 }
 
 export default async () => {
   const root = document.body;
 
   const render = () => {
-    const base = doorBase();
-    const digits = orderDigits();
+    const order = shopify.order && shopify.order.value;
+    const link = linkForOrder({
+      appMetafields: shopify.appMetafields,
+      orderName: order && order.name,
+    });
     root.replaceChildren();
-    if (!base || !digits) return; // no door, no surface
+    if (!link) return; // no door, no surface
 
     const stack = document.createElement("s-stack");
     stack.setAttribute("gap", "base");
@@ -65,7 +126,7 @@ export default async () => {
     line.textContent = "Delivery updates and help for this order.";
 
     const button = document.createElement("s-button");
-    button.setAttribute("href", base + digits);
+    button.setAttribute("href", link);
     button.setAttribute("variant", "primary");
     button.textContent = "Open the page";
 

--- a/extensions/order-page-block/src/order-page-block.test.js
+++ b/extensions/order-page-block/src/order-page-block.test.js
@@ -1,0 +1,246 @@
+// THE BLOCK ON THE ORDER STATUS PAGE — outcome tests.
+//
+// This module is the only buyer-facing code in the repo that typecheck and
+// build never see (plain JS, outside tsconfig's include, bundled only by
+// `shopify app deploy`). What it decides is which address a buyer taps out of
+// a shipping email — so the guard and the silence both get pinned here.
+//
+// The bugs these exist to catch:
+//  · a plausible-but-wrong host reaching a buyer (the Clare-V law; #1016's
+//    sm-test-hhawzn52.in.ink)
+//  · a downgrade to http, or an off-brand host smuggled through the gate
+//  · another app's metafield, or a metafield on another owner, read as ours
+//  · the block painting a surface when it has no link — a heading and a dead
+//    button is worse than nothing on a page a buyer reached from an email
+//  · a signal shape change silently blanking the block
+//  · the block reaching for the network on a page it must never slow
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import block, {
+  DOOR_KEY,
+  isOrderDoorBase,
+  doorBaseFromAppMetafields,
+  orderDigitsFromName,
+  linkForOrder,
+} from "./order-page-block.js";
+
+/** One appMetafields entry in the shape the runtime delivers. */
+function entry(value, { key = DOOR_KEY, type = "shop" } = {}) {
+  return { target: { type, id: "gid://shopify/Shop/1" }, metafield: { key, value } };
+}
+
+/** A signal, the way the runtime hands appMetafields over. */
+function signal(value) {
+  return { value, subscribe: () => {} };
+}
+
+describe("the door gate", () => {
+  it("passes the door the embed's writer produces", () => {
+    expect(isOrderDoorBase("https://stevemadden.in.ink/o/")).toBe(true);
+    expect(isOrderDoorBase("https://betsey-johnson.in.ink/o/")).toBe(true);
+    expect(isOrderDoorBase("  https://stevemadden.in.ink/o/  ")).toBe(true);
+  });
+
+  it("refuses every address that is not one of ours", () => {
+    for (const bad of [
+      "http://stevemadden.in.ink/o/", //          downgraded scheme
+      "https://evil.example.com/o/", //           foreign host
+      "https://in.ink/o/", //                     no brand label
+      "https://a.b.in.ink/o/", //                 a label under a label
+      "https://stevemadden.in.ink.evil.com/o/", // lookalike suffix
+      "https://StevEMadden.in.ink/o/", //         uppercase host
+      "https://user@stevemadden.in.ink/o/", //    userinfo
+      "https://stevemadden.in.ink:8443/o/", //    a port
+      "https://stevemadden.in.ink/o", //          not the door path
+      "https://stevemadden.in.ink/r/nfc_x", //    a page, not a door base
+      "https://stevemadden.in.ink/o/?x=1", //     a query
+      "javascript:alert(1)", //                   not a URL at all
+      "",
+      null,
+      undefined,
+    ]) {
+      expect(isOrderDoorBase(bad), `gate let through: ${String(bad)}`).toBe(false);
+    }
+  });
+});
+
+describe("reading the shop's door", () => {
+  it("takes the door out of a signal and out of a bare array alike", () => {
+    const door = "https://stevemadden.in.ink/o/";
+    expect(doorBaseFromAppMetafields(signal([entry(door)]))).toBe(door);
+    expect(doorBaseFromAppMetafields([entry(door)])).toBe(door);
+  });
+
+  it("is null when the runtime hands over nothing it can read", () => {
+    for (const empty of [undefined, null, [], signal([]), signal(undefined), {}]) {
+      expect(doorBaseFromAppMetafields(empty)).toBeNull();
+    }
+  });
+
+  it("ignores another key, and a door on any owner but the shop", () => {
+    const door = "https://stevemadden.in.ink/o/";
+    expect(doorBaseFromAppMetafields([entry(door, { key: "page_url" })])).toBeNull();
+    expect(doorBaseFromAppMetafields([entry(door, { type: "customer" })])).toBeNull();
+    // An entry whose target the runtime did not name is still ours to read.
+    expect(
+      doorBaseFromAppMetafields([{ metafield: { key: DOOR_KEY, value: door } }]),
+    ).toBe(door);
+  });
+
+  it("refuses a bad value rather than passing it on", () => {
+    expect(doorBaseFromAppMetafields([entry("https://evil.example.com/o/")])).toBeNull();
+    expect(doorBaseFromAppMetafields([entry("")])).toBeNull();
+  });
+});
+
+describe("the order number", () => {
+  it("is digits only — the door compares on digits alone", () => {
+    expect(orderDigitsFromName("#1023")).toBe("1023");
+    expect(orderDigitsFromName("1023")).toBe("1023");
+    expect(orderDigitsFromName("SM #1023")).toBe("1023");
+  });
+
+  it("is empty when there is no name to read", () => {
+    for (const none of ["", "  ", "#", null, undefined]) {
+      expect(orderDigitsFromName(none)).toBe("");
+    }
+  });
+});
+
+describe("the link", () => {
+  it("is the brand's door with this order's digits on the end", () => {
+    expect(
+      linkForOrder({
+        appMetafields: signal([entry("https://stevemadden.in.ink/o/")]),
+        orderName: "#1027",
+      }),
+    ).toBe("https://stevemadden.in.ink/o/1027");
+  });
+
+  it("is null when either half is missing — never a half-built address", () => {
+    const door = signal([entry("https://stevemadden.in.ink/o/")]);
+    expect(linkForOrder({ appMetafields: door, orderName: "" })).toBeNull();
+    expect(linkForOrder({ appMetafields: signal([]), orderName: "#1027" })).toBeNull();
+    expect(linkForOrder({})).toBeNull();
+    expect(linkForOrder()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The render itself. The runtime gives this module two globals and a DOM; the
+// fakes below are the smallest thing that answers what it actually calls.
+// ---------------------------------------------------------------------------
+
+function fakeDom() {
+  const make = (tag) => ({
+    tag,
+    attrs: {},
+    children: [],
+    textContent: "",
+    setAttribute(k, v) {
+      this.attrs[k] = v;
+    },
+    append(...kids) {
+      this.children.push(...kids);
+    },
+  });
+  const body = { ...make("body"), replaceChildren() { this.children = []; } };
+  return { body, createElement: make };
+}
+
+/** Run the extension's default export against fake globals; hand back the body. */
+async function renderWith({ appMetafields, order }) {
+  const dom = fakeDom();
+  const priorDocument = globalThis.document;
+  const priorShopify = globalThis.shopify;
+  globalThis.document = dom;
+  globalThis.shopify = { appMetafields, order };
+  try {
+    await block();
+  } finally {
+    globalThis.document = priorDocument;
+    globalThis.shopify = priorShopify;
+  }
+  return dom.body;
+}
+
+/** Every href anywhere in the rendered tree. */
+function hrefs(node) {
+  const found = node.attrs && node.attrs.href ? [node.attrs.href] : [];
+  for (const kid of node.children || []) found.push(...hrefs(kid));
+  return found;
+}
+
+describe("what the buyer sees", () => {
+  const door = signal([entry("https://stevemadden.in.ink/o/")]);
+  const order = signal({ name: "#1027" });
+
+  it("renders one link, to this order's door", async () => {
+    const body = await renderWith({ appMetafields: door, order });
+    expect(body.children).toHaveLength(1);
+    expect(hrefs(body)).toEqual(["https://stevemadden.in.ink/o/1027"]);
+  });
+
+  it("renders NOTHING when the shop has no door", async () => {
+    const body = await renderWith({ appMetafields: signal([]), order });
+    expect(body.children).toEqual([]);
+  });
+
+  it("renders NOTHING when the door is not one of ours", async () => {
+    const body = await renderWith({
+      appMetafields: signal([entry("https://evil.example.com/o/")]),
+      order,
+    });
+    expect(body.children).toEqual([]);
+  });
+
+  it("renders NOTHING when the order has no number yet", async () => {
+    const body = await renderWith({ appMetafields: door, order: signal(undefined) });
+    expect(body.children).toEqual([]);
+  });
+
+  it("renders NOTHING when the runtime hands over neither signal", async () => {
+    const body = await renderWith({ appMetafields: undefined, order: undefined });
+    expect(body.children).toEqual([]);
+  });
+
+  it("re-renders when a signal fills after first paint", async () => {
+    // The runtime may deliver appMetafields empty and fill it a beat later.
+    // Nothing at first paint must not mean nothing forever.
+    const listeners = [];
+    const late = { value: [], subscribe: (fn) => listeners.push(fn) };
+    const dom = fakeDom();
+    const priorDocument = globalThis.document;
+    const priorShopify = globalThis.shopify;
+    globalThis.document = dom;
+    globalThis.shopify = { appMetafields: late, order };
+    try {
+      await block();
+      expect(dom.body.children).toEqual([]);
+      late.value = [entry("https://stevemadden.in.ink/o/")];
+      expect(listeners).not.toHaveLength(0);
+      for (const fn of listeners) fn();
+      expect(hrefs(dom.body)).toEqual(["https://stevemadden.in.ink/o/1027"]);
+    } finally {
+      globalThis.document = priorDocument;
+      globalThis.shopify = priorShopify;
+    }
+  });
+});
+
+describe("what the block must never do", () => {
+  const SRC = readFileSync(fileURLToPath(new URL("./order-page-block.js", import.meta.url)), "utf8");
+
+  it("never touches the network — the order status page is not ours to slow", () => {
+    expect(SRC).not.toMatch(/\bfetch\s*\(/);
+    expect(SRC).not.toMatch(/XMLHttpRequest|sendBeacon|import\s*\(/);
+  });
+
+  it("carries no hardcoded brand host — the door is always read, never guessed", () => {
+    // Comments name real hosts as evidence; code must not.
+    const code = SRC.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+    expect(code).not.toMatch(/[a-z0-9-]+\.in\.ink/);
+  });
+});

--- a/shopify_dashboard.md
+++ b/shopify_dashboard.md
@@ -588,7 +588,92 @@ Currently minimal usage - can be expanded for SMS alerts.
 
 ## 🧩 Shopify Extensions
 
-### **INK Cart Selector Extension**
+### **ink order page** — the block on the Order status page
+
+**Location**: `extensions/order-page-block/`
+
+**Type**: `ui_extension`, target `customer-account.order-status.block.render` (api_version `2026-07`)
+
+**Purpose**: put the buyer's Ritualist page one tap from Shopify's own
+**"View your order"** button — **without any merchant pasting anything.**
+
+**Why it exists — it replaces the Liquid paste.** Shopify has no API for
+notification templates (re-verified 2026-08-23: they are admin-UI-only, and the
+internal `EmailTemplateUpdate` mutation is not callable). Until this block, the
+only way a shipping email opened the brand's page was one Liquid line the
+merchant pasted into their Shipping confirmation and Shipping update templates,
+by hand, per store. That line still works and stays as belt-and-braces; but for
+every merchant who never does it, the email's primary button lands on Shopify's
+Order status page — and this block is standing there.
+
+- It ships inside the app. Install = on. No per-store template surgery.
+- The target self-places: "by default, block extensions are placed in the first
+  available placement reference". A merchant can move or remove it in the
+  checkout & accounts editor; they never have to touch it.
+- The Order status page is pre-authenticated, so a buyer arriving from the email
+  sees it without logging in. All plans, not just Plus.
+
+**What it renders**: one heading, one line, one primary button to
+`https://{brand}.in.ink/o/{order_number}` — the order door, which 302s to that
+buyer's page. Copy is **placeholder, awaiting Sam**.
+
+**What it renders when anything is missing**: *nothing at all.* No fallback host,
+no host derived from the shop domain (the Clare-V law — a plausible-but-wrong
+host is how `sm-test-hhawzn52.in.ink` happened). It never touches the network.
+
+**The switch is server-side.** The block reads exactly one app metafield —
+`ink:order_door` on the **SHOP**, holding the door base
+`https://{brand}.in.ink/o/`. Its only writer is
+`app/services/order-door-metafield.server.ts`, which mints it from `brand_slug`
+and deletes it when `merchants/{shop}.order_door_block === false`. So turning a
+store on or off never redeploys this extension.
+
+**⚠️ Why the block composes the door instead of reading the order's own page
+address.** The exact address (`https://{brand}.in.ink/r/{token}`) is stamped on
+the ORDER at enrol as `ink.page_url` (`page-url-on-the-order.server.ts`), and
+reading it here would spare the redirect hop and the order-number match. It
+cannot be read. Measured against shopify.dev on **2026-09-05**, three walls, any
+one of them fatal:
+
+1. **No `order` owner.** `appMetafields` is the only metafields property this
+   target has on `2026-07`, and `AppMetafieldEntryTarget.type` is `customer` ·
+   `product` · `shop` · `shopUser` · `variant` · `company` · `companyLocation` ·
+   `cart`. There is no `order`.
+2. **The order-metafield accessor is gone.** `2025-10` documented a second root
+   property, `metafields` — *"The metafields associated with the order."*
+   `2026-07` documents `appMetafields` and nothing else.
+3. **An unreserved namespace is hidden anyway.** `ink` is merchant-owned, so its
+   Customer Account API access is *"Hidden from Customer Accounts API
+   (default)"* and *"can only be configured through the Shopify admin"* — per
+   store, by hand, which is the Liquid paste wearing a different hat. Only an
+   app-reserved namespace (`$app:…`) can be granted that access from the app.
+
+So the shop's door is the mechanism, not a consolation prize: `shop` **is** an
+owner type, it needs no merchant work, and it reaches the same page.
+`ink.page_url` stays on the order for Shopify's own notification templates,
+which read it in Liquid where none of the three walls apply.
+
+**Tests**: `extensions/order-page-block/src/order-page-block.test.js` (the gate,
+the silence, the late-filling signal, the no-network and no-hardcoded-host pins)
+and the writer↔extension contract at the foot of
+`app/services/order-door-metafield.test.ts`. `vitest.config.ts` includes
+`extensions/**/src/*.test.{js,ts}` for this reason: the block is the one
+buyer-facing file that neither `typecheck` nor `build` ever sees.
+
+**Deployment**: extensions ship **only** with `shopify app deploy` (app config +
+extensions), which is a separate act from merging to `main` (that deploys the
+Cloud Run server only). Adding or changing this extension needs **no** access
+scope, so it triggers **no merchant re-consent**; customer account UI extensions
+are listed "No" under *Requires review and approval*, so releasing a version
+carrying it needs **no** Shopify review.
+
+---
+
+### **INK Cart Selector Extension** *(removed — kept for history)*
+
+> **No longer in the repo.** The `ink-cart-selector` theme extension was taken
+> out of the release in `402472a`; `extensions/` holds only `order-page-block`.
+> The rest of this section describes what it was.
 
 **Location**: `extensions/ink-cart-selector/`
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,15 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["app/**/*.{test,canary.test}.{ts,tsx}"],
+    // `extensions/**` is here because the order status block is the one piece
+    // of buyer-facing code in this repo that neither typecheck nor build ever
+    // sees: it is plain JS, outside tsconfig's `include`, bundled by the
+    // Shopify CLI at `shopify app deploy` and by nothing else. Its guard
+    // decides what address a buyer taps out of a shipping email, so it gets
+    // real tests instead of the string-scraping pins it had.
+    include: [
+      "app/**/*.{test,canary.test}.{ts,tsx}",
+      "extensions/**/src/*.test.{js,ts}",
+    ],
   },
 });


### PR DESCRIPTION
**HELD FOR ROUND FOUR.** Stacked on #105 (base = `feat/page-url-on-the-order`). Nothing here deploys on merge — extensions ship only with `shopify app deploy`, which is Sam's act.

## What a person sees

**A buyer:** exactly what they see today. No behaviour changes on the wire. The block on Shopify's Order status page — the page the **"View your order"** button in every shipping email opens — still shows one heading, one line, one button to that order's page, and still shows *nothing at all* when the brand has no door.

**Sam:** the answer to *"I don't believe that anyone will copy and paste code into the liquid thing."* The block that removes the paste **already exists** — it shipped in #98 on 2026-08-28 and targets `customer-account.order-status.block.render`. It is not deployed by merging; it deploys with `shopify app deploy` (see **For Sam**).

**The next engineer:** the reason not to spend a day trying to point that block at `ink.page_url`, written down where they will hit it — in the module header, in the toml beside the metafield declaration, and in `shopify_dashboard.md`.

## What this actually changes

The block had **no tests** — only three regexes scraping its own source text. It is the one buyer-facing file in this repo that neither `typecheck` nor `build` ever sees: plain JS, outside `tsconfig`'s `include`, bundled by the Shopify CLI and by nothing else. What it decides is the address a buyer taps out of an email.

- **The extension's pure logic is exported** (`isOrderDoorBase`, `doorBaseFromAppMetafields`, `orderDigitsFromName`, `linkForOrder`) so it can be tested by behaviour. Same inputs, same outputs, same render.
- **18 new tests.** The gate against 14 refusals — scheme downgrade, foreign host, lookalike suffix (`stevemadden.in.ink.evil.com`), userinfo, a port, an uppercase host, a page URL where a door base belongs, `javascript:`. The silence when the door or the order number is missing. A signal that fills *after* first paint (nothing at first paint must not mean nothing forever). Pins that the block never touches the network and never carries a hardcoded brand host.
- **The writer↔extension contract** at the foot of `order-door-metafield.test.ts` now **imports the extension's own functions** instead of scraping its source for a regex literal. Same contract, pinned by behaviour, so a rewrite that keeps the meaning stays green and one that loses it goes red.
- `vitest.config.ts` reaches `extensions/**/src/*.test.{js,ts}`; `.eslintrc.cjs` gives those tests `node`+`es2022` for `globalThis`.

## The wall: the block cannot read the order's own page address

The brief for this PR was *read `ink.page_url` (the exact address #105 stamps on the order) and link to it* — no redirect hop, no order-number match. **That read is not available.** Measured against shopify.dev on 2026-09-05, three walls, any one of them fatal:

1. **No `order` owner.** `appMetafields` is the *only* metafields property this target has on `api_version 2026-07`, and `AppMetafieldEntryTarget.type` is `customer` · `product` · `shop` · `shopUser` · `variant` · `company` · `companyLocation` · `cart`. There is no `order`. — [2026-07 metafields-api](https://shopify.dev/docs/api/customer-account-ui-extensions/2026-07/target-apis/order-apis/metafields-api)
2. **The order-metafield accessor is gone.** `2025-10` documented a second root property, `metafields` — *"The metafields associated with the order."* `2026-07` documents `appMetafields` and nothing else. — [2025-10 metafields-api](https://shopify.dev/docs/api/customer-account-ui-extensions/2025-10/target-apis/order-apis/metafields-api)
3. **An unreserved namespace is hidden anyway.** `ink` is merchant-owned, so its Customer Account API access is *"Hidden from Customer Accounts API (default)"* and *"can only be configured through the Shopify admin"*. No app-side mutation can grant it — a merchant would switch it on by hand, per store, **which is the Liquid paste wearing a different hat.** — [access-controls](https://shopify.dev/docs/apps/custom-data/metafields/definitions/access-controls)

So the shop's door is **the mechanism, not a fallback**: `shop` *is* an owner type, `ink:order_door` needs no merchant work, and `https://{brand}.in.ink/o/{order_number}` 302s to the same page (measured live 2026-09-05: `/o/1027` → the page in 1.5 s). `ink.page_url` stays on the order for Shopify's own notification templates, which read it in Liquid where none of the three walls apply. The toml now says in as many words **not** to declare `ink/page_url` there — adding it would silently deliver nothing.

## Gates

| Gate | Result |
|---|---|
| `npm run typecheck` | **0 errors** (`react-router typegen && tsc --noEmit`) |
| `npm run build` | **green**, `react-router build`, 383–399 ms |
| `npx vitest run` | **179 passed / 179**, 17 files (base #105: 161 → **+18**) |
| `npx eslint --ignore-path .gitignore .` | **469 problems — exactly the base's 469**, measured both ways by stashing this diff |
| extension bundle | `esbuild --bundle --format=esm --target=es2022 --minify` → 1.4 kB, default export intact |
| guards proven to fail first | 4 sabotages, each red, then restored byte-identical: drop the door gate → 3 red · render without order digits → 2 red · add a `fetch(` → 1 red · hardcode a brand host → 2 red |

`shopify app build` was **not** run: `@shopify/cli` is not a dependency here (`npx -y @shopify/cli` in the deploy script fetches it), and running it against the live `8da1…` app record risks a link/auth prompt. The esbuild bundle above is the same operation the CLI performs on the target module. **Nothing in this PR is verified on the wire** — the embed is frozen for App Store review, so every claim above is from tests, the bundle, and the docs cited.

## New surfaces

**None.** No new component, no new route, no new extension, no new test id. `extensions/order-page-block/` and its single target `customer-account.order-status.block.render` both already exist on `main` (#98, 2026-08-28); the block's rendered shape (`s-stack` → `s-heading` "Your order page" · `s-text` · `s-button` "Open the page") is unchanged. The only added file is a test, `extensions/order-page-block/src/order-page-block.test.js`.

## For Sam

**1 · Is the block live?** Unknown from this laptop, and worth checking before anything else. Merging to `main` deploys **Cloud Run only**; the extension ships **only** with `shopify app deploy`. On disk, `.shopify/deploy-bundle` and the extension's `dist/` are dated **Aug 23 18:00**, while the current `shopify.extension.toml` is dated **Aug 28 11:50** — so the last bundle built here predates the block's current config by five days, and the stale `manifest.json` still lists a second target the toml no longer declares. If no version has been released since Aug 28, **the block is written but not published**, which would explain why the Liquid paste still feels like the only mechanism.

**2 · Does this need review or re-consent? No, to both.**
- **Review:** customer account UI extensions are listed **"No"** under *Requires review and approval* — only Post-purchase, Flow Templates and Payments extensions are "Yes". — [list-of-app-extensions](https://shopify.dev/docs/apps/build/app-extensions/list-of-app-extensions)
- **Re-consent:** merchant re-authorization is triggered by **access scope changes**, and this PR changes no scope. *"Releasing an app version replaces the current active version that's served to stores that have your app installed"* is the whole stated effect on installed stores; the consent prompt appears only where scopes are added. — [deploy-app-versions](https://shopify.dev/docs/apps/launch/deployment/deploy-app-versions), [manage-access-scopes](https://shopify.dev/docs/apps/build/authentication-authorization/app-installation/manage-access-scopes) — *honest caveat: the docs state the positive case (scopes change → prompt) and never state the negative in so many words.*

**3 · The order after round four:** merge #105 → merge this → `shopify app deploy` (this is the step that publishes the block; #103 needs it too, and only #103's optional scopes should show as changed — if the CLI says *required* scopes changed, stop) → open a shipped SM Test order's status page and confirm the block is there.

**4 · Decisions I did not take alone:**
- **The copy is still placeholder** — "Your order page" / "Delivery updates and help for this order." / "Open the page". Yours to polish.
- **The rendered shape is unchanged.** The brief asked for one text line, `See your order's page →`. I kept the heading + line + button that already shipped: it is an existing buyer-facing surface and a buyer who just tapped a button in an email is looking for a button. Say the word and it becomes one line.
- **`purchase.thank-you.block.render` was not added.** It was offered as cheap; it is not free. The enrol lands ~5 s after the order is created and the shop's door is written on fulfilment events, so at thank-you time the link can point at a page that does not resolve yet — a dead link on the highest-stakes page in the store. It is also a new buyer-facing surface, which is yours to ask for.
- **Lighting up the exact-page path would mean re-stamping the page in the app's own reserved namespace (`$app:…`)**, where all three access controls *are* app-settable. Even then, Shopify documents no `order` owner for `appMetafields` on `2026-07`, so it needs an answer from Shopify before it is worth building. Not started.
