### PR TITLE
Every switch saves into the document its reader opens

### DIFF
--- a/app/routes/app.api.auth.login.tsx
+++ b/app/routes/app.api.auth.login.tsx
@@ -1,6 +1,7 @@
 import { type ActionFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
 import { createMerchant, loginUser } from "../services/ink-api.server";
+import { findMerchantDocRef } from "../services/merchant-doc.server";
 import bcrypt from "bcryptjs";
 import crypto from "crypto";
 
@@ -93,24 +94,25 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         const freshApiKey = inkMerchantRes.api_key;
 
         if (freshApiKey) {
-          // Upsert into Firestore: first try by document ID, then by shopDomain field
-          const existingDoc = await firestore.collection("merchants").doc(merchantId).get();
-          if (existingDoc.exists) {
-            await existingDoc.ref.update({ ink_api_key: freshApiKey, updatedAt: new Date() });
+          // Cache the key in the document every reader opens — findMerchantDocRef,
+          // the resolver the fulfillment webhooks and the notification senders
+          // use. This carried its own lookup (doc-id, then `where("shopDomain")`)
+          // and on a store holding two merchant docs it wrote the key into the
+          // doc-id document while every reader took the one already carrying a
+          // key: a re-login refreshed a key nothing would ever read.
+          const hit = await findMerchantDocRef(firestore, merchantId);
+          if (hit) {
+            await hit.ref.update({ ink_api_key: freshApiKey, updatedAt: new Date() });
           } else {
-            // Also check by shopDomain field  
-            const snapshot = await firestore.collection("merchants").where("shopDomain", "==", merchantId).limit(1).get();
-            if (!snapshot.empty) {
-              await snapshot.docs[0].ref.update({ ink_api_key: freshApiKey, updatedAt: new Date() });
-            } else {
-              // Create new doc with document ID = merchantId for easy future lookups
-              await firestore.collection("merchants").doc(merchantId).set({
-                shopDomain: merchantId,
-                ink_api_key: freshApiKey,
-                createdAt: new Date(),
-                updatedAt: new Date(),
-              });
-            }
+            // Nothing exists yet — create it keyed by merchantId, and name the
+            // shop under every convention the resolver looks for.
+            await firestore.collection("merchants").doc(merchantId).set({
+              shop: merchantId,
+              shopDomain: merchantId,
+              ink_api_key: freshApiKey,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            });
           }
           console.log(`[Auth] Cached ink_api_key for merchant ${merchantId}`);
         }
@@ -158,29 +160,28 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     return json({ error: "Invalid email or password" }, { status: 401 });
   }
 
-  // Ensure the merchant configuration document exists and has a real INK API key (heal from sk_test_fallback)
-  const merchantSnapshot = await firestore
-    .collection("merchants")
-    .where("shopDomain", "==", userData.shopDomain)
-    .limit(1)
-    .get();
+  // Ensure the merchant configuration document exists and has a real INK API key
+  // (heal from sk_test_fallback). Same resolver as the embedded path above and
+  // as every reader — a `where("shopDomain")` of its own could heal a document
+  // the webhooks never open.
+  const merchantHit = await findMerchantDocRef(firestore, userData.shopDomain);
 
-  let apiKey = merchantSnapshot.empty ? null : merchantSnapshot.docs[0].data().ink_api_key;
-  let docId = merchantSnapshot.empty ? null : merchantSnapshot.docs[0].id;
+  let apiKey = merchantHit?.data?.ink_api_key ?? null;
 
   if (!apiKey || apiKey === "sk_test_fallback") {
     console.log(`[Auth] Key missing or fallback for ${userData.shopDomain}. Calling INK Admin API...`);
     try {
       const inkRes = await createMerchant(userData.shopDomain, userData.shopDomain, userData.email || email);
       apiKey = inkRes.api_key;
-      
-      if (docId) {
-        await firestore.collection("merchants").doc(docId).update({
+
+      if (merchantHit) {
+        await merchantHit.ref.update({
           ink_api_key: apiKey,
           updatedAt: new Date(),
         });
       } else {
         await firestore.collection("merchants").add({
+          shop: userData.shopDomain,
           shopDomain: userData.shopDomain,
           ink_api_key: apiKey,
           createdAt: new Date(),

--- a/app/routes/app.api.dashboard.comms.tsx
+++ b/app/routes/app.api.dashboard.comms.tsx
@@ -1,6 +1,7 @@
 import { type LoaderFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
+import { findMerchantDoc } from "../services/merchant-doc.server";
 
 const json = (data: any, init?: ResponseInit) =>
   new Response(JSON.stringify(data), {
@@ -12,11 +13,16 @@ const json = (data: any, init?: ResponseInit) =>
 // the dashboard Communications card (session-authed, mirrors tap-stats).
 // Reads the same merchants/{shop}.notification_settings the Settings panel
 // writes — never invented numbers, just the actual on/off state.
+//
+// THROUGH THE SAME RESOLVER the Settings panel writes with. This read
+// `doc(session.shop)` directly, so on a store holding two merchant docs the
+// card reported "off" for toggles the merchant had actually turned on —
+// settings/notifications saves through findMerchantDocRef.
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   try {
     const { session } = await authenticate.admin(request);
-    const doc = await firestore.collection("merchants").doc(session.shop).get();
-    const settings = doc.exists ? (doc.data()?.notification_settings ?? null) : null;
+    const hit = await findMerchantDoc(firestore, session.shop);
+    const settings = hit?.data?.notification_settings ?? null;
     return json({ settings });
   } catch (err: any) {
     if (err instanceof Response) throw err;

--- a/app/routes/app.api.onboarding.status.tsx
+++ b/app/routes/app.api.onboarding.status.tsx
@@ -1,6 +1,7 @@
 import { type LoaderFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
+import { findMerchantDoc } from "../services/merchant-doc.server";
 import { brandSlugFromDomain } from "../services/email.server";
 import { fetchBrandEmailKit } from "../services/brand-email.server";
 import { getShopIdByDomain, getMerchantTapStats } from "../services/ink-api.server";
@@ -41,8 +42,11 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     let notificationsOn = false;
     let brandSlugOverride: string | undefined;
     try {
-      const doc = await firestore.collection("merchants").doc(shop).get();
-      const d = doc.exists ? doc.data() ?? {} : {};
+      // findMerchantDoc, not `doc(shop)`: settings/notifications writes through
+      // that resolver, and a store holding two merchant docs reported its
+      // notifications step incomplete forever when this read the other one.
+      const hit = await findMerchantDoc(firestore, shop);
+      const d = hit?.data ?? {};
       const ch = d.notification_settings?.channels;
       notificationsOn = Boolean(ch?.email || ch?.sms);
       if (typeof d.brand_slug === "string" && d.brand_slug) brandSlugOverride = d.brand_slug;

--- a/app/routes/app.api.settings.delivery-mode.tsx
+++ b/app/routes/app.api.settings.delivery-mode.tsx
@@ -11,11 +11,20 @@
  *                  of which shipping method the customer picked.
  *
  * Reads/writes are gated by `authenticate.admin(request)` from Shopify.
+ *
+ * WHICH MERCHANT DOC. `findMerchantDocRef` — the same resolver the orders/create
+ * webhook uses to read this field back, not a private lookup. Both sides used
+ * to carry their own (`where("shopDomain")` first, doc-id second). They agreed
+ * on all thirteen connected shops when measured 2026-09-05, but only because a
+ * `limit(1)` field query happened to return the same document the webhook
+ * wanted — Firestore promises no ordering there, so the agreement was luck,
+ * not design. One resolver on both ends makes it design.
  */
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
 import { authenticate } from "../shopify.server";
 import { setCarrierServiceActive } from "../services/carrier-service.server";
+import { findMerchantDocRef } from "../services/merchant-doc.server";
 
 const VALID_MODES = ["background"] as const;
 type DeliveryMode = (typeof VALID_MODES)[number];
@@ -32,29 +41,16 @@ const json = (data: any, init?: ResponseInit) =>
     ...init,
   });
 
-async function getMerchantDoc(shopDomain: string) {
-  const snapshot = await firestore
-    .collection("merchants")
-    .where("shopDomain", "==", shopDomain)
-    .limit(1)
-    .get();
-  if (!snapshot.empty) return snapshot.docs[0];
-  // Fallback: doc keyed by domain directly
-  const direct = await firestore.collection("merchants").doc(shopDomain).get();
-  if (direct.exists) return direct;
-  return null;
-}
-
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (request.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
   }
 
-  const { session } = await authenticate.admin(request);
-  const shopDomain = session.shop;
+  // The gate still runs; the GET has nothing merchant-specific to read —
+  // "background" is the only mode this app supports.
+  await authenticate.admin(request);
 
   try {
-    const doc = await getMerchantDoc(shopDomain);
     const mode: DeliveryMode = "background";
     return json({ mode });
   } catch (err: any) {
@@ -86,8 +82,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       );
     }
 
-    const doc = await getMerchantDoc(shopDomain);
-    if (!doc) {
+    const hit = await findMerchantDocRef(firestore, shopDomain);
+    if (!hit) {
       console.warn(
         `[settings/delivery-mode] Merchant doc not found for ${shopDomain}; cannot persist mode`
       );
@@ -97,7 +93,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       );
     }
 
-    await doc.ref.update({
+    await hit.ref.update({
       verified_delivery_mode: mode,
       updatedAt: new Date(),
     });

--- a/app/routes/app.api.settings.inventory.tsx
+++ b/app/routes/app.api.settings.inventory.tsx
@@ -1,6 +1,7 @@
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
 import { verifyProxyToken } from "../services/token-verify.server";
+import { findMerchantDocRefByShopOrId } from "../services/merchant-doc.server";
 
 /**
  * Inventory Settings endpoint (authenticated by warehouse JWT).
@@ -9,6 +10,14 @@ import { verifyProxyToken } from "../services/token-verify.server";
  *
  * GET  /app/api/settings/inventory → { low_inventory_threshold, min_enrollment_value }
  * POST /app/api/settings/inventory → update settings
+ *
+ * WHICH MERCHANT DOC. `findMerchantDocRefByShopOrId` — the resolver every
+ * reader of these fields uses, not a private lookup. This route had its own
+ * (doc-id by merchant_id, then `where("shopDomain")`), and so did the enroll
+ * gate that reads `min_enrollment_value` back. Two private copies agreeing by
+ * luck is still the §17.2 landmine: they agree only while the shop holds one
+ * merchant doc, and a store that holds two makes the saved minimum invisible
+ * to the gate that enforces it.
  */
 
 const corsHeaders = {
@@ -25,26 +34,6 @@ const json = (data: any, init?: ResponseInit) =>
 
 // Token verification: services/token-verify.server.ts (fail-closed; the old
 // decodeToken computed an HMAC and then never checked it — pure decode).
-
-async function getMerchantDoc(shopDomain?: string, merchantId?: string) {
-  // Try by document ID (merchant_id)
-  if (merchantId) {
-    const doc = await firestore.collection("merchants").doc(merchantId).get();
-    if (doc.exists) return doc;
-  }
-
-  // Try by shopDomain field
-  if (shopDomain) {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shopDomain)
-      .limit(1)
-      .get();
-    if (!snapshot.empty) return snapshot.docs[0];
-  }
-
-  return null;
-}
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (request.method === "OPTIONS") {
@@ -64,8 +53,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { shop: shopDomain, merchant_id: merchantId } = tokenPayload;
 
   try {
-    const doc = await getMerchantDoc(shopDomain, merchantId);
-    const data = doc?.data() ?? {};
+    const hit = await findMerchantDocRefByShopOrId(firestore, shopDomain, merchantId);
+    const data = hit?.data ?? {};
 
     return json({
       low_inventory_threshold: data.low_inventory_threshold ?? 20,
@@ -116,14 +105,16 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     if (low_inventory_threshold !== undefined) updates.low_inventory_threshold = low_inventory_threshold;
     if (min_enrollment_value !== undefined) updates.min_enrollment_value = min_enrollment_value;
 
-    const doc = await getMerchantDoc(shopDomain, merchantId);
-    if (doc) {
-      await doc.ref.update(updates);
+    const hit = await findMerchantDocRefByShopOrId(firestore, shopDomain, merchantId);
+    if (hit) {
+      await hit.ref.update(updates);
     } else {
-      // Create if doesn't exist
+      // Create if doesn't exist. Name the shop under both conventions the
+      // resolver searches, so the next save finds this document instead of
+      // minting a second one beside it.
       const docId = merchantId || shopDomain || "unknown";
       await firestore.collection("merchants").doc(docId).set({
-        shopDomain,
+        ...(shopDomain ? { shop: shopDomain, shopDomain } : {}),
         ...updates,
         createdAt: new Date(),
       }, { merge: true });

--- a/app/routes/app.api.settings.media.tsx
+++ b/app/routes/app.api.settings.media.tsx
@@ -1,7 +1,23 @@
+/**
+ * Merchant media — the bumper the consumer tap plays.
+ *
+ * WHICH MERCHANT DOC. `findMerchantDocRefByShopOrId`, the resolver the reader
+ * uses. api/verify resolves the merchant by `ink_api_key` (the key that just
+ * proved it owns the proof) and reads `merchant_media` off THAT document. This
+ * route carried its own lookup — doc-id by merchant_id, then
+ * `where("shopDomain")` — so on a store holding two merchant docs the merchant
+ * uploaded a bumper, the panel listed it back, and the tap played the default.
+ *
+ * MEASURED, not theoretical: of the thirteen shops holding a Shopify session
+ * on 2026-09-05, `smusic-official.myshopify.com` has exactly this shape — this
+ * route wrote `smusic-official.myshopify.com`, api/verify reads
+ * `PWXStzc7mP8hn33xPbNf`.
+ */
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
 import { verifyProxyToken } from "../services/token-verify.server";
 import { authenticate } from "../shopify.server";
+import { findMerchantDocRefByShopOrId } from "../services/merchant-doc.server";
 
 const INK_API_URL = process.env.INK_API_URL || "https://us-central1-inink-c76d3.cloudfunctions.net/api";
 const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET;
@@ -54,22 +70,6 @@ async function decodeToken(token: string): Promise<{ shop?: string; merchant_id?
   return { shop: payload.shop as string | undefined, merchant_id: payload.merchant_id as string | undefined };
 }
 
-async function getMerchantDoc(shopDomain?: string, merchantId?: string) {
-  if (merchantId) {
-    const doc = await firestore.collection("merchants").doc(merchantId).get();
-    if (doc.exists) return doc;
-  }
-  if (shopDomain) {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shopDomain)
-      .limit(1)
-      .get();
-    if (!snapshot.empty) return snapshot.docs[0];
-  }
-  return null;
-}
-
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (request.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
@@ -117,11 +117,11 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   console.log(`[settings/media] GET proceeding for domain=${shopDomain}, merchantId=${merchantId}`);
 
   try {
-    const doc = await getMerchantDoc(shopDomain, merchantId);
-    if (!doc) {
+    const hit = await findMerchantDocRefByShopOrId(firestore, shopDomain, merchantId);
+    if (!hit) {
       console.log(`[settings/media] No merchant doc found for ${shopDomain || merchantId}`);
     }
-    const data = doc?.data() ?? {};
+    const data = hit?.data ?? {};
     
     console.log(`[settings/media] GET success, found ${data.merchant_media?.length || 0} media items`);
 
@@ -181,8 +181,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   console.log(`[settings/media] ${request.method} proceeding for domain=${shopDomain}, merchantId=${merchantId}`);
 
   try {
-    const doc = await getMerchantDoc(shopDomain, merchantId);
-    let merchantMedia = doc?.data()?.merchant_media || [];
+    const hit = await findMerchantDocRefByShopOrId(firestore, shopDomain, merchantId);
+    let merchantMedia = hit?.data?.merchant_media || [];
 
     // POST: Upload Media
     if (request.method === "POST") {
@@ -207,8 +207,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       // possible to avoid the round-trip.
       let alanMerchantId: string | null = null;
       try {
-        if (doc?.data()?.shop_id) {
-          alanMerchantId = doc.data()?.shop_id as string;
+        if (hit?.data?.shop_id) {
+          alanMerchantId = hit.data?.shop_id as string;
           console.log(`[settings/media] Using cached merchant_id from Firestore: ${alanMerchantId}`);
         } else if (shopDomain) {
           const { getShopIdByDomain } = await import("../services/ink-api.server");
@@ -302,9 +302,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
       merchantMedia.push(newItem);
       
-      if (doc) {
+      if (hit) {
           console.log(`[settings/media] Saving to Firestore (${merchantMedia.length} total items)`);
-          await doc.ref.update({ merchant_media: merchantMedia, updatedAt: new Date() });
+          await hit.ref.update({ merchant_media: merchantMedia, updatedAt: new Date() });
       } else {
           console.warn(`[settings/media] Cannot save to Firestore — merchant doc is null!`);
       }
@@ -321,7 +321,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
        // Resolve shop_id so we delete from the SAME merchant_animations doc the
        // upload writes + the tap reads (via the by-id route). The old slug route
        // deleted a different doc, leaving the media live at tap (the split-brain).
-       const dData = doc?.data();
+       const dData = hit?.data;
        let alanMerchantId: string | null =
            dData && typeof dData.shop_id === "string" ? dData.shop_id : null;
        if (!alanMerchantId && shopDomain) {
@@ -349,8 +349,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
        }
        
        merchantMedia = merchantMedia.filter((m: any) => m.id !== id);
-       if (doc) {
-           await doc.ref.update({ merchant_media: merchantMedia, updatedAt: new Date() });
+       if (hit) {
+           await hit.ref.update({ merchant_media: merchantMedia, updatedAt: new Date() });
        }
        return json({ success: true, media: merchantMedia });
     }
@@ -381,7 +381,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
            // route. The old slug route (/{toMerchantSlug(domain)}/primary) wrote a
            // DIFFERENT doc that lacks the uploaded media_items → 502 MEDIA_NOT_FOUND
            // (the split-brain: upload used shop_id, set-primary used the slug).
-           const dData = doc?.data();
+           const dData = hit?.data;
            let alanMerchantId: string | null =
                dData && typeof dData.shop_id === "string" ? dData.shop_id : null;
            if (!alanMerchantId && shopDomain) {
@@ -456,8 +456,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
            }
        }
        
-       if (doc) {
-           await doc.ref.update({ merchant_media: merchantMedia, updatedAt: new Date() });
+       if (hit) {
+           await hit.ref.update({ merchant_media: merchantMedia, updatedAt: new Date() });
        }
        return json({ success: true, media: merchantMedia });
     }

--- a/app/routes/app.api.warehouse.enroll.tsx
+++ b/app/routes/app.api.warehouse.enroll.tsx
@@ -33,33 +33,19 @@ const INK_API_URL =
 // JWTs. The old decode-without-verify fallback is gone (fix-list #2).
 
 import { enrollOrder, getShopIdByDomain, adjustMerchantInventory, getInventoryByShopDomain } from "../services/ink-api.server";
+import { findMerchantDocRefByShopOrId } from "../services/merchant-doc.server";
 
+/** The merchant's INK api_key, through the resolver that WRITES it.
+ *
+ *  api/auth/login and the orders/create self-heal both cache the key through
+ *  findMerchantDocRef, which returns the document that actually carries one.
+ *  This carried its own lookup (doc-id by merchant_id, then
+ *  `where("shopDomain")`) and could stop on a keyless document while the key
+ *  sat one doc over — measured on a connected store, 2026-09-05. */
 async function getMerchantApiKey(shopDomain?: string, merchantId?: string): Promise<string | null> {
-  // 1. Try matching by Firestore document ID (=== merchant_id from Alan JWT)
-  if (merchantId) {
-    const doc = await firestore.collection("merchants").doc(merchantId).get();
-    if (doc.exists) {
-      const apiKey = doc.data()?.ink_api_key;
-      if (apiKey && apiKey !== "sk_test_fallback") return apiKey;
-    }
-  }
-
-  // 2. Try matching by shopDomain field
-  if (shopDomain) {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shopDomain)
-      .limit(1)
-      .get();
-
-    if (!snapshot.empty) {
-      const data = snapshot.docs[0].data();
-      const apiKey = data?.ink_api_key;
-      if (apiKey && apiKey !== "sk_test_fallback") return apiKey;
-    }
-  }
-
-  return null;
+  const hit = await findMerchantDocRefByShopOrId(firestore, shopDomain, merchantId);
+  const apiKey = hit?.apiKey ?? hit?.data?.ink_api_key;
+  return apiKey && apiKey !== "sk_test_fallback" ? apiKey : null;
 }
 
 // CORS preflight
@@ -162,12 +148,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       console.log("[ENROLL] ✅ Inventory check passed. Current count:", currentCount);
 
       // Check min_enrollment_value setting
-      const merchantDoc = await (async () => {
-        const doc = await firestore.collection("merchants").doc(effectiveIdentifier).get();
-        if (doc.exists) return doc.data();
-        const snap = await firestore.collection("merchants").where("shopDomain", "==", effectiveIdentifier).limit(1).get();
-        return snap.empty ? null : snap.docs[0].data();
-      })();
+      // The same resolver settings/inventory saves the minimum through. A
+      // private lookup here would enforce a number the merchant never set.
+      const merchantDoc =
+        (await findMerchantDocRefByShopOrId(firestore, shopDomain, merchantId))?.data ?? null;
 
       const minValue = merchantDoc?.min_enrollment_value ?? 0;
       if (minValue > 0) {

--- a/app/routes/app.api.warehouse.upload.tsx
+++ b/app/routes/app.api.warehouse.upload.tsx
@@ -1,5 +1,6 @@
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
+import { findMerchantDocRefByShopOrId } from "../services/merchant-doc.server";
 import { uploadMedia, adjustMerchantInventory, getShopIdByDomain } from "../services/ink-api.server";
 import { verifyProxyToken } from "../services/token-verify.server";
 
@@ -28,32 +29,17 @@ const json = (data: any, init?: ResponseInit) =>
 // local HMAC for our own tokens, REMOTE /auth/validate for ink-backend
 // JWTs. The old decode-without-verify fallback is gone (fix-list #2).
 
+/** The merchant's INK api_key, through the resolver that WRITES it.
+ *
+ *  api/auth/login and the orders/create self-heal both cache the key through
+ *  findMerchantDocRef, which returns the document that actually carries one.
+ *  This carried its own lookup (doc-id by merchant_id, then
+ *  `where("shopDomain")`) and could stop on a keyless document while the key
+ *  sat one doc over — measured on a connected store, 2026-09-05. */
 async function getMerchantApiKey(shopDomain?: string, merchantId?: string): Promise<string | null> {
-  // 1. Try matching by Firestore document ID (=== merchant_id from Alan JWT)
-  if (merchantId) {
-    const doc = await firestore.collection("merchants").doc(merchantId).get();
-    if (doc.exists) {
-      const apiKey = doc.data()?.ink_api_key;
-      if (apiKey && apiKey !== "sk_test_fallback") return apiKey;
-    }
-  }
-
-  // 2. Try matching by shopDomain field
-  if (shopDomain) {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shopDomain)
-      .limit(1)
-      .get();
-
-    if (!snapshot.empty) {
-      const data = snapshot.docs[0].data();
-      const apiKey = data?.ink_api_key;
-      if (apiKey && apiKey !== "sk_test_fallback") return apiKey;
-    }
-  }
-
-  return null;
+  const hit = await findMerchantDocRefByShopOrId(firestore, shopDomain, merchantId);
+  const apiKey = hit?.apiKey ?? hit?.data?.ink_api_key;
+  return apiKey && apiKey !== "sk_test_fallback" ? apiKey : null;
 }
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -2,6 +2,7 @@ import { boundary } from "@shopify/shopify-app-react-router/server";
 import { useLoaderData, type LoaderFunctionArgs, useRouteError, type HeadersFunction } from "react-router";
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
+import { findMerchantDoc } from "../services/merchant-doc.server";
 import { getInventory, getInventoryByShopDomain, getShopIdByDomain } from "../services/ink-api.server";
 import Settings from "../components/settings/Settings";
 
@@ -57,20 +58,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
   let usedStr = "0";
 
   try {
-    // BY DOCUMENT ID FIRST. The embedded app provisions with
-    // `merchants.doc(shop).set({ shop, … })`, so `where("shopDomain", …)` never
-    // matched it — which is why this read "Not available" for every merchant,
-    // permanently, no matter how long ago they installed. The query is kept as
-    // a fallback: the standalone auth path creates docs with random ids and a
-    // `shopDomain` field.
-    let data: Record<string, any> | undefined;
-    const byId = await firestore.collection("merchants").doc(session.shop).get();
-    if (byId.exists) {
-      data = byId.data();
-    } else {
-      const merchantDocs = await firestore.collection("merchants").where("shopDomain", "==", session.shop).limit(1).get();
-      if (!merchantDocs.empty) data = merchantDocs.docs[0].data();
-    }
+    // ONE RESOLVER. The embedded app provisions by document id and the
+    // standalone auth path creates docs with random ids and a `shopDomain`
+    // field, which is why this row read "Not available" for every merchant
+    // until it learned to try both. It tried them in its own private order —
+    // findMerchantDoc is that same search, and it is the one updateMerchant
+    // now stamps `createdAt` through. On a store holding two merchant docs the
+    // private order read the one provisioning never wrote, and the row went
+    // blank again.
+    const data = (await findMerchantDoc(firestore, session.shop))?.data;
     if (data?.createdAt) {
       const date = data.createdAt.toDate ? data.createdAt.toDate() : new Date(data.createdAt);
       if (!Number.isNaN(date.getTime())) {

--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -3,7 +3,11 @@ import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
 import { enrollOrder, createMerchant } from "../services/ink-api.server";
 import { attachProductUrls, productDetailFromLineItem } from "../services/order-line-item";
-import { findActivationDocRef } from "../services/merchant-doc.server";
+import {
+  findActivationDocRef,
+  findMerchantDoc,
+  findMerchantDocRef,
+} from "../services/merchant-doc.server";
 import {
   countryOfWebhookOrder,
   orderActivates,
@@ -17,22 +21,18 @@ import { spendFromCap } from "../services/activation-counter.server";
  * Look up the merchant's verified-delivery mode preference.
  * Defaults to "background" so a missing preference never implies a
  * customer-paid checkout add-on.
+ *
+ * READS WHERE THE SETTING SAVES: `findMerchantDoc`, the same resolver
+ * settings/delivery-mode now writes through. This carried its own lookup
+ * (`where("shopDomain")` first, doc-id second) — a private copy on the read
+ * side of a switch is the §17.2 landmine facing the other way.
  */
 async function getMerchantDeliveryMode(
   shopDomain: string
 ): Promise<"background"> {
   try {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shopDomain)
-      .limit(1)
-      .get();
-    let docData = snapshot.empty ? null : snapshot.docs[0].data();
-    if (!docData) {
-      const direct = await firestore.collection("merchants").doc(shopDomain).get();
-      if (direct.exists) docData = direct.data() ?? null;
-    }
-    const mode = docData?.verified_delivery_mode;
+    const hit = await findMerchantDoc(firestore, shopDomain);
+    const mode = hit?.data?.verified_delivery_mode;
     if (mode === "background") return mode;
     return "background";
   } catch (e) {
@@ -47,20 +47,16 @@ async function getMerchantDeliveryMode(
 /**
  * The merchant's INK api_key — the Bearer Alan's /api/enroll (requireMerchant)
  * needs. Same source the warehouse enroll uses.
+ *
+ * `findMerchantDoc` is what this wanted all along: of every document a shop can
+ * reach, it returns the one that actually CARRIES `ink_api_key`. The private
+ * copy took the first `where("shopDomain")` hit and could land on a doc without
+ * a key while the key sat one document over.
  */
 async function getMerchantApiKey(shopDomain: string): Promise<string | null> {
   try {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shopDomain)
-      .limit(1)
-      .get();
-    let data = snapshot.empty ? null : snapshot.docs[0].data();
-    if (!data) {
-      const direct = await firestore.collection("merchants").doc(shopDomain).get();
-      if (direct.exists) data = direct.data() ?? null;
-    }
-    const key = data?.ink_api_key;
+    const hit = await findMerchantDoc(firestore, shopDomain);
+    const key = hit?.apiKey ?? hit?.data?.ink_api_key;
     return key && key !== "sk_test_fallback" ? key : null;
   } catch (e) {
     console.warn(`[orders/create] getMerchantApiKey failed for ${shopDomain}:`, e);
@@ -509,13 +505,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
               const fresh = await createMerchant(shop, shopIdentity?.name || shop, ownerEmail);
               const freshKey = fresh?.api_key;
               if (!freshKey) throw e;
-              const snap = await firestore
-                .collection("merchants")
-                .where("shopDomain", "==", shop)
-                .limit(1)
-                .get();
-              if (!snap.empty) {
-                await snap.docs[0].ref.update({ ink_api_key: freshKey, updatedAt: new Date() });
+              // Cache the fresh key in the document getMerchantApiKey reads —
+              // findMerchantDocRef, not a private `where("shopDomain")`. Writing
+              // the healed key into a doc the reader never opens would heal
+              // nothing and re-provision on every order.
+              const cacheHit = await findMerchantDocRef(firestore, shop);
+              if (cacheHit) {
+                await cacheHit.ref.update({ ink_api_key: freshKey, updatedAt: new Date() });
               } else {
                 await firestore
                   .collection("merchants")

--- a/app/services/merchant-doc-one-resolver.test.ts
+++ b/app/services/merchant-doc-one-resolver.test.ts
@@ -1,0 +1,218 @@
+// ONE RESOLVER — every writer of a per-merchant field saves into the document
+// its reader opens.
+//
+// The landmine (Bible §17.2) is a route that carries its own merchant lookup.
+// Each private copy knows a different subset of the conventions — doc id IS the
+// shop domain (the embed's own shape), field `shop`, camelCase `shopDomain`,
+// snake_case `shop_domain` — and picks a different winner when a store holds
+// more than one merchant document. The merchant flips a switch, the screen says
+// saved, and the thing the switch governs reads the other document.
+//
+// MEASURED 2026-09-05, read-only, across the thirteen shops holding a Shopify
+// session: `smusic-official.myshopify.com` holds three merchant documents and
+// resolves two ways — `findMerchantDocRef` opens `PWXStzc7mP8hn33xPbNf` (the
+// one carrying `ink_api_key`), every private doc-id-first copy opened
+// `smusic-official.myshopify.com`. Four fields landed on the wrong side of
+// that split: `branded_tracking_link` (PR #107), `merchant_media`,
+// `notification_settings`, and `ink_api_key` itself.
+//
+// These pins go red if a private lookup comes back.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Firestore } from "firebase-admin/firestore";
+import { findMerchantDocRefByShopOrId } from "./merchant-doc.server";
+
+const src = (p: string) => readFileSync(resolve(process.cwd(), p), "utf8");
+
+type Doc = { id: string; data: Record<string, unknown> };
+
+/** Minimal firestore stub speaking the exact surface the resolvers use. */
+function stubFirestore(docs: Doc[]) {
+  return {
+    collection(name: string) {
+      if (name !== "merchants") throw new Error("unexpected collection " + name);
+      return {
+        doc(id: string) {
+          const hit = docs.find((d) => d.id === id);
+          const ref = { id, __isRef: true };
+          return {
+            ...ref,
+            async get() {
+              return { exists: Boolean(hit), data: () => hit?.data, ref };
+            },
+          };
+        },
+        where(field: string, _op: string, value: unknown) {
+          return {
+            limit() {
+              return {
+                async get() {
+                  const matches = docs.filter((d) => d.data[field] === value);
+                  return {
+                    empty: matches.length === 0,
+                    docs: matches.map((d) => ({
+                      data: () => d.data,
+                      ref: { id: d.id, __isRef: true },
+                    })),
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Firestore;
+}
+
+// The measured shape of smusic-official.myshopify.com, 2026-09-05: three docs,
+// only one carrying the api key, reachable by three different conventions.
+const SPLIT_STORE: Doc[] = [
+  { id: "smusic-official.myshopify.com", data: {} },
+  { id: "PWXStzc7mP8hn33xPbNf", data: { shopDomain: "smusic-official.myshopify.com", ink_api_key: "k_real" } },
+  { id: "shop_a325592c9b37b6e9", data: { shop_domain: "smusic-official.myshopify.com", status: "active" } },
+];
+
+describe("findMerchantDocRefByShopOrId — the token path lands where the session path lands", () => {
+  it("prefers the shop domain, and picks the doc that carries the key", async () => {
+    const hit = await findMerchantDocRefByShopOrId(
+      stubFirestore(SPLIT_STORE),
+      "smusic-official.myshopify.com",
+      "smusic-official.myshopify.com",
+    );
+    expect(hit!.ref.id).toBe("PWXStzc7mP8hn33xPbNf");
+    expect(hit!.apiKey).toBe("k_real");
+  });
+
+  it("a merchant_id that names its shop CONVERGES on the session path's answer", async () => {
+    // The PWA token carries only Alan's merchant_id. Reading that document and
+    // stopping there is what put the media on the doc the tap never opens.
+    const hit = await findMerchantDocRefByShopOrId(
+      stubFirestore(SPLIT_STORE),
+      undefined,
+      "shop_a325592c9b37b6e9",
+    );
+    expect(hit!.ref.id).toBe("PWXStzc7mP8hn33xPbNf");
+  });
+
+  it("falls back to the merchant_id document when nothing names a shop", async () => {
+    const hit = await findMerchantDocRefByShopOrId(
+      stubFirestore([{ id: "orphan_1", data: { ink_api_key: "k_orphan" } }]),
+      undefined,
+      "orphan_1",
+    );
+    expect(hit!.ref.id).toBe("orphan_1");
+    expect(hit!.apiKey).toBe("k_orphan");
+  });
+
+  it("returns null when neither identifier resolves — the caller decides", async () => {
+    expect(await findMerchantDocRefByShopOrId(stubFirestore([]), "ghost.myshopify.com", "nope")).toBeNull();
+    expect(await findMerchantDocRefByShopOrId(stubFirestore(SPLIT_STORE), null, null)).toBeNull();
+  });
+});
+
+describe("SAVES WHERE THE READER READS — source pins, one per writer", () => {
+  it("settings/media saves where api/verify reads (measured: smusic-official)", () => {
+    const ROUTE = src("app/routes/app.api.settings.media.tsx");
+    expect(ROUTE).toContain("findMerchantDocRefByShopOrId");
+    expect(ROUTE).not.toContain("async function getMerchantDoc");
+    expect(ROUTE).toMatch(/hit\.ref\.update\(/);
+  });
+
+  it("settings/inventory saves where the enroll gate reads", () => {
+    const ROUTE = src("app/routes/app.api.settings.inventory.tsx");
+    const GATE = src("app/routes/app.api.warehouse.enroll.tsx");
+    expect(ROUTE).toContain("findMerchantDocRefByShopOrId");
+    expect(ROUTE).not.toContain("async function getMerchantDoc");
+    // Both ends of min_enrollment_value, same resolver.
+    expect(GATE).toContain("findMerchantDocRefByShopOrId");
+    expect(GATE).not.toMatch(/where\("shopDomain",/);
+  });
+
+  it("settings/delivery-mode saves where orders/create reads", () => {
+    const ROUTE = src("app/routes/app.api.settings.delivery-mode.tsx");
+    const WEBHOOK = src("app/routes/webhooks.orders_create.ts");
+    expect(ROUTE).toContain("findMerchantDocRef");
+    expect(ROUTE).not.toContain("async function getMerchantDoc");
+    expect(ROUTE).toMatch(/hit\.ref\.update\(/);
+    expect(WEBHOOK).toContain("findMerchantDoc");
+    expect(WEBHOOK).not.toMatch(/where\("shopDomain",/);
+  });
+
+  it("the api key is cached where every reader of it looks", () => {
+    const LOGIN = src("app/routes/app.api.auth.login.tsx");
+    const CREATE = src("app/routes/webhooks.orders_create.ts");
+    const UPLOAD = src("app/routes/app.api.warehouse.upload.tsx");
+    for (const s of [LOGIN, CREATE, UPLOAD]) {
+      expect(s).toMatch(/findMerchantDocRef|findMerchantDocRefByShopOrId|findMerchantDoc/);
+      expect(s).not.toMatch(/where\("shopDomain",/);
+    }
+  });
+
+  it("provisioning seeds the doc the fulfillment webhooks open", () => {
+    const SVC = src("app/services/merchant.server.ts");
+    expect(SVC).toContain("findMerchantDocRef");
+    // The bare doc-id read/write is gone from both getMerchant and updateMerchant.
+    expect(SVC).not.toMatch(/collection\(COLLECTION\)\.doc\(shop\)\.get\(\)/);
+    // doc(shop) survives only as the create path for a shop with no doc at all.
+    expect(SVC).toMatch(/hit\?\.ref \?\? firestore\.collection\(COLLECTION\)\.doc\(shop\)/);
+  });
+
+  it("the dashboard and onboarding read the notification toggles that were saved", () => {
+    const COMMS = src("app/routes/app.api.dashboard.comms.tsx");
+    const ONBOARD = src("app/routes/app.api.onboarding.status.tsx");
+    const WRITER = src("app/routes/app.api.settings.notifications.tsx");
+    expect(WRITER).toContain("findMerchantDocRef");
+    expect(COMMS).toContain("findMerchantDoc");
+    expect(COMMS).not.toMatch(/\.doc\(session\.shop\)\.get\(\)/);
+    expect(ONBOARD).toContain("findMerchantDoc");
+    expect(ONBOARD).not.toMatch(/collection\("merchants"\)\.doc\(shop\)\.get\(\)/);
+  });
+
+  it("the Settings install date reads the doc provisioning stamped", () => {
+    const PAGE = src("app/routes/app.settings.tsx");
+    expect(PAGE).toContain("findMerchantDoc");
+    expect(PAGE).not.toMatch(/where\("shopDomain",/);
+  });
+});
+
+describe("no route grows a sixth private copy", () => {
+  // A merchant lookup is `collection("merchants")` plus a shop-shaped field
+  // query. Anything doing that outside merchant-doc.server.ts is a private copy
+  // in the making — the allowlist below is the set of deliberate exceptions,
+  // each one resolving off something OTHER than a shop session.
+  const ALLOWED = new Set([
+    // Owned by PR #107 (feat/shopify-shipping-email-carries-the-page), which
+    // deletes its private lookup. Harmless here either way.
+    "app/routes/app.api.settings.branded-tracking-link.tsx",
+    // Consumer-facing. Resolves the merchant off the PROOF — by ink_api_key
+    // (already proven to own it), then shop_domain, then shop_id — not off a
+    // shop session, so findMerchantDoc's shop-keyed search does not apply.
+    "app/routes/api.verify.tsx",
+    "app/routes/api.retrieve.$proofId.tsx",
+  ]);
+
+  it("every shop-keyed merchant lookup lives in merchant-doc.server.ts", async () => {
+    const { globSync } = await import("node:fs");
+    const files = [
+      ...globSync("app/routes/*.ts"),
+      ...globSync("app/routes/*.tsx"),
+      ...globSync("app/services/*.ts"),
+    ].filter((f) => !f.endsWith(".test.ts") && !f.endsWith("merchant-doc.server.ts"));
+
+    const offenders = files.filter((f) => {
+      const s = src(f);
+      if (!s.includes('collection("merchants")')) return false;
+      // Comments are prose about the landmine, not a lookup: match the code form.
+      return /where\("(shop|shopDomain|shop_domain)",/.test(s);
+    });
+
+    // The sweep must actually sweep: a glob that matched nothing would make
+    // this test pass while proving nothing.
+    expect(files.length).toBeGreaterThan(40);
+    expect(offenders).toContain("app/routes/api.verify.tsx");
+
+    expect(offenders.filter((f) => !ALLOWED.has(f))).toEqual([]);
+  });
+});

--- a/app/services/merchant-doc.server.ts
+++ b/app/services/merchant-doc.server.ts
@@ -133,3 +133,55 @@ export async function findActivationDocRef(
     apiKey: (withKey?.data.ink_api_key as string) ?? null,
   };
 }
+
+/** SAME RESOLVER, for the routes authed by a PWA/App-Bridge token.
+ *
+ *  The media and inventory settings routes are reached two ways: an embedded
+ *  Shopify session (shop domain in hand) and a Bearer token that may carry
+ *  only Alan's `merchant_id`. Both carried a private lookup that tried
+ *  `doc(merchant_id)` first and `where("shopDomain")` second — so on a store
+ *  holding two merchant docs they saved into the doc-id document while the
+ *  readers (api/verify by `ink_api_key`, the fulfillment webhooks by
+ *  `findMerchantDoc`) open the one carrying the key.
+ *
+ *  Shop domain wins when we have one, because that is what every reader
+ *  resolves from. With only a merchant_id we read that document, then — if it
+ *  names its shop — resolve canonically from that name, so the token path and
+ *  the session path land on the SAME document. */
+export async function findMerchantDocRefByShopOrId(
+  firestore: Firestore,
+  shop?: string | null,
+  merchantId?: string | null,
+): Promise<MerchantDocRefHit | null> {
+  if (shop) {
+    const hit = await findMerchantDocRef(firestore, shop);
+    if (hit) return hit;
+  }
+
+  if (!merchantId) return null;
+
+  let direct;
+  try {
+    direct = await firestore.collection("merchants").doc(merchantId).get();
+  } catch {
+    return null;
+  }
+  if (!direct.exists) return null;
+
+  const data = direct.data() as DocumentData;
+  const named = ["shop", "shopDomain", "shop_domain"]
+    .map((f) => data?.[f])
+    .find((v): v is string => typeof v === "string" && Boolean(v));
+
+  // Converge on the session path's answer whenever the doc names its shop.
+  if (named && named !== merchantId) {
+    const hit = await findMerchantDocRef(firestore, named);
+    if (hit) return hit;
+  }
+
+  return {
+    data,
+    ref: direct.ref,
+    apiKey: typeof data?.ink_api_key === "string" && data.ink_api_key ? data.ink_api_key : null,
+  };
+}

--- a/app/services/merchant.server.ts
+++ b/app/services/merchant.server.ts
@@ -1,4 +1,5 @@
 import firestore from "../firestore.server";
+import { findMerchantDocRef } from "./merchant-doc.server";
 import type { NotificationSettings } from "./notification-settings";
 
 const COLLECTION = "merchants";
@@ -19,9 +20,8 @@ export interface MerchantData {
 
 export const getMerchant = async (shop: string): Promise<MerchantData | null> => {
   try {
-    const doc = await firestore.collection(COLLECTION).doc(shop).get();
-    if (!doc.exists) return null;
-    return doc.data() as MerchantData;
+    const hit = await findMerchantDocRef(firestore, shop);
+    return (hit?.data as MerchantData) ?? null;
   } catch (error) {
     console.error("Error fetching merchant:", error);
     return null;
@@ -30,7 +30,14 @@ export const getMerchant = async (shop: string): Promise<MerchantData | null> =>
 
 export const updateMerchant = async (shop: string, data: Partial<MerchantData>) => {
   try {
-    const ref = firestore.collection(COLLECTION).doc(shop);
+    // WRITE WHERE THE READERS READ. This keyed straight off `doc(shop)`, so on
+    // a store holding two merchant docs the provisioning seed — the api key,
+    // the delivery mode, and the notification_settings every sender needs —
+    // landed in the document the fulfillment webhooks never open. Resolve with
+    // findMerchantDocRef first; `doc(shop)` stays the create path for a shop
+    // that has no merchant document at all, which is what provisioning is for.
+    const hit = await findMerchantDocRef(firestore, shop);
+    const ref = hit?.ref ?? firestore.collection(COLLECTION).doc(shop);
     const now = new Date().toISOString();
 
     // STAMP THE INSTALL ONCE. Settings shows this as "Installed:", and nothing
@@ -43,8 +50,7 @@ export const updateMerchant = async (shop: string, data: Partial<MerchantData>) 
     // keys by document id, and the Settings lookup was searching for a field
     // this writer never set. Writing both ends the mismatch without migrating
     // either shape.
-    const existing = await ref.get();
-    const stamp = existing.exists && (existing.data() as MerchantData)?.createdAt
+    const stamp = (hit?.data as MerchantData | undefined)?.createdAt
       ? {}
       : { createdAt: now };
 


### PR DESCRIPTION
PR #107 fixed one route. This is the audit behind it: every writer of a per-merchant field in the `merchants` collection, which resolver it used, and which resolver its reader used.

## What was wrong

A route that carries its own merchant lookup is the §17.2 landmine. Each private copy knows a different subset of the four conventions — doc id IS the shop domain (the embed's own shape), field `shop`, camelCase `shopDomain`, snake_case `shop_domain` — so when a store holds more than one merchant document, the writer and the reader pick different ones. The merchant flips a switch, the screen says saved, and the thing the switch governs reads the other document.

Five more writers had one:

| writer | field(s) | its reader |
|---|---|---|
| `settings/media` | `merchant_media` | `api/verify`, which resolves by `ink_api_key` |
| `settings/inventory` | `low_inventory_threshold`, `min_enrollment_value` | the `warehouse/enroll` gate |
| `settings/delivery-mode` | `verified_delivery_mode` | `webhooks/orders_create` |
| `api/auth/login` | `ink_api_key` | every `findMerchantDoc` caller |
| `merchant.server.ts` | the provisioning seed — api key, delivery mode, `notification_settings` | the fulfillment webhooks and the notification senders |

## What changed

Each writer now uses the resolver its reader uses, and its private copy is gone. The readers moved with them, because a writer pinned to one resolver and a reader pinned to another is the same bug facing the other way: `orders/create` (both helpers, plus its self-heal key cache), `warehouse/enroll` and `warehouse/upload`, `dashboard/comms`, `onboarding/status`, and the Settings install date.

`findMerchantDocRefByShopOrId` is new. The media and inventory routes are also reached by a PWA/App-Bridge token that may carry only Alan's `merchant_id` instead of a shop domain; it makes that path converge on the document the session path resolves to, rather than stopping at `doc(merchant_id)`.

`findActivationDocRef` is untouched. It prefers the ACTIVE doc on purpose — the slice's record is the one the backend can write — and that difference is the fix for a different bug, not an instance of this one. A pin asserts the sweep does not drag it in.

## Measured, not theoretical

Re-measured read-only on 2026-09-05 across the thirteen shops holding a Shopify session, the same way the original was measured. Twelve resolve identically under every resolver. One store holds three merchant documents and splits: `findMerchantDocRef` opens the document carrying `ink_api_key`, every doc-id-first private copy opened the domain-keyed one. Four fields sat on the wrong side of that split:

- `branded_tracking_link` — PR #107
- `merchant_media` — an uploaded bumper never reached the consumer tap
- `notification_settings` — the dashboard Communications card and the onboarding step reported toggles the merchant had actually set
- `ink_api_key` — a re-login refreshed a key nothing would read

(The affected store is one of Sam's own. Shop identities are kept out of this public description; the full table is in the session.)

## Pins

`app/services/merchant-doc-one-resolver.test.ts` — behaviour tests for the new resolver against the measured three-document shape, one "SAVES WHERE THE READER READS" source pin per writer, and a sweep asserting that every shop-keyed merchant lookup lives in `merchant-doc.server.ts`. The sweep carries an explicit allowlist: `branded-tracking-link` (owned by PR #107, passes either way) and the two consumer-facing routes that resolve off the PROOF rather than a shop session.

## Flagged, not changed

`webhooks/shop.redact` deletes `merchants/{shop}` only. On a split store that leaves the api-key document standing after a GDPR erasure. Widening a delete is a destructive semantic change, so it is your call, not mine.

## Gates (baseline 35ae253)

- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` — 144 passed (132 before; 12 new)
- `npm run lint` — 469 → **466** problems, zero files regressed (verified per file against a clean checkout of main)

Never ran `shopify app dev` or `shopify app deploy`; `client_id` and `application_url` untouched. **Do not merge without Sam's word — merging deploys Cloud Run.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)