### PR TITLE
HELD FOR ROUND FOUR — Shopify's shipping email carries the buyer's page, once, when it hasn't gone yet

### DIFF
--- a/app/components/settings/DeliveryModeSettings.tsx
+++ b/app/components/settings/DeliveryModeSettings.tsx
@@ -10,12 +10,19 @@ import {
 } from "@shopify/polaris";
 import { toast } from "../../hooks/use-toast";
 
-const DeliveryModeSettings = () => {
+const DeliveryModeSettings = ({ shopName }: { shopName?: string }) => {
   const [loading, setLoading] = useState(true);
   // The branded tracking link. ON for every merchant unless they turn it off
   // here — so this starts true and only a loaded `false` moves it.
   const [trackingLink, setTrackingLink] = useState(true);
+  // Shopify's own shipping email, carrying the page. ON by default, same as
+  // the tracking link — Sam's ruling of 2026-09-05 is the default.
+  const [shopifyShippingEmail, setShopifyShippingEmail] = useState(true);
+  // The brand's own email. OFF by default: a second email to someone else's
+  // customer is the merchant's call, not ours.
+  const [brandPageEmail, setBrandPageEmail] = useState(false);
   const [trackingLinkSaving, setTrackingLinkSaving] = useState(false);
+  const brand = (shopName || "your brand").trim() || "your brand";
 
   // App-Bridge-aware fetch (mirrors the pattern used in BrandingSettings).
   const fetchSecure = async (path: string, options: RequestInit = {}) => {
@@ -69,6 +76,10 @@ const DeliveryModeSettings = () => {
       try {
         const res = await fetchSecure("/app/api/settings/branded-tracking-link");
         if (res && typeof res.enabled === "boolean") setTrackingLink(res.enabled);
+        if (res && typeof res.shopifyShippingEmail === "boolean") {
+          setShopifyShippingEmail(res.shopifyShippingEmail);
+        }
+        if (res && typeof res.brandPageEmail === "boolean") setBrandPageEmail(res.brandPageEmail);
       } catch (err: any) {
         console.error("Failed to load tracking link setting:", err);
       }
@@ -77,22 +88,27 @@ const DeliveryModeSettings = () => {
     load();
   }, []);
 
-  const saveTrackingLink = async (enabled: boolean) => {
-    const previous = trackingLink;
-    setTrackingLink(enabled); // optimistic — a toggle that lags feels broken
+  // ONE saver for the three switches on this card. Each one moves optimistically
+  // and is put back if the save fails — a toggle that keeps a lie on screen is
+  // worse than one that lags.
+  const saveSwitch = async (
+    field: "enabled" | "shopifyShippingEmail" | "brandPageEmail",
+    value: boolean,
+    apply: (v: boolean) => void,
+    previous: boolean,
+    message: string,
+  ) => {
+    apply(value);
     setTrackingLinkSaving(true);
     try {
       await fetchSecure("/app/api/settings/branded-tracking-link", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enabled }),
+        body: JSON.stringify({ [field]: value }),
       });
-      toast({
-        title: enabled ? "Tracking links point to your page" : "Tracking links point to the carrier",
-        duration: 2500,
-      });
+      toast({ title: message, duration: 2500 });
     } catch (err: any) {
-      setTrackingLink(previous); // say so, don't keep a lie on screen
+      apply(previous); // say so, don't keep a lie on screen
       toast({
         title: "Couldn't save that",
         description: err.message,
@@ -103,6 +119,33 @@ const DeliveryModeSettings = () => {
       setTrackingLinkSaving(false);
     }
   };
+
+  const saveTrackingLink = (enabled: boolean) =>
+    saveSwitch(
+      "enabled",
+      enabled,
+      setTrackingLink,
+      trackingLink,
+      enabled ? "Tracking links point to your page" : "Tracking links point to the carrier",
+    );
+
+  const saveShopifyShippingEmail = (on: boolean) =>
+    saveSwitch(
+      "shopifyShippingEmail",
+      on,
+      setShopifyShippingEmail,
+      shopifyShippingEmail,
+      on ? "Shopify's shipping email will carry your page" : "Shopify's shipping email is left alone",
+    );
+
+  const saveBrandPageEmail = (on: boolean) =>
+    saveSwitch(
+      "brandPageEmail",
+      on,
+      setBrandPageEmail,
+      brandPageEmail,
+      on ? `${brand} will email the page` : `${brand} sends no extra email`,
+    );
 
   if (loading) {
     return (
@@ -167,6 +210,36 @@ const DeliveryModeSettings = () => {
               with a carrier we can’t follow keep Shopify’s own tracking link, so no customer is
               ever sent to a page that can’t tell them anything.
             </Text>
+
+            {/* PLACEHOLDER COPY — Sam writes the words. The two switches Sam
+                ruled on, 2026-09-05, on the card that already owns this
+                subject rather than a new one. */}
+            <Checkbox
+              id="ink-shopify-shipping-email"
+              label="Send Shopify’s shipping email when your customer hasn’t had one"
+              helpText={
+                "If you fulfil an order without ticking Shopify’s own “Send shipment details”, your " +
+                "customer gets no shipping email at all. This sends exactly one, from your own " +
+                "template, and its tracking button opens your order page. A customer who already " +
+                "had a shipping email never gets a second."
+              }
+              checked={shopifyShippingEmail}
+              disabled={trackingLinkSaving}
+              onChange={saveShopifyShippingEmail}
+            />
+
+            <Checkbox
+              id="ink-brand-page-email"
+              label={`Email the page from ${brand} when Shopify’s email already went out`}
+              helpText={
+                "When your shipping email has already gone out with the carrier’s link in it, this " +
+                "sends one short email from your brand with a link to the order’s page. Off unless " +
+                "you turn it on: it is a second email to your customer."
+              }
+              checked={brandPageEmail}
+              disabled={trackingLinkSaving}
+              onChange={saveBrandPageEmail}
+            />
           </BlockStack>
         </Card>
       </Layout.AnnotatedSection>

--- a/app/components/settings/Settings.tsx
+++ b/app/components/settings/Settings.tsx
@@ -34,7 +34,8 @@ const Settings = ({ initialData }: { initialData?: any }) => {
   const renderTabContent = () => {
     switch (tabs[selected]?.id) {
       case "account": return <AccountSettings />;
-      case "delivery": return <DeliveryModeSettings />;
+      // shopName names the brand in the "email the page from {brand}" switch.
+      case "delivery": return <DeliveryModeSettings shopName={initialData?.shopName} />;
       case "tags": return <TagsSettings inventoryData={initialData?.inventoryData} />;
       case "branding": return <BrandingSettings />;
       // shopDomain builds the deep link into THIS store's Shopify notification

--- a/app/routes/app.api.settings.branded-tracking-link.tsx
+++ b/app/routes/app.api.settings.branded-tracking-link.tsx
@@ -1,9 +1,23 @@
 /**
- * Branded tracking link — merchant preference endpoint.
+ * The tracking-link card's preferences — one endpoint, three switches.
  *
- * GET   → { enabled: boolean }
- * PATCH → { enabled: boolean } persisted to
- *         merchants/{shopDomain}.branded_tracking_link
+ * GET   → { enabled, shopifyShippingEmail, brandPageEmail, killedGlobally }
+ * PATCH → any subset of { enabled, shopifyShippingEmail, brandPageEmail },
+ *         persisted to merchants/{shopDomain}.{branded_tracking_link,
+ *         shopify_shipping_email, brand_page_email}
+ *
+ * THE TWO NEW ONES (Sam's ruling, 2026-09-05 — "the email from shopify should
+ * have a link to the buyers in.ink order"):
+ *
+ *  · `shopify_shipping_email` — DEFAULT ON, like the tracking link above it.
+ *    When a merchant fulfills WITHOUT ticking Shopify's own notification, their
+ *    buyer gets no shipping email at all; this lets Shopify send exactly one,
+ *    from the merchant's own template, whose tracking button is the brand's
+ *    page. A buyer who already had a shipping email never gets a second
+ *    (shopify-shipping-notice.server.ts decides, from Shopify's own timeline).
+ *  · `brand_page_email` — DEFAULT OFF, and deliberately the other way round: it
+ *    is a NEW email to someone else's customer, which is the merchant's call.
+ *    Only an explicit `true` turns it on.
  *
  * DEFAULT ON (Sam, 2026-08-06): an absent field reads as enabled, so every
  * merchant gets the branded tracking link without touching this screen. The
@@ -17,6 +31,10 @@
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
 import { authenticate } from "../shopify.server";
+import {
+  readTrackingCardSwitches,
+  trackingCardUpdatesFrom,
+} from "../services/tracking-card-switches";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -54,9 +72,15 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
   try {
     const doc = await getMerchantDoc(shopDomain);
-    // Absent → ON. Only an explicit false turns it off.
-    const enabled = doc?.data()?.branded_tracking_link !== false;
-    return json({ enabled, killedGlobally: Boolean(process.env.BRANDED_TRACKING_LINK_DISABLED) });
+    // Absent → ON for the first two, OFF for the third; the rule lives in one
+    // place (tracking-card-switches.ts) so the screen and the webhooks agree.
+    const switches = readTrackingCardSwitches(doc?.data());
+    return json({
+      ...switches,
+      killedGlobally: Boolean(process.env.BRANDED_TRACKING_LINK_DISABLED),
+      shopifyShippingEmailKilledGlobally: Boolean(process.env.SHOPIFY_SHIPPING_EMAIL_DISABLED),
+      brandPageEmailKilledGlobally: Boolean(process.env.BRAND_PAGE_EMAIL_DISABLED),
+    });
   } catch (err: any) {
     console.error("[settings/branded-tracking-link] GET error:", err.message);
     return json({ error: "Failed to fetch tracking link setting" }, { status: 500 });
@@ -77,9 +101,20 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   try {
     const body = await request.json();
-    const enabled = body?.enabled;
-    if (typeof enabled !== "boolean") {
-      return json({ error: "Invalid body. Expected { enabled: boolean }" }, { status: 400 });
+
+    // Only known keys move a switch, and only a literal boolean moves one —
+    // the sanitizer discipline the notification settings already use. A body
+    // that names nothing we recognise is a 400, never a silent no-op.
+    const updates = trackingCardUpdatesFrom(body);
+
+    if (Object.keys(updates).length === 0) {
+      return json(
+        {
+          error:
+            "Invalid body. Expected at least one of { enabled, shopifyShippingEmail, brandPageEmail } as a boolean",
+        },
+        { status: 400 },
+      );
     }
 
     const doc = await getMerchantDoc(shopDomain);
@@ -93,10 +128,15 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       );
     }
 
-    await doc.ref.update({ branded_tracking_link: enabled, updatedAt: new Date() });
-    console.log(`[settings/branded-tracking-link] ${shopDomain} → enabled=${enabled}`);
+    await doc.ref.update({ ...updates, updatedAt: new Date() });
+    console.log(
+      `[settings/branded-tracking-link] ${shopDomain} → ` +
+        Object.entries(updates)
+          .map(([k, v]) => `${k}=${v}`)
+          .join(" "),
+    );
 
-    return json({ enabled });
+    return json(readTrackingCardSwitches({ ...(doc.data() ?? {}), ...updates }));
   } catch (err: any) {
     console.error("[settings/branded-tracking-link] PATCH error:", err.message);
     return json({ error: "Failed to update tracking link setting" }, { status: 500 });

--- a/app/routes/app.api.settings.branded-tracking-link.tsx
+++ b/app/routes/app.api.settings.branded-tracking-link.tsx
@@ -25,12 +25,26 @@
  * turns it off everywhere. Both are emergency exits, not opt-ins — which is
  * why `false` is stored explicitly and absence is never treated as a refusal.
  *
- * Reads/writes are gated by `authenticate.admin(request)` from Shopify. Follows
- * the app.api.settings.delivery-mode.tsx precedent exactly.
+ * Reads/writes are gated by `authenticate.admin(request)` from Shopify.
+ *
+ * WHICH MERCHANT DOC. `findMerchantDocRef` — the same resolver the fulfillment
+ * webhook uses, not a private lookup. This route had its own, which read the
+ * doc whose ID is the shop domain and stopped there; the webhook prefers the
+ * doc that actually carries `ink_api_key`. On a store where those are two
+ * different documents the switch saved in one and the webhook read the other,
+ * so the setting was invisible to the thing it governs — the fifth appearance
+ * of the §17.2 landmine `merchant-doc.server.ts` exists to end.
+ *
+ * MEASURED, not theoretical: of the thirteen shops holding a Shopify session
+ * on 2026-09-05, `smusic-official.myshopify.com` has exactly this shape (the
+ * route would write `smusic-official.myshopify.com`, the webhook reads
+ * `PWXStzc7mP8hn33xPbNf`). That store's `branded_tracking_link` switch has
+ * therefore never worked, and both new switches would have inherited it.
  */
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
 import { authenticate } from "../shopify.server";
+import { findMerchantDocRef } from "../services/merchant-doc.server";
 import {
   readTrackingCardSwitches,
   trackingCardUpdatesFrom,
@@ -48,20 +62,6 @@ const json = (data: any, init?: ResponseInit) =>
     ...init,
   });
 
-async function getMerchantDoc(shopDomain: string) {
-  const direct = await firestore.collection("merchants").doc(shopDomain).get();
-  if (direct.exists) return direct;
-  for (const field of ["shop", "shopDomain", "shop_domain"]) {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where(field, "==", shopDomain)
-      .limit(1)
-      .get();
-    if (!snapshot.empty) return snapshot.docs[0];
-  }
-  return null;
-}
-
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (request.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
@@ -71,10 +71,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const shopDomain = session.shop;
 
   try {
-    const doc = await getMerchantDoc(shopDomain);
+    const hit = await findMerchantDocRef(firestore, shopDomain);
     // Absent → ON for the first two, OFF for the third; the rule lives in one
     // place (tracking-card-switches.ts) so the screen and the webhooks agree.
-    const switches = readTrackingCardSwitches(doc?.data());
+    const switches = readTrackingCardSwitches(hit?.data);
     return json({
       ...switches,
       killedGlobally: Boolean(process.env.BRANDED_TRACKING_LINK_DISABLED),
@@ -117,8 +117,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       );
     }
 
-    const doc = await getMerchantDoc(shopDomain);
-    if (!doc) {
+    const hit = await findMerchantDocRef(firestore, shopDomain);
+    if (!hit) {
       console.warn(
         `[settings/branded-tracking-link] Merchant doc not found for ${shopDomain}; cannot persist`,
       );
@@ -128,7 +128,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       );
     }
 
-    await doc.ref.update({ ...updates, updatedAt: new Date() });
+    await hit.ref.update({ ...updates, updatedAt: new Date() });
     console.log(
       `[settings/branded-tracking-link] ${shopDomain} → ` +
         Object.entries(updates)
@@ -136,7 +136,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
           .join(" "),
     );
 
-    return json(readTrackingCardSwitches({ ...(doc.data() ?? {}), ...updates }));
+    return json(readTrackingCardSwitches({ ...(hit.data ?? {}), ...updates }));
   } catch (err: any) {
     console.error("[settings/branded-tracking-link] PATCH error:", err.message);
     return json({ error: "Failed to update tracking link setting" }, { status: 500 });

--- a/app/routes/webhooks.fulfillments_create.tsx
+++ b/app/routes/webhooks.fulfillments_create.tsx
@@ -94,7 +94,33 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     // never fatal — see branded-tracking-link.server.ts.
     try {
       const { assertBrandedTrackingUrl } = await import("../services/branded-tracking-link.server");
-      await assertBrandedTrackingUrl({
+      const { decideShopifyShippingNotice, stampShippingNotice } = await import(
+        "../services/shopify-shipping-notice.server"
+      );
+      const { brandPageEmailEnabled, sendBrandPageEmailOnce } = await import(
+        "../services/brand-page-email.server"
+      );
+      const orderGid = `gid://shopify/Order/${orderId}`;
+
+      // ONE READ OF THE TIMELINE PER EVENT, AT MOST. The decision is asked for
+      // twice — once by the rewrite, at the last moment before it mutates, and
+      // once below by the brand's own email — and both get the same answer.
+      let notice: Awaited<ReturnType<typeof decideShopifyShippingNotice>> | null = null;
+      const decideOnce = async () => {
+        if (!notice) {
+          notice = await decideShopifyShippingNotice({
+            admin,
+            shop,
+            orderGid,
+            fulfillmentPayload: payload,
+            merchantData: merchantHit?.data ?? {},
+            label: `[${topic}] shipping-notice`,
+          });
+        }
+        return notice;
+      };
+
+      const branded = await assertBrandedTrackingUrl({
         admin,
         shop,
         payload,
@@ -102,8 +128,46 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         merchantApiKey,
         merchantData: merchantHit?.data ?? {},
         shippoRegistered: patched?.shippo_registered === true,
+        // Shopify sends its OWN shipping email, once, carrying the page —
+        // but only for a buyer who has had none (shopify-shipping-notice).
+        shouldNotifyCustomer: async () => (await decideOnce()).notifyCustomer,
         label: `[${topic}] branded-tracking-link`,
       });
+
+      // Record OUR ask straight away, so a webhook redelivery can never repeat
+      // it. Written only after Shopify accepted the notifying mutation.
+      if (branded.notifiedCustomer) {
+        await stampShippingNotice({
+          admin,
+          orderGid,
+          fulfillmentId: String(payload?.id ?? ""),
+          label: `[${topic}] shipping-notice`,
+        });
+      }
+
+      // THE OTHER CASE: Shopify's shipping email already went out, with the
+      // carrier's link in it. Default OFF, so the read below costs nothing for
+      // a merchant who has not asked for it.
+      if (
+        brandPageEmailEnabled(merchantHit?.data ?? {}) &&
+        (branded.outcome === "updated" || branded.outcome === "skipped_already_branded")
+      ) {
+        const verdict = await decideOnce();
+        if (verdict.decision === "skipped_already_sent_by_shopify") {
+          await sendBrandPageEmailOnce({
+            admin,
+            shop,
+            orderGid,
+            orderName,
+            customerEmail: customer?.email,
+            proofId,
+            fulfillmentId: String(payload?.id ?? ""),
+            merchantApiKey,
+            merchantData: merchantHit?.data ?? {},
+            label: `[${topic}] brand-page-email`,
+          });
+        }
+      }
 
       // The Order status page — where the email's primary button lands —
       // carries the brand's door once this shop metafield exists. One guard

--- a/app/routes/webhooks.fulfillments_update.tsx
+++ b/app/routes/webhooks.fulfillments_update.tsx
@@ -115,7 +115,33 @@ export const action = async ({ request }: ActionFunctionArgs) => {
             );
 
             const { assertBrandedTrackingUrl } = await import("../services/branded-tracking-link.server");
-            await assertBrandedTrackingUrl({
+            const { decideShopifyShippingNotice, stampShippingNotice } = await import(
+              "../services/shopify-shipping-notice.server"
+            );
+            const { brandPageEmailEnabled, sendBrandPageEmailOnce } = await import(
+              "../services/brand-page-email.server"
+            );
+
+            // The same decision as fulfillments/create, and the same single
+            // read: tracking that arrives LATE (the 3PL shape) reaches the
+            // buyer through this handler, so the shipping email has to be
+            // decided here too or the whole 3PL population is left out.
+            let notice: Awaited<ReturnType<typeof decideShopifyShippingNotice>> | null = null;
+            const decideOnce = async () => {
+              if (!notice) {
+                notice = await decideShopifyShippingNotice({
+                  admin,
+                  shop,
+                  orderGid,
+                  fulfillmentPayload: fulfillment,
+                  merchantData: hit?.data ?? {},
+                  label: `[${topic}] shipping-notice`,
+                });
+              }
+              return notice;
+            };
+
+            const branded = await assertBrandedTrackingUrl({
               admin,
               shop,
               payload: fulfillment,
@@ -123,8 +149,39 @@ export const action = async ({ request }: ActionFunctionArgs) => {
               merchantApiKey: apiKey,
               merchantData: hit?.data ?? {},
               shippoRegistered: patched?.shippo_registered === true,
+              shouldNotifyCustomer: async () => (await decideOnce()).notifyCustomer,
               label: `[${topic}] branded-tracking-link`,
             });
+
+            if (branded.notifiedCustomer) {
+              await stampShippingNotice({
+                admin,
+                orderGid,
+                fulfillmentId: String(fulfillment?.id ?? ""),
+                label: `[${topic}] shipping-notice`,
+              });
+            }
+
+            if (
+              brandPageEmailEnabled(hit?.data ?? {}) &&
+              (branded.outcome === "updated" || branded.outcome === "skipped_already_branded")
+            ) {
+              const verdict = await decideOnce();
+              if (verdict.decision === "skipped_already_sent_by_shopify") {
+                await sendBrandPageEmailOnce({
+                  admin,
+                  shop,
+                  orderGid,
+                  orderName: trackingOrder?.name ?? String(orderId),
+                  customerEmail: trackingOrder?.customer?.email,
+                  proofId: trackingProofId,
+                  fulfillmentId: String(fulfillment?.id ?? ""),
+                  merchantApiKey: apiKey,
+                  merchantData: hit?.data ?? {},
+                  label: `[${topic}] brand-page-email`,
+                });
+              }
+            }
 
             // The Order status page — where the email's primary button lands —
             // carries the brand's door once this shop metafield exists. One

--- a/app/services/brand-email.server.ts
+++ b/app/services/brand-email.server.ts
@@ -9,7 +9,10 @@
 // selection (parallelreturns src/lib/campaigns.ts) so the email and the
 // page always agree on which aim this buyer sees.
 
-const WORKER_BASE = "https://ink-easypost-proxy.inink.workers.dev";
+/** The Worker. One author for the host, because two would drift: the brand
+ *  book read below and the buyer-mail rail (brand-page-email.server.ts) must
+ *  always be talking to the same deployment. */
+export const WORKER_BASE = "https://ink-easypost-proxy.inink.workers.dev";
 
 export interface EmailCampaign {
   id: string;

--- a/app/services/brand-page-email.server.ts
+++ b/app/services/brand-page-email.server.ts
@@ -1,0 +1,296 @@
+// WHEN SHOPIFY'S EMAIL ALREADY WENT OUT — the brand emails the page itself.
+//
+// The other half of Sam's 2026-09-05 ruling. `shopify-shipping-notice.server.ts`
+// covers the merchant who fulfilled WITHOUT notifying: Shopify sends one
+// shipping update and its tracking button is the brand's page. The merchant who
+// DID notify has already spent the buyer's shipping email on the carrier's URL,
+// and rule 4 forbids a second one from Shopify — correctly, because Shopify
+// would send it from the merchant's template as if nothing had happened.
+//
+// So this rail exists for that case only: one short email, from the brand, with
+// the page in it. It is TRANSACTIONAL — it tells a buyer where the thing they
+// bought is — and it is DEFAULT OFF, because a second email to someone else's
+// customer is the merchant's call and not ours (Sam can flip the default; the
+// PR says so under "For Sam").
+//
+// WHERE THE SENDING LIVES, AND WHY NOT HERE. Measured 2026-09-05: the Cloud Run
+// service `shopify-app` carries SENDGRID_API_KEY and no RESEND_API_KEY. Resend
+// is bound on the Cloudflare Worker, together with RESEND_WEBHOOK_SECRET and —
+// the deciding fact — the SUPPRESSION LIST (`outreach-suppress:{address}` in
+// the DEMO_REGISTRY namespace, written by Resend's bounce webhook and read
+// fail-closed). An address that hard-bounced or complained must never be mailed
+// again by anything ink runs, and a second suppression list living in this repo
+// would be the "copy that drifted from its original" failure this codebase has
+// paid for more than once. So the Worker sends and this module decides.
+//
+// THE OUTREACH RAIL IS NOT TOUCHED. Its allowlist and its 25-a-day cap are
+// fences around COLD LETTERS TO STRANGERS. This is a buyer who just bought
+// something, and it rides a separate Worker route with its own fences; nothing
+// here loosens anything there.
+//
+// FIVE REFUSALS, all of them returned in words and logged:
+//   1. the switch (env kill switch, then the merchant's own — DEFAULT OFF)
+//   2. no shared secret configured ⇒ nothing is attempted (the Worker refuses
+//      too, so the fence exists on both sides of the wire)
+//   3. no usable recipient, or no page to point at
+//   4. a test-flagged merchant may only ever reach its OWN address
+//   5. one email per order, ever — stamped on the order after a real send
+//
+// The Worker holds the same last three again, plus suppression and the daily
+// cap, because a fence that only one side enforces is a fence with a gate in it.
+
+import { WORKER_BASE } from "./brand-email.server";
+import { resolveBrandPageUrl } from "./brand-page-url.server";
+
+type Loose = Record<string, unknown>;
+
+export interface GraphqlAdmin {
+  graphql: (query: string, opts?: { variables?: Record<string, unknown> }) => Promise<Response>;
+}
+
+const NAMESPACE = "ink";
+export const SENT_KEY = "page_email_sent";
+export const BUYER_MAIL_PATH = "/api/buyer/page-email";
+
+export type BrandPageEmailOutcome =
+  | "sent"
+  | "skipped_disabled_env"
+  | "skipped_disabled_merchant"
+  | "skipped_no_secret"
+  | "skipped_no_recipient"
+  | "skipped_no_page_url"
+  | "skipped_test_merchant"
+  | "skipped_already_sent"
+  | "refused_by_worker"
+  | "failed";
+
+export interface BrandPageEmailResult {
+  outcome: BrandPageEmailOutcome;
+  /** Plain words. A refusal that is not returned and rendered is worse than
+   *  the bug it prevents. */
+  detail: string;
+}
+
+const SENT_CHECK = `#graphql
+  query InkBrandPageEmailSent($orderId: ID!) {
+    order(id: $orderId) {
+      name
+      metafield(namespace: "${NAMESPACE}", key: "${SENT_KEY}") { value }
+    }
+  }
+`;
+
+const STAMP = `#graphql
+  mutation InkBrandPageEmailStamp($metafields: [MetafieldsSetInput!]!) {
+    metafieldsSet(metafields: $metafields) {
+      userErrors { field message }
+    }
+  }
+`;
+
+/** A deliberately narrow shape check. A bounce is what kills a sending domain,
+ *  and in.ink also carries every merchant's own mail. */
+export function looksLikeAnAddress(value: unknown): boolean {
+  const s = String(value ?? "").trim();
+  if (!s || s.length > 254 || /\s/.test(s)) return false;
+  return /^[^@\s]+@[^@\s.]+(\.[^@\s.]+)+$/.test(s);
+}
+
+/** DEFAULT OFF. Only an explicit `true` turns this on for a shop — the mirror
+ *  image of `branded_tracking_link`, and deliberately so: that one is a link
+ *  the merchant already sends, this one is a new email to their customer. The
+ *  rule lives with the other two switches. */
+export { brandPageEmailEnabled } from "./tracking-card-switches";
+
+/** The merchant's own addresses — the only ones a test-flagged shop may reach. */
+function ownAddressesOf(brandDoc: Loose): string[] {
+  const fromEnv = (process.env.SEND_ALLOWLIST || "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  return [
+    ...fromEnv,
+    ...[brandDoc?.owner_email, brandDoc?.support_email, brandDoc?.email]
+      .map((v) => String(v ?? "").trim().toLowerCase())
+      .filter(Boolean),
+  ];
+}
+
+/**
+ * One email, from the brand, carrying the page — for a buyer whose shipping
+ * email has already gone out with the carrier's link in it.
+ *
+ * Never throws: this runs on the fulfillment webhook path, where the only
+ * unforgivable outcome is a non-200.
+ */
+export async function sendBrandPageEmailOnce({
+  admin,
+  shop,
+  orderGid,
+  orderName,
+  customerEmail,
+  proofId,
+  fulfillmentId,
+  merchantApiKey,
+  merchantData,
+  fetchImpl = fetch,
+  label = "brand-page-email",
+}: {
+  admin: GraphqlAdmin;
+  shop: string;
+  orderGid: string;
+  orderName: string;
+  customerEmail: string | null | undefined;
+  proofId: string;
+  fulfillmentId: string;
+  merchantApiKey?: string | null;
+  merchantData: Loose;
+  fetchImpl?: typeof fetch;
+  label?: string;
+}): Promise<BrandPageEmailResult> {
+  try {
+    if (process.env.BRAND_PAGE_EMAIL_DISABLED) {
+      console.log(`✉️ ${label}: OFF by env — the brand sends nothing.`);
+      return { outcome: "skipped_disabled_env", detail: "turned off everywhere by the env kill switch" };
+    }
+    if (merchantData?.brand_page_email !== true) {
+      console.log(`✉️ ${label}: OFF for ${shop} (default) — no second email.`);
+      return {
+        outcome: "skipped_disabled_merchant",
+        detail: "this shop has not turned on the brand's own email",
+      };
+    }
+    const secret = process.env.BUYER_MAIL_SECRET;
+    if (!secret) {
+      console.warn(
+        `✉️ ${label}: BUYER_MAIL_SECRET is not set on this service — the brand's email cannot be sent. ` +
+          `Set the same value here and on the Worker.`,
+      );
+      return { outcome: "skipped_no_secret", detail: "the shared secret for the mail rail is not configured" };
+    }
+    if (!looksLikeAnAddress(customerEmail)) {
+      console.log(`✉️ ${label}: ${orderName} has no usable customer address — nothing to send to.`);
+      return { outcome: "skipped_no_recipient", detail: "the order carries no usable email address" };
+    }
+    const to = String(customerEmail).trim();
+
+    // ONE AUTHOR for the page address, the brand slug and the brand doc — the
+    // same resolution the tracking rewrite and the order door use.
+    const resolved = await resolveBrandPageUrl({ merchantApiKey, proofId, shop, merchantData, label });
+    if (!resolved.pageUrl || !resolved.brandDoc?.brand_slug) {
+      console.log(
+        `✉️ ${label}: no page for ${orderName} (slug=${resolved.brandDoc?.brand_slug ? resolved.brandSlug : "none"}, ` +
+          `token=${resolved.nfcToken ?? "none"}) — refusing to email a host nobody serves.`,
+      );
+      return { outcome: "skipped_no_page_url", detail: "this order has no brand page address yet" };
+    }
+    const brandDoc = resolved.brandDoc;
+
+    // A test-flagged merchant may only ever reach its own inbox. Same rule as
+    // the state emails, and the Worker enforces it again from `test_context`.
+    const isTest = Boolean(brandDoc.returns_test_mode || brandDoc.is_test);
+    if (isTest && !ownAddressesOf(brandDoc).includes(to.toLowerCase())) {
+      console.log(`✉️ ${label}: ${shop} is a test shop — refusing to reach a real customer.`);
+      return {
+        outcome: "skipped_test_merchant",
+        detail: "this is a test shop, so only the merchant's own address can be reached",
+      };
+    }
+
+    // ONE PER ORDER, EVER. Checked here so a repeat costs nothing on the wire;
+    // the Worker's own key per fulfillment catches anything that gets past it.
+    const check = await admin.graphql(SENT_CHECK, { variables: { orderId: orderGid } });
+    const checkJson = (await check.json()) as Loose;
+    const checkedOrder = (checkJson?.data as Loose | undefined)?.order as Loose | undefined;
+    const already = (checkedOrder?.metafield as Loose | undefined)?.value;
+    if (already) {
+      console.log(`✉️ ${label}: ${orderName} already had the brand's email (${String(already)}) — never twice.`);
+      return { outcome: "skipped_already_sent", detail: `already sent for this order (${String(already)})` };
+    }
+
+    const body = {
+      shop_id: resolved.proofShopId || shop,
+      fulfillment_id: String(fulfillmentId),
+      order_name: orderName,
+      to,
+      brand_slug: resolved.brandSlug,
+      brand_name:
+        (brandDoc.shop_name as string | undefined) ||
+        (brandDoc.name as string | undefined) ||
+        resolved.brandSlug,
+      page_url: resolved.pageUrl,
+      reply_to:
+        (brandDoc.support_email as string | undefined) ||
+        (brandDoc.owner_email as string | undefined) ||
+        null,
+      postal_address: postalLineOf(brandDoc),
+      test_context: isTest,
+      owner_email:
+        (brandDoc.owner_email as string | undefined) ||
+        (brandDoc.support_email as string | undefined) ||
+        null,
+    };
+
+    const res = await fetchImpl(`${WORKER_BASE}${BUYER_MAIL_PATH}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Buyer-Mail-Secret": secret },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json().catch(() => null)) as Loose | null;
+
+    if (!res.ok || json?.ok !== true) {
+      // RELAY THE RAIL'S OWN WORDS. A status code we chose carries no diagnosis.
+      const detail = String(json?.error || json?.reason || `HTTP ${res.status}`);
+      console.warn(`✉️ ${label}: the mail rail refused ${orderName} — ${detail}`);
+      return { outcome: "refused_by_worker", detail };
+    }
+    if (json?.sent !== true) {
+      const detail = String(json?.reason || "the rail accepted it and sent nothing");
+      console.log(`✉️ ${label}: nothing sent for ${orderName} — ${detail}`);
+      return { outcome: "refused_by_worker", detail };
+    }
+
+    // STAMP AFTER A REAL SEND, never before: a failed send must stay retryable.
+    const stamp = await admin.graphql(STAMP, {
+      variables: {
+        metafields: [
+          {
+            ownerId: orderGid,
+            namespace: NAMESPACE,
+            key: SENT_KEY,
+            type: "single_line_text_field",
+            value: new Date().toISOString(),
+          },
+        ],
+      },
+    });
+    const stampJson = (await stamp.json()) as Loose;
+    const stampSet = (stampJson?.data as Loose | undefined)?.metafieldsSet as Loose | undefined;
+    const stampErrors = (stampSet?.userErrors as Loose[] | undefined) ?? [];
+    if (stampErrors.length > 0) {
+      console.warn(
+        `✉️ ${label}: sent for ${orderName} but the stamp failed — the Worker's own key is the remaining guard: ` +
+          stampErrors.map((e) => String(e?.message ?? e)).join("; "),
+      );
+    }
+    console.log(`✅ ${label}: ${orderName} — the brand emailed the page to the buyer.`);
+    return { outcome: "sent", detail: "the brand emailed the page" };
+  } catch (e) {
+    const said = e instanceof Error ? e.message : String(e);
+    console.error(`✉️ ${label}: threw (non-fatal) — ${said}`);
+    return { outcome: "failed", detail: said };
+  }
+}
+
+/** The merchant's postal address as one line, from the return address they
+ *  already gave the returns rail. Null when the record does not carry one —
+ *  the email then goes without it and the log says so, rather than inventing
+ *  an address for a real brand (the Clare-V law). */
+export function postalLineOf(brandDoc: Loose): string | null {
+  const a = brandDoc?.return_address as Loose | undefined;
+  if (!a || typeof a !== "object") return null;
+  const parts = [a.name, a.company, a.street1 ?? a.address1, a.street2 ?? a.address2, a.city, a.state ?? a.province, a.zip ?? a.postal_code, a.country]
+    .map((v) => String(v ?? "").trim())
+    .filter(Boolean);
+  return parts.length > 0 ? parts.join(", ") : null;
+}

--- a/app/services/brand-page-email.server.ts
+++ b/app/services/brand-page-email.server.ts
@@ -41,6 +41,7 @@
 
 import { WORKER_BASE } from "./brand-email.server";
 import { resolveBrandPageUrl } from "./brand-page-url.server";
+import { brandPageEmailEnabled } from "./tracking-card-switches";
 
 type Loose = Record<string, unknown>;
 
@@ -100,7 +101,7 @@ export function looksLikeAnAddress(value: unknown): boolean {
  *  image of `branded_tracking_link`, and deliberately so: that one is a link
  *  the merchant already sends, this one is a new email to their customer. The
  *  rule lives with the other two switches. */
-export { brandPageEmailEnabled } from "./tracking-card-switches";
+export { brandPageEmailEnabled };
 
 /** The merchant's own addresses — the only ones a test-flagged shop may reach. */
 function ownAddressesOf(brandDoc: Loose): string[] {
@@ -153,7 +154,7 @@ export async function sendBrandPageEmailOnce({
       console.log(`✉️ ${label}: OFF by env — the brand sends nothing.`);
       return { outcome: "skipped_disabled_env", detail: "turned off everywhere by the env kill switch" };
     }
-    if (merchantData?.brand_page_email !== true) {
+    if (!brandPageEmailEnabled(merchantData)) {
       console.log(`✉️ ${label}: OFF for ${shop} (default) — no second email.`);
       return {
         outcome: "skipped_disabled_merchant",
@@ -285,11 +286,27 @@ export async function sendBrandPageEmailOnce({
 /** The merchant's postal address as one line, from the return address they
  *  already gave the returns rail. Null when the record does not carry one —
  *  the email then goes without it and the log says so, rather than inventing
- *  an address for a real brand (the Clare-V law). */
+ *  an address for a real brand (the Clare-V law).
+ *
+ *  THE FIELD NAMES ARE MEASURED, NOT ASSUMED. The backend merchant record for
+ *  Steve Madden (`shop_bb508e5ca47a1036`, read 2026-09-05) carries
+ *  `{name, line1, line2, city, state, zip, country}`. A reader that only knew
+ *  `street1`/`address1` would have dropped the street out of a real brand's
+ *  email and said nothing — the silent-success shape. The other spellings stay
+ *  because the returns rail has accepted them from other writers. */
 export function postalLineOf(brandDoc: Loose): string | null {
   const a = brandDoc?.return_address as Loose | undefined;
   if (!a || typeof a !== "object") return null;
-  const parts = [a.name, a.company, a.street1 ?? a.address1, a.street2 ?? a.address2, a.city, a.state ?? a.province, a.zip ?? a.postal_code, a.country]
+  const parts = [
+    a.name,
+    a.company,
+    a.line1 ?? a.street1 ?? a.address1,
+    a.line2 ?? a.street2 ?? a.address2,
+    a.city,
+    a.state ?? a.province,
+    a.zip ?? a.postal_code,
+    a.country,
+  ]
     .map((v) => String(v ?? "").trim())
     .filter(Boolean);
   return parts.length > 0 ? parts.join(", ") : null;

--- a/app/services/brand-page-email.test.ts
+++ b/app/services/brand-page-email.test.ts
@@ -1,0 +1,278 @@
+// THE BRAND'S OWN EMAIL — the decider's fences, each proven to refuse.
+//
+// This module can put a second email in a buyer's inbox. Everything here is
+// about the cases where it must not: the switch it is off behind by default,
+// a test shop reaching a real customer, an order that already had one, a page
+// that does not exist, and a rail whose refusal must come back in words rather
+// than as a silent success.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const resolveBrandPageUrl = vi.hoisted(() => vi.fn());
+vi.mock("./brand-page-url.server", () => ({ resolveBrandPageUrl }));
+
+import {
+  sendBrandPageEmailOnce,
+  brandPageEmailEnabled,
+  looksLikeAnAddress,
+  postalLineOf,
+  SENT_KEY,
+  BUYER_MAIL_PATH,
+} from "./brand-page-email.server";
+
+const ORDER_GID = "gid://shopify/Order/7658201874670";
+
+type Loose = Record<string, unknown>;
+
+function fakeAdmin({ sent = null as string | null, stampErrors = [] as Loose[] }) {
+  const calls: Array<{ query: string; variables?: Loose }> = [];
+  return {
+    calls,
+    graphql: vi.fn(async (query: string, opts?: { variables?: Loose }) => {
+      calls.push({ query, variables: opts?.variables });
+      if (query.includes("InkBrandPageEmailStamp")) {
+        return { json: async () => ({ data: { metafieldsSet: { userErrors: stampErrors } } }) } as unknown as Response;
+      }
+      return {
+        json: async () => ({
+          data: { order: { name: "#1027", metafield: sent ? { value: sent } : null } },
+        }),
+      } as unknown as Response;
+    }),
+  };
+}
+
+function fakeFetch(body: Loose = { ok: true, sent: true }, status = 200) {
+  return vi.fn(async () => ({
+    ok: status < 400,
+    status,
+    json: async () => body,
+  })) as unknown as typeof fetch;
+}
+
+const BRAND_DOC = {
+  brand_slug: "stevemadden",
+  shop_name: "SM Test",
+  support_email: "support@example.com",
+  owner_email: "owner@example.com",
+  return_address: { name: "SM Test", street1: "1 Example St", city: "New York", state: "NY", zip: "10001", country: "US" },
+};
+
+type Overrides = Partial<Parameters<typeof sendBrandPageEmailOnce>[0]>;
+
+const run = (over: Overrides = {}) =>
+  sendBrandPageEmailOnce({
+    admin: fakeAdmin({}),
+    shop: "sm-test-hhawzn52.myshopify.com",
+    orderGid: ORDER_GID,
+    orderName: "#1027",
+    customerEmail: "buyer@example.com",
+    proofId: "proof_1",
+    fulfillmentId: "6983263912174",
+    merchantApiKey: "ink_x",
+    merchantData: { brand_page_email: true },
+    fetchImpl: fakeFetch(),
+    ...over,
+  });
+
+beforeEach(() => {
+  resolveBrandPageUrl.mockReset();
+  resolveBrandPageUrl.mockResolvedValue({
+    pageUrl: "https://stevemadden.in.ink/r/nfc_tok",
+    nfcToken: "nfc_tok",
+    brandSlug: "stevemadden",
+    proofShopId: "shop_bb508e5ca47a1036",
+    brandDoc: BRAND_DOC,
+    customerTier: null,
+  });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  process.env.BUYER_MAIL_SECRET = "s3cret";
+  delete process.env.BRAND_PAGE_EMAIL_DISABLED;
+  delete process.env.SEND_ALLOWLIST;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.BUYER_MAIL_SECRET;
+  delete process.env.BRAND_PAGE_EMAIL_DISABLED;
+  delete process.env.SEND_ALLOWLIST;
+});
+
+describe("the switch is OFF until a merchant says otherwise", () => {
+  it("DEFAULT OFF: only an explicit true turns it on", () => {
+    expect(brandPageEmailEnabled({})).toBe(false);
+    expect(brandPageEmailEnabled(undefined)).toBe(false);
+    expect(brandPageEmailEnabled({ brand_page_email: false })).toBe(false);
+    expect(brandPageEmailEnabled({ brand_page_email: true })).toBe(true);
+  });
+
+  it("an untouched merchant sends nothing, and touches no wire at all", async () => {
+    const fetchImpl = fakeFetch();
+    const admin = fakeAdmin({});
+    const out = await run({ merchantData: {}, admin, fetchImpl });
+    expect(out.outcome).toBe("skipped_disabled_merchant");
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(admin.graphql).not.toHaveBeenCalled();
+  });
+
+  it("the env kill switch beats the merchant's own on", async () => {
+    process.env.BRAND_PAGE_EMAIL_DISABLED = "1";
+    const fetchImpl = fakeFetch();
+    expect((await run({ fetchImpl })).outcome).toBe("skipped_disabled_env");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("the refusals", () => {
+  it("no shared secret means nothing is attempted, and the log says which one", async () => {
+    delete process.env.BUYER_MAIL_SECRET;
+    const fetchImpl = fakeFetch();
+    const out = await run({ fetchImpl });
+    expect(out.outcome).toBe("skipped_no_secret");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("an order with no customer address reaches nobody", async () => {
+    const fetchImpl = fakeFetch();
+    expect((await run({ customerEmail: null, fetchImpl })).outcome).toBe("skipped_no_recipient");
+    expect((await run({ customerEmail: "  ", fetchImpl })).outcome).toBe("skipped_no_recipient");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("NO PAGE, NO EMAIL — never a host nobody serves (the #1016 law)", async () => {
+    // brandSlug is populated and plausible; the DOC does not carry brand_slug.
+    resolveBrandPageUrl.mockResolvedValue({
+      pageUrl: "https://sm-test-hhawzn52.in.ink/r/nfc_tok",
+      brandSlug: "sm-test-hhawzn52",
+      brandDoc: {},
+      proofShopId: "shop_x",
+    });
+    const fetchImpl = fakeFetch();
+    expect((await run({ fetchImpl })).outcome).toBe("skipped_no_page_url");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("a test shop never reaches a real customer", async () => {
+    resolveBrandPageUrl.mockResolvedValue({
+      pageUrl: "https://stevemadden.in.ink/r/nfc_tok",
+      brandSlug: "stevemadden",
+      proofShopId: "shop_x",
+      brandDoc: { ...BRAND_DOC, returns_test_mode: true },
+    });
+    const fetchImpl = fakeFetch();
+    expect((await run({ fetchImpl })).outcome).toBe("skipped_test_merchant");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("a test shop MAY reach the merchant's own address — that is how it is tried", async () => {
+    resolveBrandPageUrl.mockResolvedValue({
+      pageUrl: "https://stevemadden.in.ink/r/nfc_tok",
+      brandSlug: "stevemadden",
+      proofShopId: "shop_x",
+      brandDoc: { ...BRAND_DOC, is_test: true },
+    });
+    const out = await run({ customerEmail: "owner@example.com" });
+    expect(out.outcome).toBe("sent");
+  });
+
+  it("one email per order, ever", async () => {
+    const fetchImpl = fakeFetch();
+    const admin = fakeAdmin({ sent: "2026-09-05T02:10:00.000Z" });
+    const out = await run({ admin, fetchImpl });
+    expect(out.outcome).toBe("skipped_already_sent");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("never throws, whatever the wire does", async () => {
+    const fetchImpl = vi.fn(async () => { throw new Error("dns"); }) as unknown as typeof fetch;
+    const out = await run({ fetchImpl });
+    expect(out.outcome).toBe("failed");
+    expect(out.detail).toContain("dns");
+  });
+});
+
+describe("what it asks the rail for", () => {
+  it("posts the brand, the page, the reply-to and the fulfilment it is keyed on", async () => {
+    const fetchImpl = fakeFetch();
+    await run({ fetchImpl });
+    const [url, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain(BUYER_MAIL_PATH);
+    expect((init.headers as Record<string, string>)["X-Buyer-Mail-Secret"]).toBe("s3cret");
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({
+      shop_id: "shop_bb508e5ca47a1036",
+      fulfillment_id: "6983263912174",
+      to: "buyer@example.com",
+      brand_slug: "stevemadden",
+      brand_name: "SM Test",
+      page_url: "https://stevemadden.in.ink/r/nfc_tok",
+      reply_to: "support@example.com",
+      test_context: false,
+      owner_email: "owner@example.com",
+    });
+    expect(body.postal_address).toContain("1 Example St");
+  });
+
+  it("tells the rail when the shop is a test shop, so the fence exists on both sides", async () => {
+    resolveBrandPageUrl.mockResolvedValue({
+      pageUrl: "https://stevemadden.in.ink/r/nfc_tok",
+      brandSlug: "stevemadden",
+      proofShopId: "shop_x",
+      brandDoc: { ...BRAND_DOC, is_test: true },
+    });
+    const fetchImpl = fakeFetch();
+    await run({ customerEmail: "owner@example.com", fetchImpl });
+    expect(JSON.parse((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1].body).test_context).toBe(true);
+  });
+});
+
+describe("the rail's own words come back", () => {
+  it("a refusal is relayed verbatim, never dressed as a send", async () => {
+    const out = await run({ fetchImpl: fakeFetch({ ok: false, error: "Resend 403: domain is not verified" }, 502) });
+    expect(out.outcome).toBe("refused_by_worker");
+    expect(out.detail).toContain("domain is not verified");
+  });
+
+  it("a 200 that sent nothing is NOT a send — the success-costume law", async () => {
+    const admin = fakeAdmin({});
+    const out = await run({ admin, fetchImpl: fakeFetch({ ok: true, sent: false, reason: "suppressed — bounced previously" }) });
+    expect(out.outcome).toBe("refused_by_worker");
+    expect(out.detail).toContain("suppressed");
+    // And nothing was stamped, so a later fix can still send.
+    expect(admin.calls.some((c) => c.query.includes("Stamp"))).toBe(false);
+  });
+
+  it("stamps the order only after a real send", async () => {
+    const admin = fakeAdmin({});
+    const out = await run({ admin });
+    expect(out.outcome).toBe("sent");
+    const stamp = admin.calls.find((c) => c.query.includes("InkBrandPageEmailStamp"));
+    expect((stamp?.variables?.metafields as Loose[])[0]).toMatchObject({
+      ownerId: ORDER_GID,
+      namespace: "ink",
+      key: SENT_KEY,
+    });
+  });
+
+  it("a failed stamp still reports the send — the rail's own key is the remaining guard", async () => {
+    const admin = fakeAdmin({ stampErrors: [{ message: "throttled" }] });
+    expect((await run({ admin })).outcome).toBe("sent");
+  });
+});
+
+describe("the small honest helpers", () => {
+  it("an address is an address", () => {
+    expect(looksLikeAnAddress("a@b.co")).toBe(true);
+    expect(looksLikeAnAddress("a b@b.co")).toBe(false);
+    expect(looksLikeAnAddress("a@b")).toBe(false);
+    expect(looksLikeAnAddress("")).toBe(false);
+    expect(looksLikeAnAddress(null)).toBe(false);
+    expect(looksLikeAnAddress(`${"x".repeat(250)}@b.co`)).toBe(false);
+  });
+
+  it("the postal line is the merchant's own, or nothing at all", () => {
+    expect(postalLineOf(BRAND_DOC)).toBe("SM Test, 1 Example St, New York, NY, 10001, US");
+    expect(postalLineOf({})).toBeNull();
+    expect(postalLineOf({ return_address: {} })).toBeNull();
+  });
+});

--- a/app/services/brand-page-email.test.ts
+++ b/app/services/brand-page-email.test.ts
@@ -275,4 +275,23 @@ describe("the small honest helpers", () => {
     expect(postalLineOf({})).toBeNull();
     expect(postalLineOf({ return_address: {} })).toBeNull();
   });
+
+  it("READS THE SHAPE THE REAL RECORD USES — line1/line2, measured on Steve Madden", () => {
+    // Verbatim from merchants/shop_bb508e5ca47a1036 on 2026-09-05. A reader
+    // that only knew street1/address1 would have dropped the street out of a
+    // real brand's email and reported a clean send.
+    expect(
+      postalLineOf({
+        return_address: {
+          country: "US",
+          line2: "",
+          zip: "10036",
+          city: "New York",
+          name: "Times Square Store",
+          state: "ny",
+          line1: "3 Times Square",
+        },
+      }),
+    ).toBe("Times Square Store, 3 Times Square, New York, ny, 10036, US");
+  });
 });

--- a/app/services/branded-tracking-link.canary.test.ts
+++ b/app/services/branded-tracking-link.canary.test.ts
@@ -103,9 +103,68 @@ describe("the outbox canary — the happy path actually rewrites the link", () =
     // answering its question better — the number and company stay visible.
     expect(input.company).toBe("UPS");
 
-    // NO SILENT NOTIFICATION: rewriting a link must never re-send a shipping
-    // email to a buyer who already got one.
+    // NO SILENT NOTIFICATION: with no decider supplied, this is byte-identical
+    // to every rewrite this app has ever made. Silence is the default.
     expect(variables.notifyCustomer).toBe(false);
+  });
+
+  it("a decider that says yes makes Shopify send its own shipping email", async () => {
+    // Sam, 2026-09-05: "the email from shopify should have a link to the buyers
+    // in.ink order." The decider answers from Shopify's own timeline; here it
+    // stands for a buyer who has had no shipping email at all.
+    const admin = fakeAdmin();
+    const result = await assertBrandedTrackingUrl({
+      admin,
+      ...base(),
+      shouldNotifyCustomer: async () => true,
+    });
+    expect(admin.calls[0].variables.notifyCustomer).toBe(true);
+    expect(result.notifiedCustomer).toBe(true);
+    // The email Shopify composes carries the URL THIS mutation sets, which is
+    // why the notify rides the rewrite instead of a second call.
+    expect((admin.calls[0].variables.trackingInfoInput as Record<string, unknown>).url).toBe(
+      "https://clarev.in.ink/r/nfc_test_token",
+    );
+  });
+
+  it("a decider that says no leaves the buyer alone", async () => {
+    const admin = fakeAdmin();
+    const result = await assertBrandedTrackingUrl({
+      admin,
+      ...base(),
+      shouldNotifyCustomer: async () => false,
+    });
+    expect(admin.calls[0].variables.notifyCustomer).toBe(false);
+    expect(result.notifiedCustomer).toBe(false);
+  });
+
+  it("A DECIDER THAT FELL OVER HAS NOT PROVEN THE BUYER GOT NOTHING", async () => {
+    const admin = fakeAdmin();
+    const result = await assertBrandedTrackingUrl({
+      admin,
+      ...base(),
+      shouldNotifyCustomer: async () => {
+        throw new Error("timeline unreadable");
+      },
+    });
+    expect(admin.calls[0].variables.notifyCustomer).toBe(false);
+    expect(result.outcome).toBe("updated");
+  });
+
+  it("the decision is asked ONCE, and only when a rewrite is really going to happen", async () => {
+    const decider = vi.fn(async () => true);
+    // A dead feed refuses before the mutation, so the timeline is never read —
+    // one Shopify call per event is the whole steady-state cost.
+    await assertBrandedTrackingUrl({
+      admin: fakeAdmin(),
+      ...base(),
+      shippoRegistered: false,
+      shouldNotifyCustomer: decider,
+    });
+    expect(decider).not.toHaveBeenCalled();
+
+    await assertBrandedTrackingUrl({ admin: fakeAdmin(), ...base(), shouldNotifyCustomer: decider });
+    expect(decider).toHaveBeenCalledTimes(1);
   });
 
   it("a multi-parcel fulfillment uses the plural form, one page per number", async () => {

--- a/app/services/branded-tracking-link.server.ts
+++ b/app/services/branded-tracking-link.server.ts
@@ -27,8 +27,19 @@
 //     everywhere; `merchants/{shop}.branded_tracking_link === false` turns it
 //     off for one merchant. Rollout is default-ON for every merchant (Sam,
 //     2026-08-06) — these are the emergency exits, not the opt-in.
-//  4. NO SILENT NOTIFICATION. notifyCustomer:false — rewriting a link must
-//     never re-send a shipping email to a buyer who already got one.
+//  4. NO SILENT NOTIFICATION. Rewriting a link must never re-send a shipping
+//     email to a buyer who already got one — and that sentence has a second
+//     half. Until 2026-09-05 this pinned notifyCustomer to false for EVERY
+//     buyer, including the ones who got nothing at all: a merchant who
+//     fulfills with the notification unticked (3PLs, ShipStation, bulk
+//     fulfillment) sends no shipping email, and we refused to send the one
+//     that would have carried the brand. Sam's ruling that day: "the email
+//     from shopify should have a link to the buyers in.ink order."
+//     So the flag is now DECIDED, not pinned: `shouldNotifyCustomer` is asked
+//     once, at the last possible moment before the mutation, and it answers
+//     from Shopify's own order timeline (shopify-shipping-notice.server.ts).
+//     No decider, or a decider that says no, and the value is false exactly
+//     as before. The default of this argument is silence.
 
 import { resolveBrandPageUrl } from "./brand-page-url.server";
 
@@ -47,6 +58,10 @@ export interface BrandedTrackingResult {
   outcome: BrandedTrackingOutcome;
   url?: string;
   detail?: string;
+  /** Did this rewrite ask Shopify to email the buyer? Only ever true when a
+   *  decider was supplied AND said yes; the caller stamps its own record off
+   *  this, so it must never be optimistic. */
+  notifiedCustomer?: boolean;
 }
 
 const MUTATION = `#graphql
@@ -94,6 +109,7 @@ export async function assertBrandedTrackingUrl({
   merchantApiKey,
   merchantData,
   shippoRegistered,
+  shouldNotifyCustomer,
   label = "branded-tracking-link",
 }: {
   admin: { graphql: (query: string, opts?: any) => Promise<Response> };
@@ -106,6 +122,13 @@ export async function assertBrandedTrackingUrl({
   /** From the backend's PATCH /proofs/:id/tracking response. Only `true`
    *  means the Shippo feed is registered and our page can actually speak. */
   shippoRegistered: boolean;
+  /** Asked ONCE, immediately before the mutation, and only when a rewrite is
+   *  actually going to happen — so an echo or a dead feed costs nothing. It
+   *  answers "has this buyer already had a shipping email for this
+   *  fulfillment?" from Shopify's own timeline. Absent ⇒ notifyCustomer:false,
+   *  byte-identical to every rewrite before 2026-09-05. It must never throw;
+   *  a thrown decider is treated as a no. */
+  shouldNotifyCustomer?: () => Promise<boolean>;
   label?: string;
 }): Promise<BrandedTrackingResult> {
   const carrier = String(payload?.tracking_company || "").trim() || "(no carrier name)";
@@ -170,12 +193,26 @@ export async function assertBrandedTrackingUrl({
       : { number: numbers[0], url: resolved.pageUrl }),
   };
 
+  // THE LAST MOMENT. Everything above has already agreed to rewrite, so this
+  // question is asked once per real rewrite and never on a refusal.
+  let notifyCustomer = false;
+  if (shouldNotifyCustomer) {
+    try {
+      notifyCustomer = (await shouldNotifyCustomer()) === true;
+    } catch (e) {
+      // A decider that fell over has not proven the buyer got nothing.
+      const said = e instanceof Error ? e.message : String(e);
+      console.warn(`🔗 ${label}: the notify decision threw — sending silently. ${said}`);
+      notifyCustomer = false;
+    }
+  }
+
   try {
     const res = await admin.graphql(MUTATION, {
       variables: {
         fulfillmentId: `gid://shopify/Fulfillment/${fulfillmentRawId}`,
         trackingInfoInput,
-        notifyCustomer: false,
+        notifyCustomer,
       },
     });
     const json: any = await res.json();
@@ -190,8 +227,13 @@ export async function assertBrandedTrackingUrl({
       console.error(`🔗 ${label}: GraphQL error — ${detail}`);
       return { outcome: "failed", detail };
     }
-    console.log(`✅ ${label}: ${carrier} tracking for proof ${proofId} now points at ${resolved.pageUrl}`);
-    return { outcome: "updated", url: resolved.pageUrl };
+    console.log(
+      `✅ ${label}: ${carrier} tracking for proof ${proofId} now points at ${resolved.pageUrl}` +
+        (notifyCustomer
+          ? " — and Shopify is sending its own shipping email, carrying that address."
+          : ""),
+    );
+    return { outcome: "updated", url: resolved.pageUrl, notifiedCustomer: notifyCustomer };
   } catch (e: any) {
     // Webhook discipline: a failed rewrite is a link that stays as Shopify's.
     // It is never a non-200.

--- a/app/services/shipping-email-wiring.test.ts
+++ b/app/services/shipping-email-wiring.test.ts
@@ -1,0 +1,96 @@
+// THE WIRING, PINNED TO THE SOURCE.
+//
+// Both services here are correct in isolation and worth nothing unless the
+// webhook actually calls them, at the right moment, on both paths. A unit test
+// cannot see a call site that was never written — the sibling repo's 2026-07-20
+// outage was a correct change with every gate green, because every gate asked
+// about code shape and none asked whether the product still worked.
+//
+// So these read the files that ship and assert the seams that make the promise:
+//  · the notify decision rides the rewrite that sets the URL, not a second call
+//  · BOTH fulfilment paths are wired, or the 3PL population is silently excluded
+//  · our ask is stamped the moment Shopify accepts it
+//  · the brand's email fires only in the case it exists for
+//  · the merchant can actually see both switches on the card
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const read = (p: string) => readFileSync(resolve(process.cwd(), p), "utf8");
+
+const CREATE = read("app/routes/webhooks.fulfillments_create.tsx");
+const UPDATE = read("app/routes/webhooks.fulfillments_update.tsx");
+const CARD = read("app/components/settings/DeliveryModeSettings.tsx");
+const ROUTE = read("app/routes/app.api.settings.branded-tracking-link.tsx");
+const LINK = read("app/services/branded-tracking-link.server.ts");
+
+describe.each([
+  ["fulfillments/create", CREATE],
+  ["fulfillments/update", UPDATE],
+])("%s", (_name, src) => {
+  it("hands the rewrite a decider instead of a hardcoded flag", () => {
+    expect(src).toContain("decideShopifyShippingNotice");
+    expect(src).toMatch(/shouldNotifyCustomer:\s*async \(\) => \(await decideOnce\(\)\)\.notifyCustomer/);
+  });
+
+  it("reads the timeline at most once per event", () => {
+    // Two callers, one answer: the rewrite's decider and the brand email below
+    // it both go through decideOnce.
+    expect(src.match(/decideShopifyShippingNotice\(/g)?.length).toBe(1);
+    expect(src.match(/decideOnce\(\)/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("stamps our ask as soon as Shopify accepts it", () => {
+    expect(src).toContain("stampShippingNotice");
+    expect(src).toMatch(/if \(branded\.notifiedCustomer\)/);
+  });
+
+  it("sends the brand's own email ONLY when Shopify already emailed this buyer", () => {
+    expect(src).toContain("sendBrandPageEmailOnce");
+    expect(src).toMatch(/verdict\.decision === "skipped_already_sent_by_shopify"/);
+  });
+
+  it("costs a merchant who never turned the second email on absolutely nothing", () => {
+    expect(src).toMatch(/brandPageEmailEnabled\((merchantHit|hit)\?\.data \?\? \{\}\) &&/);
+  });
+});
+
+describe("the rewrite itself", () => {
+  it("still defaults to silence — no decider means notifyCustomer:false", () => {
+    expect(LINK).toContain("let notifyCustomer = false;");
+    expect(LINK).toMatch(/if \(shouldNotifyCustomer\) \{/);
+    // The flag passed to Shopify is the decided variable, never a literal.
+    expect(LINK).toMatch(/variables: \{[\s\S]*?notifyCustomer,\n/);
+  });
+
+  it("treats a decider that threw as a no", () => {
+    // Read the decider block itself rather than counting characters: a pin
+    // that measures distance goes red the next time somebody adds a line.
+    const start = LINK.indexOf("if (shouldNotifyCustomer) {");
+    const block = LINK.slice(start, LINK.indexOf("admin.graphql(MUTATION", start));
+    expect(start).toBeGreaterThan(0);
+    expect(block).toContain("(await shouldNotifyCustomer()) === true");
+    expect(block).toContain("catch (e)");
+    expect(block).toContain("notifyCustomer = false;");
+  });
+});
+
+describe("what the merchant sees", () => {
+  it("the tracking-link card carries both switches, and no new card was added", () => {
+    expect(CARD).toContain('id="ink-shopify-shipping-email"');
+    expect(CARD).toContain('id="ink-brand-page-email"');
+    // Two annotated sections, exactly as before: Delivery mode and Tracking link.
+    expect(CARD.match(/<Layout\.AnnotatedSection/g)).toHaveLength(2);
+  });
+
+  it("the second switch names the merchant's own brand", () => {
+    expect(CARD).toContain("Email the page from ${brand}");
+  });
+
+  it("one endpoint serves all three switches", () => {
+    expect(ROUTE).toContain("readTrackingCardSwitches");
+    expect(ROUTE).toContain("trackingCardUpdatesFrom");
+    // A body naming nothing we know is a refusal in words, not a quiet no-op.
+    expect(ROUTE).toMatch(/Object\.keys\(updates\)\.length === 0/);
+  });
+});

--- a/app/services/shipping-email-wiring.test.ts
+++ b/app/services/shipping-email-wiring.test.ts
@@ -93,4 +93,14 @@ describe("what the merchant sees", () => {
     // A body naming nothing we know is a refusal in words, not a quiet no-op.
     expect(ROUTE).toMatch(/Object\.keys\(updates\)\.length === 0/);
   });
+
+  it("SAVES WHERE THE WEBHOOK READS — the same resolver, not a private lookup", () => {
+    // A switch written to a document the webhook never opens is a switch that
+    // saves and does nothing. Measured 2026-09-05: one connected store
+    // (smusic-official) already holds those as two different documents.
+    expect(ROUTE).toContain("findMerchantDocRef");
+    expect(ROUTE).not.toContain("async function getMerchantDoc");
+    // And it writes through that resolver's own ref.
+    expect(ROUTE).toMatch(/hit\.ref\.update\(/);
+  });
 });

--- a/app/services/shopify-shipping-notice.server.ts
+++ b/app/services/shopify-shipping-notice.server.ts
@@ -53,6 +53,8 @@
 // today's behaviour. The cost of a wrong YES is a second email in a stranger's
 // inbox, which is not ours to spend.
 
+import { shippingNoticeEnabled } from "./tracking-card-switches";
+
 /** Anything Shopify hands back, before we have looked at it. */
 type Loose = Record<string, unknown>;
 
@@ -145,7 +147,7 @@ function mailTemplateName(args: unknown): string {
  *  merchant off, and the env kills it everywhere. The rule itself lives with
  *  the other two switches, so "absent means on" cannot drift between the
  *  screen that shows it and the webhook that obeys it. */
-export { shippingNoticeEnabled } from "./tracking-card-switches";
+export { shippingNoticeEnabled };
 
 /**
  * Should Shopify send its shipping email for this fulfillment — the one that
@@ -189,7 +191,7 @@ export async function decideShopifyShippingNotice({
     console.log(`📨 ${label}: OFF by env — Shopify sends nothing on our account.`);
     return no("skipped_disabled_env", "turned off everywhere by the env kill switch");
   }
-  if (merchantData?.shopify_shipping_email === false) {
+  if (!shippingNoticeEnabled(merchantData)) {
     console.log(`📨 ${label}: OFF for ${shop} — the merchant turned this off.`);
     return no("skipped_disabled_merchant", "this shop turned the setting off");
   }

--- a/app/services/shopify-shipping-notice.server.ts
+++ b/app/services/shopify-shipping-notice.server.ts
@@ -1,0 +1,346 @@
+// SHOPIFY'S OWN SHIPPING EMAIL, CARRYING THE BRAND'S PAGE — the decision.
+//
+// SAM'S RULING, 2026-09-05: "there was a timing issue — the email from shopify
+// should have a link to the buyers in.ink order."
+//
+// THE TIMING, MEASURED (Steve Madden order #1027, store sm-test-hhawzn52, read
+// from Shopify's own order timeline):
+//
+//   01:59:28Z  fulfillment created
+//   01:59:29Z  mail_sent · "Shipping confirmation" · delivery_status delivered
+//   01:59:35Z  fulfillment_tracking_info_updated · by "The Ritualist"
+//
+// Shopify composes the shipping email at the instant of fulfillment. Our
+// branded rewrite lands SIX SECONDS later, and it lands with
+// `notifyCustomer:false` — so the email the buyer actually opened carried
+// ups.com. Nothing of ours runs earlier than Shopify's own composer, and no
+// API can edit a notification template. The one lever left is the SECOND email
+// Shopify will send about a tracking change: the merchant's own template, from
+// the merchant's own sending domain, whose tracking button renders whatever
+// URL the fulfillment carries at compose time — ours.
+//
+// WHICH TEMPLATE. Shopify's help centre states the trigger of each customer
+// notification: "Shipping confirmation — Sent when an order is fulfilled";
+// "Shipping update — Sent when tracking information is updated"
+// (https://help.shopify.com/en/manual/fulfillment/setup/notifications/customer-notifications).
+// So a notifying `fulfillmentTrackingInfoUpdate` sends SHIPPING UPDATE, never
+// Shipping confirmation. The confirmation is unreachable by any app; only the
+// merchant's pasted Liquid line can put the page in that one (embed #105).
+//
+// RULE 4 NOW MEANS WHAT IT SAYS. `branded-tracking-link.server.ts` reads:
+// "rewriting a link must never re-send a shipping email to a buyer who already
+// got one." The implementation pinned notifyCustomer to false for EVERY buyer,
+// including the ones who got nothing at all — a merchant who fulfills with the
+// notification unticked (3PLs, ShipStation, bulk fulfillment) sends their buyer
+// no shipping email whatsoever, and we then refuse to send the one that would
+// have carried the brand. This module supplies the missing half of the
+// sentence: has this buyer already got one?
+//
+// THE SIGNAL, AND WHY IT IS NOT A STRING MATCH. Shopify records every customer
+// email it sends as an order event with `action: "mail_sent"`; `arguments[0]`
+// names the template ("Shipping confirmation", "Order Confirmation"). That name
+// is merchant-facing prose and is localized, so matching on it would be a fence
+// that quietly opens in French. We match on TIME instead: any `mail_sent` at or
+// after the fulfillment's own creation is, by construction, an email about this
+// shipment — an order confirmation fires when the order is placed, which on
+// #1027 was seven hours earlier. The template names are logged verbatim anyway,
+// so the real distribution accumulates in the Cloud Run log the way the
+// carrier-skip log accumulates carriers.
+//
+// FAIL CLOSED, ALWAYS TOWARDS SILENCE. Every uncertainty — an unreadable
+// timeline, a fulfillment too young for the mail event to have landed, a
+// missing order id — resolves to "do not notify". The cost of a wrong NO is
+// today's behaviour. The cost of a wrong YES is a second email in a stranger's
+// inbox, which is not ours to spend.
+
+/** Anything Shopify hands back, before we have looked at it. */
+type Loose = Record<string, unknown>;
+
+export interface GraphqlAdmin {
+  graphql: (query: string, opts?: { variables?: Record<string, unknown> }) => Promise<Response>;
+}
+
+const NAMESPACE = "ink";
+/** One order, one notice from us, ever. The value is the fulfillment id we
+ *  notified for, so the log can say which parcel spoke. A split shipment gets
+ *  ONE email because the page is per ORDER — it shows the whole order, and a
+ *  second email would point at the same page. */
+export const NOTICE_KEY = "shipping_notice";
+
+/** How old a fulfillment must be before "no mail yet" is trustworthy.
+ *  Shopify stamped the mail_sent event ONE second after the fulfillment on the
+ *  measured order, and our own rewrite arrives at about six; three seconds is
+ *  the margin between those two facts, and it is logged on every pass so the
+ *  real distribution is visible rather than assumed. */
+export const MIN_FULFILLMENT_AGE_MS = 3000;
+
+export type ShippingNoticeDecision =
+  | "notify"
+  | "skipped_disabled_env"
+  | "skipped_disabled_merchant"
+  | "skipped_already_notified_by_us"
+  | "skipped_already_sent_by_shopify"
+  | "skipped_fulfillment_too_young"
+  | "skipped_no_order_id"
+  | "skipped_no_fulfillment_created_at"
+  | "skipped_timeline_unreadable";
+
+export interface ShippingNoticeVerdict {
+  decision: ShippingNoticeDecision;
+  /** True only for "notify" — the single boolean the mutation needs. */
+  notifyCustomer: boolean;
+  /** Plain words, for the log and for any caller that reports refusals. */
+  detail: string;
+  /** Every mail Shopify already sent about this shipment, newest first, as
+   *  `"<template name> @ <iso>"`. Empty when none. The expansion list. */
+  mailAlreadySent: string[];
+  /** Measured age of the fulfillment at decision time, in ms. */
+  fulfillmentAgeMs: number | null;
+}
+
+const GUARD_QUERY = `#graphql
+  query InkShippingNoticeGuard($orderId: ID!) {
+    order(id: $orderId) {
+      id
+      name
+      metafield(namespace: "${NAMESPACE}", key: "${NOTICE_KEY}") { value }
+      events(first: 40, sortKey: CREATED_AT, reverse: true) {
+        nodes {
+          id
+          createdAt
+          ... on BasicEvent {
+            action
+            arguments
+          }
+        }
+      }
+    }
+  }
+`;
+
+const STAMP_MUTATION = `#graphql
+  mutation InkShippingNoticeStamp($metafields: [MetafieldsSetInput!]!) {
+    metafieldsSet(metafields: $metafields) {
+      userErrors { field message }
+    }
+  }
+`;
+
+/** Whatever a thrown value was, said in words. */
+function asMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/** The template name Shopify put in the event, or a readable stand-in. The
+ *  first argument of a `mail_sent` event is the message type; everything after
+ *  it is recipient and delivery detail we deliberately do not log (PII). */
+function mailTemplateName(args: unknown): string {
+  if (Array.isArray(args) && args.length > 0 && typeof args[0] === "string") {
+    return args[0];
+  }
+  return "(unnamed email)";
+}
+
+/** Default ON (Sam's ruling is the default); only an explicit `false` turns one
+ *  merchant off, and the env kills it everywhere. The rule itself lives with
+ *  the other two switches, so "absent means on" cannot drift between the
+ *  screen that shows it and the webhook that obeys it. */
+export { shippingNoticeEnabled } from "./tracking-card-switches";
+
+/**
+ * Should Shopify send its shipping email for this fulfillment — the one that
+ * will carry the brand's page, because our URL is on the fulfillment by the
+ * time it composes?
+ *
+ * Never throws: a webhook's only unforgivable outcome is a non-200.
+ */
+export async function decideShopifyShippingNotice({
+  admin,
+  shop,
+  orderGid,
+  fulfillmentPayload,
+  merchantData,
+  now = Date.now(),
+  label = "shipping-notice",
+}: {
+  admin: GraphqlAdmin;
+  shop: string;
+  orderGid: string | null | undefined;
+  /** The Fulfillment webhook payload — `id` and `created_at` are what matter. */
+  fulfillmentPayload: Loose | null | undefined;
+  merchantData: Loose;
+  now?: number;
+  label?: string;
+}): Promise<ShippingNoticeVerdict> {
+  const no = (
+    decision: ShippingNoticeDecision,
+    detail: string,
+    extra: Partial<ShippingNoticeVerdict> = {},
+  ): ShippingNoticeVerdict => ({
+    decision,
+    notifyCustomer: false,
+    detail,
+    mailAlreadySent: [],
+    fulfillmentAgeMs: null,
+    ...extra,
+  });
+
+  if (process.env.SHOPIFY_SHIPPING_EMAIL_DISABLED) {
+    console.log(`📨 ${label}: OFF by env — Shopify sends nothing on our account.`);
+    return no("skipped_disabled_env", "turned off everywhere by the env kill switch");
+  }
+  if (merchantData?.shopify_shipping_email === false) {
+    console.log(`📨 ${label}: OFF for ${shop} — the merchant turned this off.`);
+    return no("skipped_disabled_merchant", "this shop turned the setting off");
+  }
+  if (!orderGid) {
+    console.warn(`📨 ${label}: no order id on the fulfillment — cannot read the timeline.`);
+    return no("skipped_no_order_id", "the fulfillment named no order");
+  }
+
+  const createdAtRaw = fulfillmentPayload?.created_at;
+  const createdAtMs = createdAtRaw ? Date.parse(String(createdAtRaw)) : NaN;
+  if (!Number.isFinite(createdAtMs)) {
+    console.warn(`📨 ${label}: fulfillment carries no readable created_at — refusing to guess.`);
+    return no("skipped_no_fulfillment_created_at", "the fulfillment carries no creation time");
+  }
+  const ageMs = now - createdAtMs;
+
+  // A fulfillment younger than the margin cannot yet prove Shopify sent
+  // nothing: the mail event lands about a second after fulfillment and this
+  // read could win the race. Silence is the safe side of that coin.
+  if (ageMs < MIN_FULFILLMENT_AGE_MS) {
+    console.log(
+      `📨 ${label}: fulfillment is ${ageMs}ms old (< ${MIN_FULFILLMENT_AGE_MS}ms) — too early to know ` +
+        `whether Shopify already emailed; leaving it to Shopify's own notification.`,
+    );
+    return no("skipped_fulfillment_too_young", "checked too soon after fulfillment to be sure", {
+      fulfillmentAgeMs: ageMs,
+    });
+  }
+
+  let order: Loose | null = null;
+  try {
+    const res = await admin.graphql(GUARD_QUERY, { variables: { orderId: orderGid } });
+    const json = (await res.json()) as Loose;
+    const topErrors = Array.isArray(json?.errors) ? (json.errors as Loose[]) : [];
+    if (topErrors.length > 0) {
+      const detail = topErrors.map((e) => String(e?.message ?? e)).join("; ");
+      console.warn(`📨 ${label}: Shopify would not read the timeline — ${detail}`);
+      return no("skipped_timeline_unreadable", `Shopify refused the timeline read: ${detail}`, {
+        fulfillmentAgeMs: ageMs,
+      });
+    }
+    order = ((json?.data as Loose | undefined)?.order as Loose | undefined) ?? null;
+  } catch (e) {
+    console.warn(`📨 ${label}: timeline read threw (non-fatal) — ${asMessage(e)}`);
+    return no("skipped_timeline_unreadable", `the timeline read failed: ${asMessage(e)}`, {
+      fulfillmentAgeMs: ageMs,
+    });
+  }
+
+  const eventNodes = ((order?.events as Loose | undefined)?.nodes as Loose[] | undefined) ?? null;
+  if (!order || !Array.isArray(eventNodes)) {
+    console.warn(`📨 ${label}: no timeline for ${orderGid} — refusing to notify on an unknown history.`);
+    return no("skipped_timeline_unreadable", "the order's timeline came back empty", {
+      fulfillmentAgeMs: ageMs,
+    });
+  }
+
+  // OUR OWN STAMP FIRST — one notice per order, ever, even if Shopify's
+  // timeline read is generous and even across webhook redeliveries.
+  const stamped = (order?.metafield as Loose | undefined)?.value;
+  if (stamped) {
+    console.log(`📨 ${label}: ${String(order.name ?? orderGid)} already has our notice (${String(stamped)}) — never twice.`);
+    return no("skipped_already_notified_by_us", `we already asked Shopify to email this order (${String(stamped)})`, {
+      fulfillmentAgeMs: ageMs,
+    });
+  }
+
+  // THE MEASUREMENT. Any customer email Shopify recorded at or after this
+  // fulfillment was born is an email about this shipment.
+  const mailAlreadySent: string[] = [];
+  for (const node of eventNodes) {
+    if (node?.action !== "mail_sent") continue;
+    const at = Date.parse(String(node?.createdAt ?? ""));
+    if (!Number.isFinite(at) || at < createdAtMs) continue;
+    mailAlreadySent.push(`${mailTemplateName(node.arguments)} @ ${String(node.createdAt)}`);
+  }
+
+  if (mailAlreadySent.length > 0) {
+    // NO SILENT CAPS: the template names are the expansion list, exactly as the
+    // carrier names are for the branded link.
+    console.log(
+      `📨 ${label}: Shopify already emailed this buyer about ${String(order.name ?? orderGid)} ` +
+        `[${mailAlreadySent.join(" | ")}] — never a second shipping email from us. ` +
+        `(fulfillment age ${ageMs}ms)`,
+    );
+    return no(
+      "skipped_already_sent_by_shopify",
+      `Shopify already sent ${mailAlreadySent.length} email(s) for this shipment`,
+      { mailAlreadySent, fulfillmentAgeMs: ageMs },
+    );
+  }
+
+  console.log(
+    `📨 ${label}: no customer email exists for ${String(order.name ?? orderGid)} since the fulfillment ` +
+      `(age ${ageMs}ms) — asking Shopify to send ONE shipping update, carrying the brand's page.`,
+  );
+  return {
+    decision: "notify",
+    notifyCustomer: true,
+    detail: "no shipping email exists for this fulfillment yet",
+    mailAlreadySent: [],
+    fulfillmentAgeMs: ageMs,
+  };
+}
+
+/**
+ * Record that we asked Shopify to email this order. Written only AFTER the
+ * notifying mutation succeeded, so a failed ask stays retryable — the same
+ * order the state emails use for their sent-stamps.
+ *
+ * Never throws. A lost stamp is a possible duplicate on a webhook redelivery,
+ * which is worth a warning and never worth a non-200.
+ */
+export async function stampShippingNotice({
+  admin,
+  orderGid,
+  fulfillmentId,
+  label = "shipping-notice",
+}: {
+  admin: GraphqlAdmin;
+  orderGid: string;
+  fulfillmentId: string;
+  label?: string;
+}): Promise<boolean> {
+  try {
+    const res = await admin.graphql(STAMP_MUTATION, {
+      variables: {
+        metafields: [
+          {
+            ownerId: orderGid,
+            namespace: NAMESPACE,
+            key: NOTICE_KEY,
+            type: "single_line_text_field",
+            value: `${fulfillmentId}@${new Date().toISOString()}`,
+          },
+        ],
+      },
+    });
+    const json = (await res.json()) as Loose;
+    const set = (json?.data as Loose | undefined)?.metafieldsSet as Loose | undefined;
+    const errors = (set?.userErrors as Loose[] | undefined) ?? [];
+    if (errors.length > 0) {
+      console.warn(
+        `📨 ${label}: Shopify emailed the buyer but the stamp failed — a redelivery could repeat it: ` +
+          errors.map((e) => String(e?.message ?? e)).join("; "),
+      );
+      return false;
+    }
+    return true;
+  } catch (e) {
+    console.warn(`📨 ${label}: stamp threw (non-fatal) — ${asMessage(e)}`);
+    return false;
+  }
+}

--- a/app/services/shopify-shipping-notice.test.ts
+++ b/app/services/shopify-shipping-notice.test.ts
@@ -1,0 +1,238 @@
+// THE DECISION: does Shopify still owe this buyer a shipping email?
+//
+// Every test here names the bad outcome it prevents. Two of them are the whole
+// point of the module: a buyer who already had a shipping email must never get
+// a second, and a buyer who had none must get the one that carries the page.
+//
+// THE FIXTURE IS REAL. The timeline below is Steve Madden order #1027, read off
+// Shopify on 2026-09-05 — the fulfilment at 01:59:28Z, the shipping
+// confirmation one second later, our own rewrite six seconds after that. If
+// Shopify ever changes the shape of a `mail_sent` event, these go red against
+// the shape that actually shipped rather than one somebody imagined.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  decideShopifyShippingNotice,
+  stampShippingNotice,
+  shippingNoticeEnabled,
+  MIN_FULFILLMENT_AGE_MS,
+  NOTICE_KEY,
+} from "./shopify-shipping-notice.server";
+
+const FULFILLED_AT = "2026-09-05T01:59:28Z";
+const ORDER_GID = "gid://shopify/Order/7658201874670";
+
+/** Verbatim from the store, minus the buyer's address. */
+const SHIPPING_CONFIRMATION = {
+  id: "gid://shopify/BasicEvent/177427766313100",
+  __typename: "BasicEvent",
+  createdAt: "2026-09-05T01:59:29Z",
+  action: "mail_sent",
+  arguments: ["Shipping confirmation", "buyer@example.com", "api_client_id", 1830279],
+  message: "SM Test Admin sent a shipping confirmation email to a customer.",
+};
+const ORDER_CONFIRMATION = {
+  id: "gid://shopify/BasicEvent/177427766313101",
+  __typename: "BasicEvent",
+  // Seven hours BEFORE the fulfilment — the event that must never be mistaken
+  // for a shipping email, and the reason this matches on time not on words.
+  createdAt: "2026-09-04T18:56:54Z",
+  action: "mail_sent",
+  arguments: ["Order Confirmation", "buyer@example.com"],
+  message: "Order confirmation email was sent to a customer.",
+};
+const FULFILLMENT_SUCCESS = {
+  id: "gid://shopify/BasicEvent/177427766313102",
+  __typename: "BasicEvent",
+  createdAt: "2026-09-05T01:59:29Z",
+  action: "fulfillment_success",
+  arguments: [6983263912174, 1],
+  message: "SM Test Admin marked 1 item as fulfilled from Shop location.",
+};
+
+type Loose = Record<string, unknown>;
+
+function fakeAdmin({
+  events = [] as Loose[],
+  metafield = null as string | null,
+  errors = null as Loose[] | null,
+  throwWith = "",
+}) {
+  const calls: Array<{ query: string; variables?: Loose }> = [];
+  return {
+    calls,
+    graphql: vi.fn(async (query: string, opts?: { variables?: Loose }) => {
+      calls.push({ query, variables: opts?.variables });
+      if (throwWith) throw new Error(throwWith);
+      if (query.includes("InkShippingNoticeStamp")) {
+        return { json: async () => ({ data: { metafieldsSet: { userErrors: [] } } }) } as unknown as Response;
+      }
+      if (errors) return { json: async () => ({ errors }) } as unknown as Response;
+      return {
+        json: async () => ({
+          data: {
+            order: {
+              id: ORDER_GID,
+              name: "#1027",
+              metafield: metafield ? { value: metafield } : null,
+              events: { nodes: events },
+            },
+          },
+        }),
+      } as unknown as Response;
+    }),
+  };
+}
+
+/** Well past the young-fulfilment margin, as every real webhook is. */
+const NOW = Date.parse(FULFILLED_AT) + 6000;
+
+type Overrides = Partial<Parameters<typeof decideShopifyShippingNotice>[0]>;
+
+const decide = (over: Overrides = {}) =>
+  decideShopifyShippingNotice({
+    admin: fakeAdmin({}),
+    shop: "sm-test-hhawzn52.myshopify.com",
+    orderGid: ORDER_GID,
+    fulfillmentPayload: { id: 6983263912174, created_at: FULFILLED_AT },
+    merchantData: {},
+    now: NOW,
+    ...over,
+  });
+
+beforeEach(() => {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  delete process.env.SHOPIFY_SHIPPING_EMAIL_DISABLED;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.SHOPIFY_SHIPPING_EMAIL_DISABLED;
+});
+
+describe("the buyer who already had a shipping email", () => {
+  it("is NEVER emailed again — rule 4, in the half it always meant", async () => {
+    const admin = fakeAdmin({ events: [SHIPPING_CONFIRMATION, FULFILLMENT_SUCCESS, ORDER_CONFIRMATION] });
+    const out = await decide({ admin });
+    expect(out.decision).toBe("skipped_already_sent_by_shopify");
+    expect(out.notifyCustomer).toBe(false);
+  });
+
+  it("names what Shopify sent, so the real template names accumulate in the log", async () => {
+    const admin = fakeAdmin({ events: [SHIPPING_CONFIRMATION] });
+    const out = await decide({ admin });
+    expect(out.mailAlreadySent).toEqual([`Shipping confirmation @ ${SHIPPING_CONFIRMATION.createdAt}`]);
+  });
+
+  it("counts ANY email sent since the fulfilment, whatever it is called — the fence must hold in every language", async () => {
+    const localized = { ...SHIPPING_CONFIRMATION, arguments: ["Confirmation d’expédition", "buyer@example.com"] };
+    const out = await decide({ admin: fakeAdmin({ events: [localized] }) });
+    expect(out.decision).toBe("skipped_already_sent_by_shopify");
+  });
+});
+
+describe("the buyer who had nothing", () => {
+  it("gets the one email that carries the page", async () => {
+    const admin = fakeAdmin({ events: [FULFILLMENT_SUCCESS, ORDER_CONFIRMATION] });
+    const out = await decide({ admin });
+    expect(out.decision).toBe("notify");
+    expect(out.notifyCustomer).toBe(true);
+    expect(out.mailAlreadySent).toEqual([]);
+  });
+
+  it("an order confirmation from hours earlier does NOT count as a shipping email", async () => {
+    // The whole reason the match is on time and not on the template's name:
+    // every order has an order confirmation, and a name check that got this
+    // wrong would silently turn the feature off for every merchant.
+    const out = await decide({ admin: fakeAdmin({ events: [ORDER_CONFIRMATION] }) });
+    expect(out.decision).toBe("notify");
+  });
+
+  it("reads the timeline exactly once, with the order it was given", async () => {
+    const admin = fakeAdmin({ events: [] });
+    await decide({ admin });
+    expect(admin.graphql).toHaveBeenCalledOnce();
+    expect(admin.calls[0].variables).toEqual({ orderId: ORDER_GID });
+  });
+});
+
+describe("the switches", () => {
+  it("the env kill switch turns it off everywhere and reads nothing", async () => {
+    process.env.SHOPIFY_SHIPPING_EMAIL_DISABLED = "1";
+    const admin = fakeAdmin({ events: [] });
+    const out = await decide({ admin });
+    expect(out.decision).toBe("skipped_disabled_env");
+    expect(admin.graphql).not.toHaveBeenCalled();
+  });
+
+  it("a merchant who turned it off is left alone, and costs no API call", async () => {
+    const admin = fakeAdmin({ events: [] });
+    const out = await decide({ admin, merchantData: { shopify_shipping_email: false } });
+    expect(out.decision).toBe("skipped_disabled_merchant");
+    expect(admin.graphql).not.toHaveBeenCalled();
+  });
+
+  it("DEFAULT ON: an absent field is not a refusal", () => {
+    expect(shippingNoticeEnabled({})).toBe(true);
+    expect(shippingNoticeEnabled(undefined)).toBe(true);
+    expect(shippingNoticeEnabled({ shopify_shipping_email: true })).toBe(true);
+    expect(shippingNoticeEnabled({ shopify_shipping_email: false })).toBe(false);
+  });
+});
+
+describe("every uncertainty resolves to silence", () => {
+  it("our own stamp stops a second ask, even across a webhook redelivery", async () => {
+    const admin = fakeAdmin({ events: [], metafield: "6983263912174@2026-09-05T02:00:00.000Z" });
+    const out = await decide({ admin });
+    expect(out.decision).toBe("skipped_already_notified_by_us");
+    expect(out.notifyCustomer).toBe(false);
+  });
+
+  it("a fulfilment younger than the margin is too early to know", async () => {
+    const out = await decide({ now: Date.parse(FULFILLED_AT) + MIN_FULFILLMENT_AGE_MS - 1 });
+    expect(out.decision).toBe("skipped_fulfillment_too_young");
+    expect(out.fulfillmentAgeMs).toBe(MIN_FULFILLMENT_AGE_MS - 1);
+  });
+
+  it("a timeline Shopify refused to read is never read as 'nothing was sent'", async () => {
+    const admin = fakeAdmin({ errors: [{ message: "Access denied for events field" }] });
+    const out = await decide({ admin });
+    expect(out.decision).toBe("skipped_timeline_unreadable");
+    expect(out.detail).toContain("Access denied");
+  });
+
+  it("a timeline read that threw is not a clean history either", async () => {
+    const out = await decide({ admin: fakeAdmin({ throwWith: "network down" }) });
+    expect(out.decision).toBe("skipped_timeline_unreadable");
+    expect(out.notifyCustomer).toBe(false);
+  });
+
+  it("a fulfilment with no creation time is refused rather than guessed", async () => {
+    const out = await decide({ fulfillmentPayload: { id: 1 } });
+    expect(out.decision).toBe("skipped_no_fulfillment_created_at");
+  });
+
+  it("a fulfilment naming no order is refused", async () => {
+    const out = await decide({ orderGid: null });
+    expect(out.decision).toBe("skipped_no_order_id");
+  });
+
+  it("never throws, whatever happens", async () => {
+    await expect(decide({ admin: fakeAdmin({ throwWith: "boom" }) })).resolves.toBeTruthy();
+  });
+});
+
+describe("the stamp", () => {
+  it("writes the fulfilment it notified for, on the order", async () => {
+    const admin = fakeAdmin({});
+    const ok = await stampShippingNotice({ admin, orderGid: ORDER_GID, fulfillmentId: "998" });
+    expect(ok).toBe(true);
+    const mf = (admin.calls[0].variables?.metafields as Loose[])[0];
+    expect(mf).toMatchObject({ ownerId: ORDER_GID, namespace: "ink", key: NOTICE_KEY });
+    expect(String(mf.value)).toContain("998@");
+  });
+
+  it("a failed stamp is reported, never thrown — the webhook still 200s", async () => {
+    const admin = { graphql: vi.fn(async () => { throw new Error("nope"); }) };
+    await expect(stampShippingNotice({ admin, orderGid: ORDER_GID, fulfillmentId: "1" })).resolves.toBe(false);
+  });
+});

--- a/app/services/tracking-card-switches.test.ts
+++ b/app/services/tracking-card-switches.test.ts
@@ -1,0 +1,63 @@
+// THE THREE DEFAULTS, PINNED. Each of these is a product decision, and each
+// one has already been written down in more than one place once. If a reader
+// and a writer ever disagree about "absent means on", a merchant's setting
+// silently stops meaning what the screen says it means.
+import { describe, it, expect } from "vitest";
+import {
+  SWITCH_FIELDS,
+  readTrackingCardSwitches,
+  trackingCardUpdatesFrom,
+  brandedTrackingLinkEnabled,
+  shippingNoticeEnabled,
+  brandPageEmailEnabled,
+} from "./tracking-card-switches";
+
+describe("the defaults", () => {
+  it("a merchant who has never opened this card gets the tracking link and Shopify's email, and no second email", () => {
+    expect(readTrackingCardSwitches({})).toEqual({
+      enabled: true,
+      shopifyShippingEmail: true,
+      brandPageEmail: false,
+    });
+    expect(readTrackingCardSwitches(undefined)).toEqual({
+      enabled: true,
+      shopifyShippingEmail: true,
+      brandPageEmail: false,
+    });
+  });
+
+  it("only an explicit false turns the two ON switches off", () => {
+    expect(brandedTrackingLinkEnabled({ branded_tracking_link: false })).toBe(false);
+    expect(shippingNoticeEnabled({ shopify_shipping_email: false })).toBe(false);
+    // Anything that is not literally false is still on — a half-written doc
+    // must not read as a refusal.
+    expect(brandedTrackingLinkEnabled({ branded_tracking_link: null })).toBe(true);
+    expect(shippingNoticeEnabled({ shopify_shipping_email: "no" })).toBe(true);
+  });
+
+  it("only an explicit true turns the OFF switch on", () => {
+    expect(brandPageEmailEnabled({ brand_page_email: true })).toBe(true);
+    expect(brandPageEmailEnabled({ brand_page_email: "yes" })).toBe(false);
+    expect(brandPageEmailEnabled({ brand_page_email: 1 })).toBe(false);
+  });
+});
+
+describe("what an untrusted body may move", () => {
+  it("moves exactly the switches it names, under their Firestore names", () => {
+    expect(trackingCardUpdatesFrom({ enabled: false })).toEqual({ branded_tracking_link: false });
+    expect(trackingCardUpdatesFrom({ shopifyShippingEmail: false, brandPageEmail: true })).toEqual({
+      [SWITCH_FIELDS.shopifyShippingEmail]: false,
+      [SWITCH_FIELDS.brandPageEmail]: true,
+    });
+  });
+
+  it("ignores everything else, including a truthy string", () => {
+    expect(trackingCardUpdatesFrom({ enabled: "true", brand_page_email: true, admin: true })).toEqual({});
+    expect(trackingCardUpdatesFrom(null)).toEqual({});
+    expect(trackingCardUpdatesFrom("enabled")).toEqual({});
+  });
+
+  it("an empty result is how the route knows to answer 400 rather than report a save", () => {
+    expect(Object.keys(trackingCardUpdatesFrom({}))).toHaveLength(0);
+  });
+});

--- a/app/services/tracking-card-switches.ts
+++ b/app/services/tracking-card-switches.ts
@@ -1,0 +1,72 @@
+// THE THREE SWITCHES ON THE TRACKING-LINK CARD — one author for their defaults.
+//
+// Each of these is a per-merchant field on the embed's own merchant doc, and
+// each has a default that is a PRODUCT DECISION, not a coding convenience:
+//
+//   branded_tracking_link   DEFAULT ON  — Sam, 2026-08-06. "Track your shipment"
+//                                         lands on the brand's page.
+//   shopify_shipping_email  DEFAULT ON  — Sam, 2026-09-05. "the email from
+//                                         shopify should have a link to the
+//                                         buyers in.ink order."
+//   brand_page_email        DEFAULT OFF — a SECOND email to somebody else's
+//                                         customer is the merchant's call.
+//
+// The defaults lived in three places for the first switch alone — the route's
+// GET, the route's PATCH and the service that reads it — and "absent means on"
+// is exactly the kind of rule that drifts into "absent means off" in one of
+// them. So it is written once, here, and every reader imports it.
+
+export const SWITCH_FIELDS = {
+  enabled: "branded_tracking_link",
+  shopifyShippingEmail: "shopify_shipping_email",
+  brandPageEmail: "brand_page_email",
+} as const;
+
+export interface TrackingCardSwitches {
+  enabled: boolean;
+  shopifyShippingEmail: boolean;
+  brandPageEmail: boolean;
+}
+
+/** ON unless the doc says `false`. The emergency exit, never the opt-in. */
+export function brandedTrackingLinkEnabled(data: Record<string, unknown> | null | undefined): boolean {
+  return data?.[SWITCH_FIELDS.enabled] !== false;
+}
+
+/** ON unless the doc says `false`. Sam's ruling is the default. */
+export function shippingNoticeEnabled(data: Record<string, unknown> | null | undefined): boolean {
+  return data?.[SWITCH_FIELDS.shopifyShippingEmail] !== false;
+}
+
+/** OFF unless the doc says `true`. The mirror image, and deliberately so. */
+export function brandPageEmailEnabled(data: Record<string, unknown> | null | undefined): boolean {
+  return data?.[SWITCH_FIELDS.brandPageEmail] === true;
+}
+
+/** What the card should show for this merchant. */
+export function readTrackingCardSwitches(
+  data: Record<string, unknown> | null | undefined,
+): TrackingCardSwitches {
+  return {
+    enabled: brandedTrackingLinkEnabled(data),
+    shopifyShippingEmail: shippingNoticeEnabled(data),
+    brandPageEmail: brandPageEmailEnabled(data),
+  };
+}
+
+/** The Firestore fields an untrusted PATCH body is allowed to move.
+ *
+ *  Only known keys survive and only a literal boolean moves a switch — the
+ *  same discipline `sanitizeNotificationSettings` uses, for the same reason:
+ *  the old route wrote what it was handed. An empty result means the body
+ *  named nothing we recognise, and the caller answers 400 rather than
+ *  reporting a save that changed nothing. */
+export function trackingCardUpdatesFrom(body: unknown): Record<string, boolean> {
+  const raw = (body && typeof body === "object" ? body : {}) as Record<string, unknown>;
+  const updates: Record<string, boolean> = {};
+  for (const [key, field] of Object.entries(SWITCH_FIELDS)) {
+    const value = raw[key];
+    if (value === true || value === false) updates[field] = value;
+  }
+  return updates;
+}


### PR DESCRIPTION
> **HELD FOR ROUND FOUR.** Open, never merged, never deployed until Shopify answers the 2026-09-04 resubmission. Merging deploys Cloud Run automatically.

## What a person sees

**The buyer, when the merchant fulfils WITHOUT ticking Shopify's own "Send shipment details".** Today they get no shipping email at all. After this, Shopify sends them one — the merchant's own template, from the merchant's own sending domain — and its tracking button opens `https://{brand}.in.ink/r/{token}`. Exactly one email, ever.

**The buyer, when the merchant DID tick it.** Nothing changes. They already had their shipping email, it already went out with the carrier's link in it, and nothing here sends a second one. If the merchant turns on the second switch below, their brand emails that buyer one short note with the page in it — off unless they ask for it.

**The merchant, in Settings → Delivery → Tracking link.** The card they already have gains two checkboxes under the one that is there now. No new card, no new tab.

## The measurement this is built on

Steve Madden test store `sm-test-hhawzn52`, order **#1027**, read from Shopify's own order timeline on 2026-09-05 (read-only, `order.events`):

```
01:59:28Z  fulfillment created
01:59:29Z  mail_sent   arguments: ["Shipping confirmation", …]   delivery_status: delivered
01:59:35Z  fulfillment_tracking_info_updated   by "The Ritualist"
```

Shopify composes the shipping email at the instant of fulfilment. Our branded rewrite lands **six seconds** later, with `notifyCustomer:false` by rule. So the email the buyer opened carried ups.com, and nothing of ours runs earlier than Shopify's own composer. The 2026-08-07 milestone worked only because the mutation then sent the mail itself.

**The signal, and why it is not a string match.** Shopify records every customer email it sends as an order event with `action: "mail_sent"`, and `arguments[0]` names the template — `"Shipping confirmation"`, `"Order Confirmation"`. That name is merchant-facing prose and is localized, so matching on it would be a fence that quietly opens in French. We match on **time**: any `mail_sent` at or after the fulfilment's own `created_at` is, by construction, an email about this shipment. On #1027 the order confirmation is timestamped 2026-09-04T18:56:54Z — seven hours before the fulfilment — so it is never mistaken for one. The template names are logged verbatim anyway, exactly as skipped carriers are, so the real distribution accumulates instead of being guessed at.

The query, validated against the 2025-10 Admin schema with Shopify's dev MCP validator (required scopes `read_orders`, already held):

```graphql
query InkShippingNoticeGuard($orderId: ID!) {
  order(id: $orderId) {
    id
    name
    metafield(namespace: "ink", key: "shipping_notice") { value }
    events(first: 40, sortKey: CREATED_AT, reverse: true) {
      nodes { id createdAt ... on BasicEvent { action arguments } }
    }
  }
}
```

## Which template Shopify sends, and what its button carries

Shopify's help centre states the trigger of each customer notification: **"Shipping confirmation — Sent when an order is fulfilled"**; **"Shipping update — Sent when tracking information is updated"** ([customer notifications](https://help.shopify.com/en/manual/fulfillment/setup/notifications/customer-notifications)). So a notifying `fulfillmentTrackingInfoUpdate` sends **Shipping update**, never Shipping confirmation.

Say that plainly: **no app can ever put the page in Shopify's Shipping confirmation.** It is composed before any app can react. Only the merchant's pasted Liquid line can reach that one, which is what embed #105 and the order-door line exist for. What this PR reaches is the second email — the one Shopify sends about a tracking change — and for a buyer who has had nothing, that is their only shipping email.

Both shipping templates take their tracking button from `fulfillment.tracking_url` / `fulfillment.tracking_urls` ([email variables](https://help.shopify.com/en/manual/fulfillment/setup/notifications/email-variables)), which is our page by the time this composes, because **the notify rides the very mutation that sets the URL** rather than a second call afterwards. A second call with unchanged tracking info might not count as "updated" at all, and a rail that quietly sends nothing is the worst failure this codebase knows.

## What changes

- **`app/services/shopify-shipping-notice.server.ts`** — the decision, with nine named outcomes. Fails closed towards silence on every uncertainty: an unreadable timeline, a fulfilment younger than 3 s (the margin between Shopify's mail event at +1 s and our rewrite at +6 s, logged on every pass), a missing order id, a missing `created_at`. The cost of a wrong no is today's behaviour; the cost of a wrong yes is a second email in a stranger's inbox.
- **`branded-tracking-link.server.ts`** takes `shouldNotifyCustomer?: () => Promise<boolean>` instead of a pinned `false`, asked **once**, at the last moment before the mutation, and never on a refusal — so an echo or a dead carrier feed costs no extra Shopify call. **No decider, or a decider that says no, or a decider that throws ⇒ `notifyCustomer: false`, byte-identical to every rewrite this app has made.** Rule 4's comment now carries both halves of its own sentence.
- **Idempotency** — order metafield `ink.shipping_notice`, holding the fulfilment id we notified for, written only after Shopify accepts the mutation, so a failed ask stays retryable and a webhook redelivery can never repeat it. One notice **per order**, not per fulfilment, because the page is per order: a split shipment gets one email pointing at the page that shows the whole order.
- **`app/services/brand-page-email.server.ts`** — the other case. When Shopify's email already went out, the brand can email the page itself. **DEFAULT OFF.** Five refusals, each returned in words and logged: the switch, no shared secret, no recipient or no page, a test shop reaching anyone but its own owner, and one email per order ever.
- **Both fulfilment paths are wired** — `fulfillments/create` and `fulfillments/update`. Tracking that arrives late (the 3PL and ShipStation shape) reaches the buyer through the second one, and leaving it out would silently exclude that whole population.
- **`app/services/tracking-card-switches.ts`** — the three defaults in one place. `branded_tracking_link` ON, `shopify_shipping_email` ON, `brand_page_email` OFF. The first one's default already lived in three files, and "absent means on" is exactly the rule that drifts into "absent means off" in one of them.
- **Kill switches**, mirroring the existing one: env `SHOPIFY_SHIPPING_EMAIL_DISABLED` and `BRAND_PAGE_EMAIL_DISABLED`; per shop, the two Firestore fields above.
- **Scope: nothing new.** `read_orders` for the timeline and `write_orders` for the metafield are both already in `shopify.app.toml` and `app/shopify.server.ts`, and this webhook already writes `ink.*` order metafields. No merchant re-consents; the reviewed scope set is unchanged; this PR alone needs no resubmission.

## Where the second email is sent, and why not here

Measured 2026-09-05 on the live service: Cloud Run `shopify-app` carries `SENDGRID_API_KEY` and **no** `RESEND_API_KEY`. Resend is bound on the Cloudflare Worker, together with `RESEND_WEBHOOK_SECRET` and — the deciding fact — the **suppression list** (`outreach-suppress:{address}` in the `DEMO_REGISTRY` namespace, written by Resend's bounce webhook and read fail-closed). An address that hard-bounced must never be mailed again by anything ink runs, and a second suppression list in this repo would be one more copy that drifts from its original.

So the sending lives in the Worker, in **ssmusic/the-ritualist #1256 (https://github.com/ssmusic/the-ritualist/pull/1256)** — **merged and deployed 2026-09-05 17:39Z**, and inert: measured live straight after the deploy, `POST /api/buyer/page-email` answers `503 {"ok":false,"error":"buyer_mail_secret_not_configured"}` with or without a secret header, and `POST /outreach/send` still answers `401`. **The outreach rail is untouched** — its allowlist and 25-a-day cap are fences around cold letters to strangers; this is a buyer who bought something minutes ago, on a separate route with its own idempotency key, its own per-merchant daily cap and the same suppression list.

## Tests

`npm test` — **195 tests, 19 files** (132 before this PR, 63 new):

- `shopify-shipping-notice.test.ts` (18) — the timeline fixture is verbatim from order #1027. Already-sent never notifies; a localized template name still counts; an order confirmation from hours earlier does not; our own stamp stops a redelivery; a too-young fulfilment, an unreadable timeline, a thrown read, a missing `created_at` and a missing order id all resolve to silence; the timeline is read exactly once; the module never throws.
- `brand-page-email.test.ts` (19) — default off; the env kill switch beats the merchant's on; no secret, no recipient, no page; a test shop cannot reach a real customer but can reach its own owner; one per order; a 200 that sent nothing is **not** a send; the rail's refusal is relayed verbatim; the stamp lands only after a real send.
- `tracking-card-switches.test.ts` (6) — the three defaults, and what an untrusted body may move.
- `shipping-email-wiring.test.ts` (16) — source pins: both webhook paths hand the rewrite a decider, read the timeline at most once, stamp on acceptance, and fire the brand's email only in the case it exists for; the card carries both control ids and is still two sections.
- `branded-tracking-link.canary.test.ts` (+5) — a decider that says yes, one that says no, one that throws, the once-only ask, and the URL the notifying mutation sets.

**Eight sabotages, each proven to go red, then restored** (a guard that passes under sabotage teaches nothing): dropping the time window (2 red) · dropping our own stamp check (1 red) · a thrown decider defaulting to yes (1 red) · accepting any brand's page URL (2 red, Worker) · a suppression lookup that threw reading as clear (1 red, Worker) · the test-shop fence opened (2 red, Worker) · the postal line reading `street1` only (1 red) · the settings route's private merchant lookup put back (1 red).

**Two real bugs this found before it shipped.**

**One — the switch that saved and did nothing.** This route carried its own merchant lookup: the doc whose ID is the shop domain, then a field query, first match wins. The fulfilment webhook uses `findMerchantDocRef`, which prefers the doc actually carrying `ink_api_key`. Where those are two different documents, the merchant flips the switch, the screen says saved, and the webhook reads the other doc. Measured across the thirteen shops holding a Shopify session on 2026-09-05: **`smusic-official.myshopify.com` has exactly that shape** — the route would write `smusic-official.myshopify.com`, the webhook reads `PWXStzc7mP8hn33xPbNf`. So that store's existing `branded_tracking_link` switch has never worked, and both new switches would have inherited it. The route now uses the webhook's own resolver and its private copy is gone — the fifth appearance of the landmine `merchant-doc.server.ts` exists to end (`ebdd8dd`).

**Two — the address that would have vanished.** `postalLineOf` was written against `street1`/`address1`. The backend merchant record for Steve Madden actually carries `{name, line1, line2, city, state, zip, country}` (read 2026-09-05). The street would have been dropped out of a real brand's email and the send would have reported clean — the silent-success shape. Fixed in `4c42397`, with the measured record pinned verbatim in a test.

| Gate | Exit | Number |
|---|---|---|
| `npm run typecheck` | 0 | — |
| `npm test` | 0 | 195 tests, 19 files |
| `npm run build` | 0 | — |
| `npm run lint` | 1 | **469 problems (431 errors, 38 warnings) — identical to `origin/main`'s 469**, measured on a clean worktree of `35ae253`. Lint is not a CI gate here by design; every new file reports zero. |

## Six facts

written ✓ · committed ✓ (`afc4d5b`, `4c42397`, `ebdd8dd`) · pushed ✓ · **not merged** · **not deployed** · **verified by tests and by a read-only measurement of Shopify's order timeline** — no email has been sent by this code. See "What is not verified" below.

## New surfaces

Two controls, both on the **existing** "Tracking link" card in Settings → Delivery (`app/components/settings/DeliveryModeSettings.tsx`). No new card, no new route, no new tab.

- `ink-shopify-shipping-email` — "Send Shopify's shipping email when your customer hasn't had one"
- `ink-brand-page-email` — "Email the page from {brand} when Shopify's email already went out"

Copy on both is **placeholder** — Sam writes the words.

## What is not verified

- **No email has been sent by this code.** The wire test needs an order on the Steve Madden test store whose customer address is Sam's own. Measured: the store owner is `smusic@gmail.com` and the backend merchant record's `owner_email`/`support_email` are both `smusic@gmail.com`, but every order on that store (#1022–#1027) goes to `realprops@gmail.com`. No qualifying order exists, so none was fabricated and nothing was sent. Sam creates the order when he wants it.
- **Which template Shopify actually renders** is taken from Shopify's help centre, not from a message in an inbox. The code measures it anyway: the first real fulfilment writes the answer into the Cloud Run log as `📨 … Shopify already emailed this buyer … [<template name> @ <time>]`, and the next `mail_sent` event on that order names the template Shopify chose.
- **The Resend leg has never run.** It needs `BUYER_MAIL_SECRET` set on both services (below).

## For Sam

**Two things to paste, once each, and only when you want this on.** Both take the same value — a password you invent, at least 32 characters. Nothing sends until both exist, and the rail says so out loud until they do.

On the Worker (prompts for the value, so it never lands in your shell history):

```bash
cd ~/Desktop/INK_7_13/parallelreturns\ master/worker-recovered && npx wrangler@4.99.0 secret put BUYER_MAIL_SECRET
```

On the embed, in the Cloud Run console — `shopify-app` → Edit & deploy new revision → Variables → add `BUYER_MAIL_SECRET` with the same value. The console is the better half here: the CLI form (`gcloud run services update shopify-app --region us-central1 --project inink-c76d3 --update-env-vars BUYER_MAIL_SECRET=…`) works, but it writes the value into your shell history.

**Why a new secret rather than one you already have.** Both services already hold `INK_ADMIN_SECRET`, so reusing it would have cost you nothing. I could not prove the two values are the same: Cloudflare's API returns only `{name, type}` for a Worker secret — no value and no digest — so there is nothing to compare, and a mismatch would have shown up as a silent 401 with no email and no explanation. A purpose-scoped secret also keeps the backend's admin credential out of a mail path it has no business in.

**The default you may want to flip.** "Email the page from {brand} when Shopify's email already went out" is **OFF** for every merchant, because it is a second email to somebody else's customer and that felt like the merchant's call rather than ours. If you would rather it be on for everyone the way the tracking link is, say so: it is one word in `app/services/tracking-card-switches.ts` (`=== true` becomes `!== false`) and one line in this PR.

**After round four, in order:** merge this PR (Cloud Run deploys itself, ~5–6 min; confirm the serving revision flipped) → no `shopify app deploy` is needed for this PR, nothing in the app config changed → on Steve Madden, fulfil a new order **without** ticking "Send shipment details to your customer" → within seconds the Cloud Run log reads `📨 … no customer email exists … asking Shopify to send ONE shipping update, carrying the brand's page`, and the shipping email that arrives opens `stevemadden.in.ink/r/…`. Fulfil a second order **with** the tick, and the log reads `📨 … Shopify already emailed this buyer … never a second shipping email from us`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
