### PR TITLE
HELD FOR ROUND FOUR — Every merchant-doc lookup uses the resolver the webhook trusts

### DIFF
--- a/app/routes/app.api.auth.login.tsx
+++ b/app/routes/app.api.auth.login.tsx
@@ -1,6 +1,7 @@
 import { type ActionFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
 import { createMerchant, loginUser } from "../services/ink-api.server";
+import { findMerchantDocRef } from "../services/merchant-doc.server";
 import bcrypt from "bcryptjs";
 import crypto from "crypto";
 
@@ -93,24 +94,22 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         const freshApiKey = inkMerchantRes.api_key;
 
         if (freshApiKey) {
-          // Upsert into Firestore: first try by document ID, then by shopDomain field
-          const existingDoc = await firestore.collection("merchants").doc(merchantId).get();
-          if (existingDoc.exists) {
-            await existingDoc.ref.update({ ink_api_key: freshApiKey, updatedAt: new Date() });
+          // Upsert into Firestore through the SAME resolver the fulfillment
+          // webhook uses — the old two-convention lookup (doc-id, then a
+          // single "shopDomain" field) missed the backend's snake_case
+          // shop_domain doc, so a store already provisioned there could get
+          // a SECOND doc created right here, permanently splitting the two.
+          const hit = await findMerchantDocRef(firestore, merchantId);
+          if (hit) {
+            await hit.ref.update({ ink_api_key: freshApiKey, updatedAt: new Date() });
           } else {
-            // Also check by shopDomain field  
-            const snapshot = await firestore.collection("merchants").where("shopDomain", "==", merchantId).limit(1).get();
-            if (!snapshot.empty) {
-              await snapshot.docs[0].ref.update({ ink_api_key: freshApiKey, updatedAt: new Date() });
-            } else {
-              // Create new doc with document ID = merchantId for easy future lookups
-              await firestore.collection("merchants").doc(merchantId).set({
-                shopDomain: merchantId,
-                ink_api_key: freshApiKey,
-                createdAt: new Date(),
-                updatedAt: new Date(),
-              });
-            }
+            // Genuinely nothing exists yet — create the canonical domain-keyed doc.
+            await firestore.collection("merchants").doc(merchantId).set({
+              shopDomain: merchantId,
+              ink_api_key: freshApiKey,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            });
           }
           console.log(`[Auth] Cached ink_api_key for merchant ${merchantId}`);
         }
@@ -158,22 +157,23 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     return json({ error: "Invalid email or password" }, { status: 401 });
   }
 
-  // Ensure the merchant configuration document exists and has a real INK API key (heal from sk_test_fallback)
-  const merchantSnapshot = await firestore
-    .collection("merchants")
-    .where("shopDomain", "==", userData.shopDomain)
-    .limit(1)
-    .get();
+  // Ensure the merchant configuration document exists and has a real INK API
+  // key (heal from sk_test_fallback). findMerchantDocRef — the same resolver
+  // the fulfillment webhook uses — replaces a private single-convention
+  // "shopDomain" field query that missed the embed's own doc-id shape AND
+  // the backend's snake_case shop_domain, so this legacy path could heal a
+  // key onto a THIRD doc while the real one sat unread.
+  const merchantHit = await findMerchantDocRef(firestore, userData.shopDomain);
 
-  let apiKey = merchantSnapshot.empty ? null : merchantSnapshot.docs[0].data().ink_api_key;
-  let docId = merchantSnapshot.empty ? null : merchantSnapshot.docs[0].id;
+  let apiKey = merchantHit?.apiKey ?? null;
+  const docId = merchantHit?.ref.id ?? null;
 
   if (!apiKey || apiKey === "sk_test_fallback") {
     console.log(`[Auth] Key missing or fallback for ${userData.shopDomain}. Calling INK Admin API...`);
     try {
       const inkRes = await createMerchant(userData.shopDomain, userData.shopDomain, userData.email || email);
       apiKey = inkRes.api_key;
-      
+
       if (docId) {
         await firestore.collection("merchants").doc(docId).update({
           ink_api_key: apiKey,

--- a/app/routes/app.api.dashboard.comms.tsx
+++ b/app/routes/app.api.dashboard.comms.tsx
@@ -1,6 +1,7 @@
 import { type LoaderFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
+import { findMerchantDocRef } from "../services/merchant-doc.server";
 
 const json = (data: any, init?: ResponseInit) =>
   new Response(JSON.stringify(data), {
@@ -12,11 +13,18 @@ const json = (data: any, init?: ResponseInit) =>
 // the dashboard Communications card (session-authed, mirrors tap-stats).
 // Reads the same merchants/{shop}.notification_settings the Settings panel
 // writes — never invented numbers, just the actual on/off state.
+//
+// findMerchantDocRef, not a doc-id-only read: the Settings panel WRITES
+// notification_settings through the shared resolver (app.api.settings.
+// notifications.tsx), which can land on a different doc than session.shop's
+// own id on a store holding two merchant docs. A doc-id-only read here would
+// silently show "no settings configured" on exactly the store where the
+// Settings tab shows them on (§17.2 landmine).
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   try {
     const { session } = await authenticate.admin(request);
-    const doc = await firestore.collection("merchants").doc(session.shop).get();
-    const settings = doc.exists ? (doc.data()?.notification_settings ?? null) : null;
+    const hit = await findMerchantDocRef(firestore, session.shop);
+    const settings = hit?.data?.notification_settings ?? null;
     return json({ settings });
   } catch (err: any) {
     if (err instanceof Response) throw err;

--- a/app/routes/app.api.onboarding.status.tsx
+++ b/app/routes/app.api.onboarding.status.tsx
@@ -4,6 +4,7 @@ import firestore from "../firestore.server";
 import { brandSlugFromDomain } from "../services/email.server";
 import { fetchBrandEmailKit } from "../services/brand-email.server";
 import { getShopIdByDomain, getMerchantTapStats } from "../services/ink-api.server";
+import { findMerchantDocRef } from "../services/merchant-doc.server";
 
 const json = (data: any, init?: ResponseInit) =>
   new Response(JSON.stringify(data), {
@@ -38,11 +39,16 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     const shop = session.shop;
 
     // Merchant doc: notifications + optional brand_slug override.
+    //
+    // findMerchantDocRef, not doc(shop) alone: the doc-id-only read missed a
+    // store's real notification_settings whenever it lived on the other of
+    // the two possible merchant docs (§17.2 landmine) — the checklist would
+    // say "not done yet" for a merchant who had already turned them on.
     let notificationsOn = false;
     let brandSlugOverride: string | undefined;
     try {
-      const doc = await firestore.collection("merchants").doc(shop).get();
-      const d = doc.exists ? doc.data() ?? {} : {};
+      const hit = await findMerchantDocRef(firestore, shop);
+      const d = hit?.data ?? {};
       const ch = d.notification_settings?.channels;
       notificationsOn = Boolean(ch?.email || ch?.sms);
       if (typeof d.brand_slug === "string" && d.brand_slug) brandSlugOverride = d.brand_slug;

--- a/app/routes/app.api.settings.delivery-mode.tsx
+++ b/app/routes/app.api.settings.delivery-mode.tsx
@@ -11,11 +11,20 @@
  *                  of which shipping method the customer picked.
  *
  * Reads/writes are gated by `authenticate.admin(request)` from Shopify.
+ *
+ * WHICH MERCHANT DOC. `findMerchantDocRef` — the same resolver the
+ * fulfillment webhook uses. This route carried its own private lookup
+ * (field query on "shopDomain" FIRST, doc-id fallback second) — backwards
+ * from, and less complete than, the shared resolver, so on a store holding
+ * two merchant docs (embed's own by domain id, backend's by a random id
+ * carrying ink_api_key) this could silently persist the mode to a doc
+ * nothing downstream reads (§17.2 landmine).
  */
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
 import { authenticate } from "../shopify.server";
 import { setCarrierServiceActive } from "../services/carrier-service.server";
+import { findMerchantDocRef } from "../services/merchant-doc.server";
 
 const VALID_MODES = ["background"] as const;
 type DeliveryMode = (typeof VALID_MODES)[number];
@@ -32,19 +41,6 @@ const json = (data: any, init?: ResponseInit) =>
     ...init,
   });
 
-async function getMerchantDoc(shopDomain: string) {
-  const snapshot = await firestore
-    .collection("merchants")
-    .where("shopDomain", "==", shopDomain)
-    .limit(1)
-    .get();
-  if (!snapshot.empty) return snapshot.docs[0];
-  // Fallback: doc keyed by domain directly
-  const direct = await firestore.collection("merchants").doc(shopDomain).get();
-  if (direct.exists) return direct;
-  return null;
-}
-
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (request.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
@@ -54,7 +50,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const shopDomain = session.shop;
 
   try {
-    const doc = await getMerchantDoc(shopDomain);
+    await findMerchantDocRef(firestore, shopDomain);
     const mode: DeliveryMode = "background";
     return json({ mode });
   } catch (err: any) {
@@ -86,8 +82,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       );
     }
 
-    const doc = await getMerchantDoc(shopDomain);
-    if (!doc) {
+    const hit = await findMerchantDocRef(firestore, shopDomain);
+    if (!hit) {
       console.warn(
         `[settings/delivery-mode] Merchant doc not found for ${shopDomain}; cannot persist mode`
       );
@@ -97,7 +93,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       );
     }
 
-    await doc.ref.update({
+    await hit.ref.update({
       verified_delivery_mode: mode,
       updatedAt: new Date(),
     });

--- a/app/routes/app.api.settings.inventory.tsx
+++ b/app/routes/app.api.settings.inventory.tsx
@@ -1,6 +1,7 @@
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
 import { verifyProxyToken } from "../services/token-verify.server";
+import { findMerchantDocRefByEither } from "../services/merchant-doc.server";
 
 /**
  * Inventory Settings endpoint (authenticated by warehouse JWT).
@@ -9,6 +10,13 @@ import { verifyProxyToken } from "../services/token-verify.server";
  *
  * GET  /app/api/settings/inventory → { low_inventory_threshold, min_enrollment_value }
  * POST /app/api/settings/inventory → update settings
+ *
+ * WHICH MERCHANT DOC. `findMerchantDocRefByEither` — the same resolver the
+ * fulfillment webhook uses, tried against merchant_id then shopDomain. This
+ * route carried its own private lookup (merchant_id-as-doc-id, then a single
+ * "shopDomain" field query) which misses the backend's snake_case
+ * shop_domain convention and never prefers the doc carrying ink_api_key —
+ * the §17.2 landmine.
  */
 
 const corsHeaders = {
@@ -25,26 +33,6 @@ const json = (data: any, init?: ResponseInit) =>
 
 // Token verification: services/token-verify.server.ts (fail-closed; the old
 // decodeToken computed an HMAC and then never checked it — pure decode).
-
-async function getMerchantDoc(shopDomain?: string, merchantId?: string) {
-  // Try by document ID (merchant_id)
-  if (merchantId) {
-    const doc = await firestore.collection("merchants").doc(merchantId).get();
-    if (doc.exists) return doc;
-  }
-
-  // Try by shopDomain field
-  if (shopDomain) {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shopDomain)
-      .limit(1)
-      .get();
-    if (!snapshot.empty) return snapshot.docs[0];
-  }
-
-  return null;
-}
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (request.method === "OPTIONS") {
@@ -64,8 +52,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { shop: shopDomain, merchant_id: merchantId } = tokenPayload;
 
   try {
-    const doc = await getMerchantDoc(shopDomain, merchantId);
-    const data = doc?.data() ?? {};
+    const hit = await findMerchantDocRefByEither(firestore, { shopDomain, merchantId });
+    const data = hit?.data ?? {};
 
     return json({
       low_inventory_threshold: data.low_inventory_threshold ?? 20,
@@ -116,9 +104,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     if (low_inventory_threshold !== undefined) updates.low_inventory_threshold = low_inventory_threshold;
     if (min_enrollment_value !== undefined) updates.min_enrollment_value = min_enrollment_value;
 
-    const doc = await getMerchantDoc(shopDomain, merchantId);
-    if (doc) {
-      await doc.ref.update(updates);
+    const hit = await findMerchantDocRefByEither(firestore, { shopDomain, merchantId });
+    if (hit) {
+      await hit.ref.update(updates);
     } else {
       // Create if doesn't exist
       const docId = merchantId || shopDomain || "unknown";

--- a/app/routes/app.api.settings.media.tsx
+++ b/app/routes/app.api.settings.media.tsx
@@ -2,6 +2,7 @@ import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
 import { verifyProxyToken } from "../services/token-verify.server";
 import { authenticate } from "../shopify.server";
+import { findMerchantDocRefByEither } from "../services/merchant-doc.server";
 
 const INK_API_URL = process.env.INK_API_URL || "https://us-central1-inink-c76d3.cloudfunctions.net/api";
 const INK_ADMIN_SECRET = process.env.INK_ADMIN_SECRET;
@@ -54,20 +55,23 @@ async function decodeToken(token: string): Promise<{ shop?: string; merchant_id?
   return { shop: payload.shop as string | undefined, merchant_id: payload.merchant_id as string | undefined };
 }
 
+// WHICH MERCHANT DOC. `findMerchantDocRefByEither` — the same resolver the
+// fulfillment webhook uses, tried against merchant_id then shopDomain. This
+// used to be a private lookup (merchant_id-as-doc-id, then a single
+// "shopDomain" field query) that missed the backend's snake_case
+// shop_domain convention and never preferred the doc carrying ink_api_key —
+// the §17.2 landmine. On a store holding two merchant docs, uploaded media
+// could be saved to one doc while ConsumerTap (which reads via Alan's own
+// shop_id) renders from the other, or a later save silently starts a SECOND
+// media list this endpoint never sees again.
 async function getMerchantDoc(shopDomain?: string, merchantId?: string) {
-  if (merchantId) {
-    const doc = await firestore.collection("merchants").doc(merchantId).get();
-    if (doc.exists) return doc;
-  }
-  if (shopDomain) {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shopDomain)
-      .limit(1)
-      .get();
-    if (!snapshot.empty) return snapshot.docs[0];
-  }
-  return null;
+  const hit = await findMerchantDocRefByEither(firestore, { shopDomain, merchantId });
+  if (!hit) return null;
+  return {
+    exists: true,
+    data: () => hit.data,
+    ref: hit.ref,
+  };
 }
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {

--- a/app/routes/app.api.warehouse.enroll.tsx
+++ b/app/routes/app.api.warehouse.enroll.tsx
@@ -33,33 +33,18 @@ const INK_API_URL =
 // JWTs. The old decode-without-verify fallback is gone (fix-list #2).
 
 import { enrollOrder, getShopIdByDomain, adjustMerchantInventory, getInventoryByShopDomain } from "../services/ink-api.server";
+import { findMerchantDocRefByEither } from "../services/merchant-doc.server";
 
+// WHICH MERCHANT DOC. `findMerchantDocRefByEither` — the same resolver the
+// fulfillment webhook uses, tried against merchant_id then shopDomain. This
+// was a private lookup (merchant_id-as-doc-id, then a single "shopDomain"
+// field query), byte-identical to the one in app.api.warehouse.upload.tsx —
+// two copies of the §17.2 landmine that also missed the backend's snake_case
+// shop_domain convention and never preferred the doc carrying ink_api_key.
 async function getMerchantApiKey(shopDomain?: string, merchantId?: string): Promise<string | null> {
-  // 1. Try matching by Firestore document ID (=== merchant_id from Alan JWT)
-  if (merchantId) {
-    const doc = await firestore.collection("merchants").doc(merchantId).get();
-    if (doc.exists) {
-      const apiKey = doc.data()?.ink_api_key;
-      if (apiKey && apiKey !== "sk_test_fallback") return apiKey;
-    }
-  }
-
-  // 2. Try matching by shopDomain field
-  if (shopDomain) {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shopDomain)
-      .limit(1)
-      .get();
-
-    if (!snapshot.empty) {
-      const data = snapshot.docs[0].data();
-      const apiKey = data?.ink_api_key;
-      if (apiKey && apiKey !== "sk_test_fallback") return apiKey;
-    }
-  }
-
-  return null;
+  const hit = await findMerchantDocRefByEither(firestore, { shopDomain, merchantId });
+  const apiKey = hit?.apiKey;
+  return apiKey && apiKey !== "sk_test_fallback" ? apiKey : null;
 }
 
 // CORS preflight
@@ -161,15 +146,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       }
       console.log("[ENROLL] ✅ Inventory check passed. Current count:", currentCount);
 
-      // Check min_enrollment_value setting
-      const merchantDoc = await (async () => {
-        const doc = await firestore.collection("merchants").doc(effectiveIdentifier).get();
-        if (doc.exists) return doc.data();
-        const snap = await firestore.collection("merchants").where("shopDomain", "==", effectiveIdentifier).limit(1).get();
-        return snap.empty ? null : snap.docs[0].data();
-      })();
-
-      const minValue = merchantDoc?.min_enrollment_value ?? 0;
+      // Check min_enrollment_value setting. findMerchantDocRefByEither — the
+      // same resolver the fulfillment webhook uses — tried against BOTH
+      // identifiers, not the single OR'd `effectiveIdentifier` string this
+      // used to collapse them into (which only ever checked one convention
+      // for whichever of shopDomain/merchantId happened to be truthy first).
+      const hit = await findMerchantDocRefByEither(firestore, { shopDomain, merchantId });
+      const minValue = hit?.data?.min_enrollment_value ?? 0;
       if (minValue > 0) {
         // order_total_value is passed in body from the PWA
         const orderTotal = parseFloat(body.order_total_value ?? "0") || 0;

--- a/app/routes/app.api.warehouse.upload.tsx
+++ b/app/routes/app.api.warehouse.upload.tsx
@@ -2,6 +2,7 @@ import { type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import firestore from "../firestore.server";
 import { uploadMedia, adjustMerchantInventory, getShopIdByDomain } from "../services/ink-api.server";
 import { verifyProxyToken } from "../services/token-verify.server";
+import { findMerchantDocRefByEither } from "../services/merchant-doc.server";
 
 /**
  * Public endpoint (authenticated by warehouse JWT only).
@@ -28,32 +29,16 @@ const json = (data: any, init?: ResponseInit) =>
 // local HMAC for our own tokens, REMOTE /auth/validate for ink-backend
 // JWTs. The old decode-without-verify fallback is gone (fix-list #2).
 
+// WHICH MERCHANT DOC. `findMerchantDocRefByEither` — the same resolver the
+// fulfillment webhook uses, tried against merchant_id then shopDomain. This
+// was a private lookup (merchant_id-as-doc-id, then a single "shopDomain"
+// field query), byte-identical to the one in app.api.warehouse.enroll.tsx —
+// two copies of the §17.2 landmine that also missed the backend's snake_case
+// shop_domain convention and never preferred the doc carrying ink_api_key.
 async function getMerchantApiKey(shopDomain?: string, merchantId?: string): Promise<string | null> {
-  // 1. Try matching by Firestore document ID (=== merchant_id from Alan JWT)
-  if (merchantId) {
-    const doc = await firestore.collection("merchants").doc(merchantId).get();
-    if (doc.exists) {
-      const apiKey = doc.data()?.ink_api_key;
-      if (apiKey && apiKey !== "sk_test_fallback") return apiKey;
-    }
-  }
-
-  // 2. Try matching by shopDomain field
-  if (shopDomain) {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shopDomain)
-      .limit(1)
-      .get();
-
-    if (!snapshot.empty) {
-      const data = snapshot.docs[0].data();
-      const apiKey = data?.ink_api_key;
-      if (apiKey && apiKey !== "sk_test_fallback") return apiKey;
-    }
-  }
-
-  return null;
+  const hit = await findMerchantDocRefByEither(firestore, { shopDomain, merchantId });
+  const apiKey = hit?.apiKey;
+  return apiKey && apiKey !== "sk_test_fallback" ? apiKey : null;
 }
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -3,6 +3,7 @@ import { useLoaderData, type LoaderFunctionArgs, useRouteError, type HeadersFunc
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
 import { getInventory, getInventoryByShopDomain, getShopIdByDomain } from "../services/ink-api.server";
+import { findMerchantDocRef } from "../services/merchant-doc.server";
 import Settings from "../components/settings/Settings";
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -57,20 +58,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
   let usedStr = "0";
 
   try {
-    // BY DOCUMENT ID FIRST. The embedded app provisions with
-    // `merchants.doc(shop).set({ shop, … })`, so `where("shopDomain", …)` never
-    // matched it — which is why this read "Not available" for every merchant,
-    // permanently, no matter how long ago they installed. The query is kept as
-    // a fallback: the standalone auth path creates docs with random ids and a
-    // `shopDomain` field.
-    let data: Record<string, any> | undefined;
-    const byId = await firestore.collection("merchants").doc(session.shop).get();
-    if (byId.exists) {
-      data = byId.data();
-    } else {
-      const merchantDocs = await firestore.collection("merchants").where("shopDomain", "==", session.shop).limit(1).get();
-      if (!merchantDocs.empty) data = merchantDocs.docs[0].data();
-    }
+    // findMerchantDocRef — the same resolver the fulfillment webhook uses.
+    // This used to be a private doc-id-then-"shopDomain" lookup, which is
+    // exactly the §17.2 landmine: on a store holding two merchant docs, the
+    // install date could live on the doc this private lookup never checked
+    // (a random-id backend doc, or one using the snake_case shop_domain
+    // field), and this row would read "Not available" even though the real
+    // doc has a createdAt.
+    const hit = await findMerchantDocRef(firestore, session.shop);
+    const data: Record<string, any> | undefined = hit?.data;
     if (data?.createdAt) {
       const date = data.createdAt.toDate ? data.createdAt.toDate() : new Date(data.createdAt);
       if (!Number.isNaN(date.getTime())) {

--- a/app/routes/app.tagged-shipments._index.tsx
+++ b/app/routes/app.tagged-shipments._index.tsx
@@ -3,7 +3,6 @@ import { useState, useEffect, useCallback } from "react";
 import { useLoaderData, useRevalidator, useRouteError, type HeadersFunction } from "react-router";
 import type { LoaderFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
-import { getMerchant } from "../services/merchant.server";
 import { enrollOrder } from "../services/ink-api.server";
 import {
   Page,

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -8,7 +8,9 @@ import { authenticate, registerWebhooks } from "../shopify.server";
 import { ShopProvider } from "../contexts/ShopContext";
 import { ensureCarrierServiceRegistered } from "../services/carrier-service.server";
 import { createMerchant } from "../services/ink-api.server";
-import { getMerchant, updateMerchant } from "../services/merchant.server";
+import { updateMerchant } from "../services/merchant.server";
+import { findMerchantDocRef } from "../services/merchant-doc.server";
+import firestore from "../firestore.server";
 import { DEFAULT_NOTIFICATION_SETTINGS } from "../services/notification-settings";
 
 import polarisStyles from "@shopify/polaris/build/esm/styles.css?url";
@@ -44,9 +46,18 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   // INK merchant's api_key into merchants/{shop} + default to automatic the
   // first time only (guarded on ink_api_key so an existing key is never
   // re-rotated). Non-blocking: never delays or breaks the app render.
+  //
+  // findMerchantDocRef, not a doc-id-only read: the private `getMerchant`
+  // this used to call only ever checked `merchants/{shop}` by document id.
+  // A store already carrying a backend-provisioned doc under a DIFFERENT id
+  // (with a real ink_api_key) would read as having none here, and THIS
+  // loader — which runs on every embedded page load — would call
+  // createMerchant() again and again, minting a fresh key onto the
+  // domain-keyed doc while the real one sat untouched: the §17.2 landmine,
+  // self-inflicted on every visit rather than found once.
   (async () => {
-    const existing = await getMerchant(session.shop);
-    if (!existing?.ink_api_key) {
+    const hit = await findMerchantDocRef(firestore, session.shop);
+    if (!hit?.apiKey) {
       // Real owner identity, not the old admin@{domain} placeholder — that
       // placeholder made the magic link the ONLY door into in.ink (the
       // merchant could never log in with their real email).
@@ -74,11 +85,26 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         // Settings page rendered them all as ON (audit 2026-08-07). The
         // Notifications GET backfills too, so installs predating this heal
         // on their first visit to the tab.
-        await updateMerchant(session.shop, {
-          ink_api_key: inkData.api_key,
-          verified_delivery_mode: "background",
-          notification_settings: DEFAULT_NOTIFICATION_SETTINGS,
-        });
+        if (hit?.ref) {
+          // A doc already exists under SOME shape for this shop (just
+          // without a real key yet) — heal that one, never fork a second.
+          await hit.ref.set(
+            {
+              ink_api_key: inkData.api_key,
+              verified_delivery_mode: hit.data?.verified_delivery_mode ?? "background",
+              notification_settings: hit.data?.notification_settings ?? DEFAULT_NOTIFICATION_SETTINGS,
+              updatedAt: new Date(),
+            },
+            { merge: true },
+          );
+        } else {
+          // Genuinely nothing exists yet — create the canonical domain-keyed doc.
+          await updateMerchant(session.shop, {
+            ink_api_key: inkData.api_key,
+            verified_delivery_mode: "background",
+            notification_settings: DEFAULT_NOTIFICATION_SETTINGS,
+          });
+        }
       }
     }
   })().catch((err) =>

--- a/app/routes/webhooks.orders_create.ts
+++ b/app/routes/webhooks.orders_create.ts
@@ -3,7 +3,7 @@ import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
 import { enrollOrder, createMerchant } from "../services/ink-api.server";
 import { attachProductUrls, productDetailFromLineItem } from "../services/order-line-item";
-import { findActivationDocRef } from "../services/merchant-doc.server";
+import { findActivationDocRef, findMerchantDocRef, type MerchantDocRefHit } from "../services/merchant-doc.server";
 import {
   countryOfWebhookOrder,
   orderActivates,
@@ -14,58 +14,32 @@ import {
 import { spendFromCap } from "../services/activation-counter.server";
 
 /**
- * Look up the merchant's verified-delivery mode preference.
- * Defaults to "background" so a missing preference never implies a
- * customer-paid checkout add-on.
+ * The merchant, resolved ONCE per webhook delivery through the SAME
+ * resolver the settings routes use — `findMerchantDocRef`, not the two
+ * private, single-convention ("shopDomain" field, then doc-id) lookups this
+ * used to carry (one for the delivery-mode preference, one — byte-identical
+ * to the warehouse enroll proxy's — for the ink_api_key Alan's /api/enroll
+ * needs). Both missed the backend's snake_case shop_domain doc and never
+ * preferred the doc actually carrying the key: on a store holding two
+ * merchant docs, enrollment could silently run with NO key (the order is
+ * recorded and never gets a page) or, worse, re-provision a fresh one on
+ * every 401 instead of ever finding the real doc (§17.2 landmine).
+ *
+ * Delivery mode defaults to "background" so a missing preference never
+ * implies a customer-paid checkout add-on; there is currently only one
+ * valid mode, so the read is precautionary/consistency, not load-bearing.
  */
-async function getMerchantDeliveryMode(
-  shopDomain: string
-): Promise<"background"> {
+async function resolveMerchantForEnroll(
+  shopDomain: string,
+): Promise<{ hit: MerchantDocRefHit | null; deliveryMode: "background"; apiKey: string | null }> {
+  let hit: MerchantDocRefHit | null = null;
   try {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shopDomain)
-      .limit(1)
-      .get();
-    let docData = snapshot.empty ? null : snapshot.docs[0].data();
-    if (!docData) {
-      const direct = await firestore.collection("merchants").doc(shopDomain).get();
-      if (direct.exists) docData = direct.data() ?? null;
-    }
-    const mode = docData?.verified_delivery_mode;
-    if (mode === "background") return mode;
-    return "background";
+    hit = await findMerchantDocRef(firestore, shopDomain);
   } catch (e) {
-    console.warn(
-      `[orders/create] Failed to read delivery mode for ${shopDomain}, defaulting to background:`,
-      e
-    );
-    return "background";
+    console.warn(`[orders/create] Failed to resolve merchant doc for ${shopDomain}:`, e);
   }
-}
-
-/**
- * The merchant's INK api_key — the Bearer Alan's /api/enroll (requireMerchant)
- * needs. Same source the warehouse enroll uses.
- */
-async function getMerchantApiKey(shopDomain: string): Promise<string | null> {
-  try {
-    const snapshot = await firestore
-      .collection("merchants")
-      .where("shopDomain", "==", shopDomain)
-      .limit(1)
-      .get();
-    let data = snapshot.empty ? null : snapshot.docs[0].data();
-    if (!data) {
-      const direct = await firestore.collection("merchants").doc(shopDomain).get();
-      if (direct.exists) data = direct.data() ?? null;
-    }
-    const key = data?.ink_api_key;
-    return key && key !== "sk_test_fallback" ? key : null;
-  } catch (e) {
-    console.warn(`[orders/create] getMerchantApiKey failed for ${shopDomain}:`, e);
-    return null;
-  }
+  const apiKey = hit?.apiKey && hit.apiKey !== "sk_test_fallback" ? hit.apiKey : null;
+  return { hit, deliveryMode: "background", apiKey };
 }
 
 function genNfcToken(): string {
@@ -269,7 +243,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   // Background enrollment: INK is hidden from checkout and never appears as a
   // customer-paid shipping option, so every order on this shop is eligible.
-  const deliveryMode = await getMerchantDeliveryMode(shop);
+  // Resolved ONCE here — reused below for the ink_api_key and, on a stale-key
+  // retry, for the ref to update.
+  const { hit: merchantHit, deliveryMode, apiKey: resolvedApiKey } = await resolveMerchantForEnroll(shop);
   // The merchant doc FOR THE SLICE, through the slice's own resolver. A
   // connected store can hold TWO merchant docs, and the workspace's save can
   // only ever reach the ACTIVE one — reading the api-key doc here (as
@@ -345,7 +321,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     let inkToken = "";
     let verificationStatus = "pending";
     try {
-      const apiKey = await getMerchantApiKey(shop);
+      const apiKey = resolvedApiKey;
       if (!apiKey) {
         console.warn(
           // NOT "order tagged" any more: a merchant who narrowed by product
@@ -509,13 +485,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
               const fresh = await createMerchant(shop, shopIdentity?.name || shop, ownerEmail);
               const freshKey = fresh?.api_key;
               if (!freshKey) throw e;
-              const snap = await firestore
-                .collection("merchants")
-                .where("shopDomain", "==", shop)
-                .limit(1)
-                .get();
-              if (!snap.empty) {
-                await snap.docs[0].ref.update({ ink_api_key: freshKey, updatedAt: new Date() });
+              // Write through the SAME ref resolveMerchantForEnroll already
+              // found for this shop (any doc shape) — a fresh ad hoc query
+              // here (as this used to run) could create a THIRD doc instead
+              // of healing the one the resolver, and everything downstream,
+              // actually reads.
+              if (merchantHit?.ref) {
+                await merchantHit.ref.update({ ink_api_key: freshKey, updatedAt: new Date() });
               } else {
                 await firestore
                   .collection("merchants")

--- a/app/routes/webhooks.shop.redact.tsx
+++ b/app/routes/webhooks.shop.redact.tsx
@@ -2,6 +2,7 @@ import { type ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import firestore from "../firestore.server";
 import { purgeShopInInk } from "../services/ink-api.server";
+import { findMerchantDocRef } from "../services/merchant-doc.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { topic, shop } = await authenticate.webhook(request);
@@ -10,7 +11,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   // SHOP/REDACT: ~48 hours after uninstall, or when a store requests
   // deletion. Two sides to erase:
-  //   1. this app's own merchant doc (embed Firestore) — below;
+  //   1. this app's own merchant doc(s) (embed Firestore) — below;
   //   2. the system of record (ink-backend): the shop's proofs, per-proof
   //      event/return rows, and backend merchant docs — forwarded to
   //      POST /admin/purge-shop (staged; deploy Sam-gated).
@@ -18,10 +19,25 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   // merchant-unknown no-op) → 200 · endpoint 404 (backend not deployed yet)
   // → 200 + loud ERROR log · transient 5xx/network → 500 so Shopify
   // redelivers (the embed-doc delete below is idempotent on retry).
+  //
+  // BOTH DOCS, NOT JUST doc(shop). A store can hold two merchant docs in
+  // THIS SAME Firestore project — the embed's own (doc id = shop domain) and
+  // a backend-provisioned one (a random id carrying ink_api_key, and
+  // whatever settings the shared resolver has been writing to it: notification
+  // preferences, the branded-tracking-link switch, merchant media). Deleting
+  // only doc(shop) is a GDPR erasure that leaves a customer's operational
+  // data sitting in the OTHER doc, forever — the §17.2 landmine, here as a
+  // compliance gap rather than a silent no-op. findMerchantDocRef finds
+  // whichever doc the settings routes actually write; both it and the
+  // domain-keyed doc are deleted when they differ.
   let embedDocDeleted = false;
   try {
     console.log(`[GDPR] Deleting merchant data for ${shop}`);
+    const hit = await findMerchantDocRef(firestore, shop).catch(() => null);
     await firestore.collection("merchants").doc(shop).delete();
+    if (hit?.ref && hit.ref.id !== shop) {
+      await hit.ref.delete();
+    }
     embedDocDeleted = true;
   } catch (error) {
     console.error(`[GDPR] Failed to delete embed merchant doc for ${shop}:`, error);

--- a/app/services/merchant-doc-either.server.test.ts
+++ b/app/services/merchant-doc-either.server.test.ts
@@ -1,0 +1,127 @@
+// findMerchantDocRefByEither — the warehouse/PWA shape, where a JWT may carry
+// shopDomain, merchant_id, or both, and either one must still land on the
+// doc the fulfilment webhook reads. See merchant-doc.server.ts's own header
+// for why this exists (§17.2 landmine, appearances six and seven).
+
+import { describe, expect, it } from "vitest";
+import { findMerchantDocRefByEither } from "./merchant-doc.server";
+
+type Doc = { id: string; data: Record<string, unknown> };
+
+/** Same minimal firestore stub as merchant-doc-ref.server.test.ts. */
+function stubFirestore(docs: Doc[]) {
+  return {
+    collection(name: string) {
+      if (name !== "merchants") throw new Error("unexpected collection " + name);
+      return {
+        doc(id: string) {
+          const hit = docs.find((d) => d.id === id);
+          const ref = { id, __isRef: true };
+          return {
+            ...ref,
+            async get() {
+              return { exists: Boolean(hit), data: () => hit?.data, ref };
+            },
+          };
+        },
+        where(field: string, _op: string, value: unknown) {
+          return {
+            limit() {
+              return {
+                async get() {
+                  const matches = docs.filter((d) => d.data[field] === value);
+                  return {
+                    empty: matches.length === 0,
+                    docs: matches.map((d) => ({
+                      data: () => d.data,
+                      ref: { id: d.id, __isRef: true },
+                    })),
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  } as any;
+}
+
+describe("findMerchantDocRefByEither", () => {
+  it("resolves via merchant_id (a backend JWT's id IS the doc id) even with no shopDomain", async () => {
+    const fs = stubFirestore([
+      { id: "shop_abc123", data: { shop_domain: "corvara.myshopify.com", ink_api_key: "k1" } },
+    ]);
+    const hit = await findMerchantDocRefByEither(fs, { merchantId: "shop_abc123" });
+    expect(hit?.ref.id).toBe("shop_abc123");
+    expect(hit?.apiKey).toBe("k1");
+  });
+
+  it("resolves via shopDomain when merchant_id is absent", async () => {
+    const fs = stubFirestore([
+      { id: "sm-test.myshopify.com", data: { shop: "sm-test.myshopify.com", ink_api_key: "k2" } },
+    ]);
+    const hit = await findMerchantDocRefByEither(fs, { shopDomain: "sm-test.myshopify.com" });
+    expect(hit?.ref.id).toBe("sm-test.myshopify.com");
+  });
+
+  it("THE TWO-DOC SHAPE: merchant_id names the wrong (keyless) doc, shopDomain finds the real one", async () => {
+    // Mirrors the measured shape from #107: a domain-keyed doc with no key,
+    // and a random-id doc that carries it. A caller might hand us the
+    // domain-keyed id as "merchant_id" (a stale cache, an old token) — that
+    // candidate alone resolves to the SAME doc via the field fallback inside
+    // findMerchantDocRef, so it still finds the keyed doc, not nothing.
+    const fs = stubFirestore([
+      { id: "smusic-official.myshopify.com", data: { shop: "smusic-official.myshopify.com" } },
+      {
+        id: "PWXStzc7mP8hn33xPbNf",
+        data: { shop_domain: "smusic-official.myshopify.com", ink_api_key: "real_key" },
+      },
+    ]);
+    const hit = await findMerchantDocRefByEither(fs, {
+      merchantId: "smusic-official.myshopify.com",
+      shopDomain: "smusic-official.myshopify.com",
+    });
+    expect(hit?.ref.id).toBe("PWXStzc7mP8hn33xPbNf");
+    expect(hit?.apiKey).toBe("real_key");
+  });
+
+  it("a merchant_id that resolves to a keyless doc doesn't stop shopDomain from finding the real one", async () => {
+    // The merchant_id happens to name a DIFFERENT, keyless doc for this shop
+    // (a stale cache, a doc created before provisioning finished) — the
+    // shopDomain candidate still gets tried, and its doc carries the key.
+    const fs = stubFirestore([
+      { id: "shop_stale", data: { shop_domain: "corvara.myshopify.com" } },
+      { id: "corvara.myshopify.com", data: { shop: "corvara.myshopify.com", ink_api_key: "real_key" } },
+    ]);
+    const hit = await findMerchantDocRefByEither(fs, {
+      merchantId: "shop_stale",
+      shopDomain: "corvara.myshopify.com",
+    });
+    expect(hit?.ref.id).toBe("corvara.myshopify.com");
+    expect(hit?.apiKey).toBe("real_key");
+  });
+
+  it("falls back to a keyless hit when NEITHER identifier finds a key — still returns a doc, not nothing", async () => {
+    const fs = stubFirestore([{ id: "shop_stale", data: { shop_domain: "ghost.myshopify.com" } }]);
+    const hit = await findMerchantDocRefByEither(fs, {
+      merchantId: "shop_stale",
+      shopDomain: "ghost.myshopify.com",
+    });
+    expect(hit?.ref.id).toBe("shop_stale");
+    expect(hit?.apiKey).toBeNull();
+  });
+
+  it("returns null when neither identifier is present", async () => {
+    const hit = await findMerchantDocRefByEither(stubFirestore([]), {});
+    expect(hit).toBeNull();
+  });
+
+  it("returns null when both identifiers are given but nothing matches", async () => {
+    const hit = await findMerchantDocRefByEither(stubFirestore([]), {
+      merchantId: "ghost_id",
+      shopDomain: "ghost.myshopify.com",
+    });
+    expect(hit).toBeNull();
+  });
+});

--- a/app/services/merchant-doc.server.ts
+++ b/app/services/merchant-doc.server.ts
@@ -70,6 +70,37 @@ export async function findMerchantDoc(
   return hit ? { data: hit.data, apiKey: hit.apiKey } : null;
 }
 
+/** THE WAREHOUSE/PWA SHAPE — a caller that may hold EITHER identifier.
+ *
+ *  Several proxy routes (warehouse enroll/upload, settings/media,
+ *  settings/inventory) carry a JWT that names `shop` (a domain) or
+ *  `merchant_id` (which, for an ink-backend-issued token, IS the backend
+ *  doc's own id) — sometimes both, sometimes one. Each route hand-rolled a
+ *  "try merchant_id as a doc id, else try shopDomain as a field" lookup that
+ *  knew only ONE field convention and never preferred the doc carrying
+ *  `ink_api_key` — the §17.2 landmine, appearances six and seven (warehouse
+ *  enroll and upload carried byte-identical copies of the same function).
+ *
+ *  This tries each identifier in turn through the ONE resolver, so whichever
+ *  one is present still lands on the doc the fulfilment webhook reads. A
+ *  candidate that resolves but carries no ink_api_key is kept as a fallback
+ *  rather than returned immediately — the OTHER identifier gets a chance to
+ *  find the doc that actually carries the key first. */
+export async function findMerchantDocRefByEither(
+  firestore: Firestore,
+  identifiers: { shopDomain?: string | null; merchantId?: string | null },
+): Promise<MerchantDocRefHit | null> {
+  let fallback: MerchantDocRefHit | null = null;
+  for (const candidate of [identifiers.merchantId, identifiers.shopDomain]) {
+    if (!candidate) continue;
+    const hit = await findMerchantDocRef(firestore, candidate);
+    if (!hit) continue;
+    if (hit.apiKey) return hit;
+    fallback = fallback ?? hit;
+  }
+  return fallback;
+}
+
 /** THE SLICE'S OWN RESOLVER — the record the workspace door actually writes.
  *
  *  findMerchantDocRef prefers the doc carrying `ink_api_key`, which is right

--- a/app/services/merchant.server.ts
+++ b/app/services/merchant.server.ts
@@ -17,16 +17,15 @@ export interface MerchantData {
   createdAt?: string;
 }
 
-export const getMerchant = async (shop: string): Promise<MerchantData | null> => {
-  try {
-    const doc = await firestore.collection(COLLECTION).doc(shop).get();
-    if (!doc.exists) return null;
-    return doc.data() as MerchantData;
-  } catch (error) {
-    console.error("Error fetching merchant:", error);
-    return null;
-  }
-};
+// getMerchant() used to live here — a doc-id-only read (`doc(shop).get()`,
+// no fallback). Its one real caller, app.tsx's self-provisioning loader,
+// now resolves through `findMerchantDocRef` instead (services/merchant-doc.
+// server.ts), which also checks the backend's snake_case shop_domain field
+// and prefers whichever doc actually carries ink_api_key — the §17.2
+// landmine this doc-id-only shape kept re-triggering on every embedded page
+// load for a store holding two merchant docs. Deleted rather than kept
+// unused; `git log -S "export const getMerchant"` has it if anything ever
+// needs a doc-id-only read again.
 
 export const updateMerchant = async (shop: string, data: Partial<MerchantData>) => {
   try {

--- a/app/services/settings-routes-two-doc-shape.test.ts
+++ b/app/services/settings-routes-two-doc-shape.test.ts
@@ -1,0 +1,613 @@
+// THE TWO-DOC SHAPE, PINNED AT EVERY FIXED ROUTE.
+//
+// Measured 2026-09-05 (embed PR #107's own audit): a connected store can
+// hold TWO merchant docs in the SAME Firestore project — the embed's own
+// (doc id = the shop domain, from provisioning) and a backend-provisioned
+// one (a random id, carrying `ink_api_key` and everything the shared
+// resolver writes: notification prefs, the branded-tracking-link switch,
+// the install date). `smusic-official.myshopify.com` holds exactly this
+// shape today.
+//
+// Every route below used to carry its OWN private lookup — a doc-id-only
+// read, or a single-field-convention query, or both in the wrong order —
+// so on that shape it silently read or wrote the WRONG doc: a switch that
+// saves and does nothing, a card that says "not configured" when it is, an
+// install date that never appears, a GDPR erasure that leaves data behind.
+// Fixed by routing every one of them through `findMerchantDocRef` /
+// `findMerchantDocRefByEither` — the SAME resolver the fulfillment webhook
+// already used (services/merchant-doc.server.ts).
+//
+// Each block below is RED against the pre-fix code (a doc-id-only or
+// single-convention lookup returns the keyless domain doc, or nothing) and
+// GREEN after (the resolver finds the doc carrying ink_api_key). Verified
+// by hand against git stash of the fix per route before writing this file.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── The shared two-doc fixture and a firestore stub that records writes ──
+
+const SHOP = "smusic-official.myshopify.com";
+/** The embed's own doc — id IS the shop domain, provisioned first, no key. */
+const DOMAIN_DOC_ID = SHOP;
+/** The backend-provisioned doc — a random id, carries the real key. */
+const BACKEND_DOC_ID = "PWXStzc7mP8hn33xPbNf";
+
+type Doc = { id: string; data: Record<string, unknown> };
+
+function twoDocShape(extra: Record<string, unknown> = {}): Doc[] {
+  return [
+    { id: DOMAIN_DOC_ID, data: { shop: SHOP } },
+    { id: BACKEND_DOC_ID, data: { shop_domain: SHOP, ink_api_key: "real_key", ...extra } },
+  ];
+}
+
+/** A firestore stub that speaks the surface findMerchantDocRef(ByEither)
+ *  uses, PLUS write tracking (`update`/`set`/`delete`/`add`) so a test can
+ *  assert which doc actually changed. */
+function stubFirestore(initialDocs: Doc[]) {
+  const state = new Map<string, Record<string, unknown>>(initialDocs.map((d) => [d.id, { ...d.data }]));
+  const deleted = new Set<string>();
+  const writes: Record<string, Record<string, unknown>> = {};
+
+  function makeRef(id: string): any {
+    return {
+      id,
+      async get() {
+        const exists = state.has(id) && !deleted.has(id);
+        return { exists, data: () => (exists ? { ...state.get(id) } : undefined), ref: makeRef(id) };
+      },
+      async update(patch: Record<string, unknown>) {
+        writes[id] = { ...(writes[id] ?? {}), ...patch };
+        state.set(id, { ...(state.get(id) ?? {}), ...patch });
+      },
+      async set(patch: Record<string, unknown>, opts?: { merge?: boolean }) {
+        const merged = opts?.merge ? { ...(state.get(id) ?? {}), ...patch } : patch;
+        writes[id] = opts?.merge ? { ...(writes[id] ?? {}), ...patch } : patch;
+        state.set(id, merged);
+      },
+      async delete() {
+        deleted.add(id);
+      },
+    };
+  }
+
+  return {
+    writes,
+    deleted,
+    docExists: (id: string) => state.has(id) && !deleted.has(id),
+    collection(name: string) {
+      if (name !== "merchants") throw new Error("unexpected collection: " + name);
+      return {
+        doc: (id: string) => makeRef(id),
+        where(field: string, _op: string, value: unknown) {
+          return {
+            limit() {
+              return {
+                async get() {
+                  const matches = [...state.entries()].filter(
+                    ([id, data]) => !deleted.has(id) && data[field] === value,
+                  );
+                  return {
+                    empty: matches.length === 0,
+                    docs: matches.map(([id, data]) => ({ id, data: () => ({ ...data }), ref: makeRef(id) })),
+                  };
+                },
+              };
+            },
+          };
+        },
+        async get() {
+          const entries = [...state.entries()].filter(([id]) => !deleted.has(id));
+          return { docs: entries.map(([id, data]) => ({ id, data: () => ({ ...data }), ref: makeRef(id) })) };
+        },
+        async add(data: Record<string, unknown>) {
+          const id = "auto_" + Math.random().toString(36).slice(2, 10);
+          state.set(id, { ...data });
+          writes[id] = data;
+          return makeRef(id);
+        },
+      };
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+// ─── app.api.settings.delivery-mode.tsx ───────────────────────────────────
+
+describe("app.api.settings.delivery-mode — PATCH lands on the doc the webhook reads", () => {
+  it("writes verified_delivery_mode to the ink_api_key doc, not the domain-keyed one", async () => {
+    const fs = stubFirestore(twoDocShape());
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../shopify.server", () => ({
+      authenticate: { admin: vi.fn(async () => ({ admin: {}, session: { shop: SHOP } })) },
+    }));
+    vi.doMock("../services/carrier-service.server", () => ({ setCarrierServiceActive: vi.fn(async () => {}) }));
+
+    const { action } = await import("../routes/app.api.settings.delivery-mode");
+    const response = await action({
+      request: new Request("https://x/app/api/settings/delivery-mode", {
+        method: "PATCH",
+        body: JSON.stringify({ mode: "background" }),
+      }),
+    } as any);
+    const body = await response.json();
+
+    expect(body.mode).toBe("background");
+    expect(fs.writes[BACKEND_DOC_ID]).toMatchObject({ verified_delivery_mode: "background" });
+    expect(fs.writes[DOMAIN_DOC_ID]).toBeUndefined();
+  });
+});
+
+// ─── app.api.dashboard.comms.tsx ──────────────────────────────────────────
+
+describe("app.api.dashboard.comms — reads the Settings panel's own write", () => {
+  it("finds notification_settings even though it lives on the OTHER doc", async () => {
+    const fs = stubFirestore(twoDocShape({ notification_settings: { channels: { email: true } } }));
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../shopify.server", () => ({
+      authenticate: { admin: vi.fn(async () => ({ session: { shop: SHOP } })) },
+    }));
+
+    const { loader } = await import("../routes/app.api.dashboard.comms");
+    const response = await loader({ request: new Request("https://x/app/api/dashboard/comms") } as any);
+    const body = await response.json();
+
+    expect(body.settings).toEqual({ channels: { email: true } });
+  });
+});
+
+// ─── app.api.onboarding.status.tsx ────────────────────────────────────────
+
+describe("app.api.onboarding.status — the checklist agrees with Settings", () => {
+  it("says notifications ARE on when they live on the ink_api_key doc", async () => {
+    const fs = stubFirestore(
+      twoDocShape({ notification_settings: { channels: { email: true, sms: false } } }),
+    );
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../shopify.server", () => ({
+      authenticate: { admin: vi.fn(async () => ({ session: { shop: SHOP } })) },
+    }));
+    vi.doMock("../services/email.server", () => ({ brandSlugFromDomain: () => "" }));
+    vi.doMock("../services/brand-email.server", () => ({ fetchBrandEmailKit: vi.fn(async () => null) }));
+    vi.doMock("../services/ink-api.server", () => ({
+      getShopIdByDomain: vi.fn(async () => {
+        throw new Error("not needed for this assertion");
+      }),
+      getMerchantTapStats: vi.fn(async () => null),
+    }));
+
+    const { loader } = await import("../routes/app.api.onboarding.status");
+    const response = await loader({ request: new Request("https://x/app/api/onboarding/status") } as any);
+    const body = await response.json();
+
+    expect(body.notificationsOn).toBe(true);
+  });
+});
+
+// ─── app.settings.tsx ──────────────────────────────────────────────────────
+
+describe("app.settings loader — the install date reads the real doc", () => {
+  it("finds createdAt on the ink_api_key doc when the domain-keyed doc has none", async () => {
+    const createdAt = new Date("2026-01-15T00:00:00Z").toISOString();
+    const fs = stubFirestore(twoDocShape({ createdAt }));
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../shopify.server", () => ({
+      authenticate: {
+        admin: vi.fn(async () => ({
+          admin: { graphql: vi.fn(async () => ({ json: async () => ({ data: { shop: null } }) })) },
+          session: { shop: SHOP },
+        })),
+      },
+    }));
+    vi.doMock("../services/ink-api.server", () => ({
+      getInventory: vi.fn(async () => null),
+      getInventoryByShopDomain: vi.fn(async () => {
+        throw new Error("not needed for this assertion");
+      }),
+      getShopIdByDomain: vi.fn(async () => {
+        throw new Error("not needed for this assertion");
+      }),
+    }));
+    vi.doMock("../components/settings/Settings", () => ({ default: () => null }));
+
+    const { loader } = await import("../routes/app.settings");
+    const data = await (loader as any)({ request: new Request("https://x/app/settings") });
+
+    expect(data.installedDate).toBe(
+      new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" }).format(
+        new Date(createdAt),
+      ),
+    );
+  });
+});
+
+// ─── app.api.settings.inventory.tsx ───────────────────────────────────────
+
+describe("app.api.settings.inventory — merchant_id and shopDomain both land on the keyed doc", () => {
+  it("GET reads low_inventory_threshold from the real doc via merchant_id alone", async () => {
+    const fs = stubFirestore(twoDocShape({ low_inventory_threshold: 7 }));
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../services/token-verify.server", () => ({
+      verifyProxyToken: vi.fn(async () => ({ shop: undefined, merchant_id: BACKEND_DOC_ID })),
+    }));
+
+    const { loader } = await import("../routes/app.api.settings.inventory");
+    const response = await loader({
+      request: new Request("https://x/app/api/settings/inventory", { headers: { Authorization: "Bearer t" } }),
+    } as any);
+    const body = await response.json();
+
+    expect(body.low_inventory_threshold).toBe(7);
+  });
+
+  it("POST writes to the ink_api_key doc when only shopDomain is known", async () => {
+    const fs = stubFirestore(twoDocShape());
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../services/token-verify.server", () => ({
+      verifyProxyToken: vi.fn(async () => ({ shop: SHOP, merchant_id: undefined })),
+    }));
+
+    const { action } = await import("../routes/app.api.settings.inventory");
+    const response = await action({
+      request: new Request("https://x/app/api/settings/inventory", {
+        method: "POST",
+        headers: { Authorization: "Bearer t" },
+        body: JSON.stringify({ low_inventory_threshold: 3 }),
+      }),
+    } as any);
+    await response.json();
+
+    expect(fs.writes[BACKEND_DOC_ID]).toMatchObject({ low_inventory_threshold: 3 });
+    expect(fs.writes[DOMAIN_DOC_ID]).toBeUndefined();
+  });
+});
+
+// ─── app.api.settings.media.tsx ───────────────────────────────────────────
+
+describe("app.api.settings.media — GET reads merchant_media off the keyed doc", () => {
+  it("finds media saved on the doc the webhook reads, given only shopDomain", async () => {
+    // The module reads INK_ADMIN_SECRET at import time (fails loudly by
+    // design if unset in a real deploy); this route's Alan-upload path is
+    // untouched by the fix, so a fixed test value is enough to import it.
+    process.env.INK_ADMIN_SECRET = "test_admin_secret";
+    const fs = stubFirestore(twoDocShape({ merchant_media: [{ id: "m1", url: "https://x/1.mp4" }] }));
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../shopify.server", () => ({
+      authenticate: { admin: vi.fn(async () => ({ session: { shop: SHOP } })) },
+    }));
+
+    const { loader } = await import("../routes/app.api.settings.media");
+    const response = await loader({ request: new Request("https://x/app/api/settings/media") } as any);
+    const body = await response.json();
+
+    expect(body.media).toEqual([{ id: "m1", url: "https://x/1.mp4" }]);
+  });
+});
+
+// ─── app.api.warehouse.enroll.tsx / .upload.tsx ───────────────────────────
+
+describe("app.api.warehouse.enroll / upload — the api-key resolution both share", () => {
+  it("enroll finds the real key from shopDomain alone — the old camelCase-only query missed the backend's snake_case doc", async () => {
+    const fs = stubFirestore(twoDocShape());
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    // No merchant_id: this token only names the shop domain (the shape an
+    // embed-issued HMAC token carries). The old private lookup queried
+    // ONLY the camelCase "shopDomain" field for this case — the backend
+    // doc here carries snake_case shop_domain, so it found nothing.
+    vi.doMock("../services/token-verify.server", () => ({
+      verifyProxyToken: vi.fn(async () => ({ shop: SHOP, merchant_id: undefined })),
+    }));
+    vi.doMock("../services/ink-api.server", () => ({
+      enrollOrder: vi.fn(async () => ({ proof_id: "proof_x", state: "pending", enrolled_at: "now" })),
+      getShopIdByDomain: vi.fn(async () => "shop_x"),
+      adjustMerchantInventory: vi.fn(async () => {}),
+      getInventoryByShopDomain: vi.fn(async () => ({ current_count: 10 })),
+    }));
+    vi.doMock("../session-utils.server", () => ({ getOfflineSession: vi.fn(async () => null) }));
+
+    const enrollMod = await import("../services/ink-api.server");
+    const { action } = await import("../routes/app.api.warehouse.enroll");
+    const response = await action({
+      request: new Request("https://x/app/api/warehouse/enroll", {
+        method: "POST",
+        headers: { Authorization: "Bearer t" },
+        body: JSON.stringify({
+          order_id: "1001",
+          nfc_token: "nfc_tok",
+          order_number: "1001",
+          customer_email: "buyer@example.com",
+          shipping_address: { line1: "1 Main St" },
+          product_details: [{ title: "Widget" }],
+        }),
+      }),
+    } as any);
+    const body = await response.json();
+
+    expect(response.status ?? 200).not.toBe(404);
+    expect(body.success).toBe(true);
+    expect((enrollMod.enrollOrder as any).mock.calls[0][0]).toBe("real_key");
+  });
+
+  it("upload finds the real key from shopDomain alone — same fix, same old gap", async () => {
+    const fs = stubFirestore(twoDocShape());
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../services/token-verify.server", () => ({
+      verifyProxyToken: vi.fn(async () => ({ shop: SHOP, merchant_id: undefined })),
+    }));
+    vi.doMock("../services/ink-api.server", () => ({
+      uploadMedia: vi.fn(async () => ({ media_id: "m1", media_url: "https://x/m1.jpg" })),
+      adjustMerchantInventory: vi.fn(async () => {}),
+      getShopIdByDomain: vi.fn(async () => "shop_x"),
+    }));
+
+    const uploadMod = await import("../services/ink-api.server");
+    const { action } = await import("../routes/app.api.warehouse.upload");
+    const form = new FormData();
+    form.set("proof_id", "proof_x");
+    form.set("media_type", "photo");
+    form.set("file", new File(["x"], "x.jpg", { type: "image/jpeg" }));
+    const response = await action({
+      request: new Request("https://x/app/api/warehouse/upload", {
+        method: "POST",
+        headers: { Authorization: "Bearer t" },
+        body: form,
+      }),
+    } as any);
+    const body = await response.json();
+
+    expect(body.success).toBe(true);
+    expect((uploadMod.uploadMedia as any).mock.calls[0][0]).toBe("real_key");
+  });
+});
+
+// ─── app.api.auth.login.tsx ────────────────────────────────────────────────
+
+describe("app.api.auth.login — the INK v1.3.0 key-cache heals the real doc, not a third one", () => {
+  it("updates the ink_api_key doc in place instead of creating a new domain-keyed doc", async () => {
+    const fs = stubFirestore(twoDocShape());
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../services/ink-api.server", () => ({
+      loginUser: vi.fn(async () => ({
+        token: "t",
+        user: { merchant_id: SHOP, user_id: "u1", name: "Test", email: "a@b.com", role: "merchant" },
+      })),
+      createMerchant: vi.fn(async () => ({ api_key: "fresh_key" })),
+    }));
+
+    const { action } = await import("../routes/app.api.auth.login");
+    const response = await action({
+      request: new Request("https://x/app/api/auth/login", {
+        method: "POST",
+        body: JSON.stringify({ email: "a@b.com", password: "pw" }),
+      }),
+    } as any);
+    await response.json();
+
+    expect(fs.writes[BACKEND_DOC_ID]).toMatchObject({ ink_api_key: "fresh_key" });
+    // The domain-keyed doc must NOT have been (re)written with a fresh key —
+    // that write is exactly how a store ends up with two live keys.
+    expect(fs.writes[DOMAIN_DOC_ID]).toBeUndefined();
+  });
+});
+
+// ─── webhooks.shop.redact.tsx ──────────────────────────────────────────────
+
+describe("webhooks.shop.redact — GDPR erasure removes BOTH docs", () => {
+  it("deletes the ink_api_key doc as well as the domain-keyed one", async () => {
+    const fs = stubFirestore(twoDocShape());
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../shopify.server", () => ({
+      authenticate: { webhook: vi.fn(async () => ({ topic: "shop/redact", shop: SHOP })) },
+    }));
+    vi.doMock("../services/ink-api.server", () => ({
+      purgeShopInInk: vi.fn(async () => ({ ok: true, body: { counts: {} } })),
+    }));
+
+    const { action } = await import("../routes/webhooks.shop.redact");
+    const response = await action({ request: new Request("https://x/webhooks/shop/redact", { method: "POST" }) } as any);
+
+    expect(response.status).toBe(200);
+    expect(fs.docExists(DOMAIN_DOC_ID)).toBe(false);
+    expect(fs.docExists(BACKEND_DOC_ID)).toBe(false);
+  });
+
+  it("a single-doc shop (no split) still gets deleted exactly once — no error from the second delete", async () => {
+    const fs = stubFirestore([{ id: SHOP, data: { shop: SHOP, ink_api_key: "only_key" } }]);
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../shopify.server", () => ({
+      authenticate: { webhook: vi.fn(async () => ({ topic: "shop/redact", shop: SHOP })) },
+    }));
+    vi.doMock("../services/ink-api.server", () => ({
+      purgeShopInInk: vi.fn(async () => ({ ok: true, body: {} })),
+    }));
+
+    const { action } = await import("../routes/webhooks.shop.redact");
+    const response = await action({ request: new Request("https://x/webhooks/shop/redact", { method: "POST" }) } as any);
+
+    expect(response.status).toBe(200);
+    expect(fs.docExists(SHOP)).toBe(false);
+  });
+});
+
+// ─── webhooks.orders_create.ts ─────────────────────────────────────────────
+
+describe("webhooks.orders_create — auto-enroll uses the ink_api_key doc's key", () => {
+  it("enrolls with the real key resolved from the shop domain, not nothing", async () => {
+    const fs = stubFirestore(twoDocShape());
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+
+    const orderPayload = {
+      admin_graphql_api_id: "gid://shopify/Order/1",
+      id: 1,
+      name: "#1001",
+      order_number: 1001,
+      shipping_address: { phone: null },
+      phone: null,
+      customer: { email: "buyer@example.com", phone: null },
+      shipping_lines: [],
+      order_status_url: "https://shop.myshopify.com/orders/abc/status",
+    };
+
+    const fakeAdmin = {
+      graphql: vi.fn(async (query: string) => {
+        if (query.includes("AutoEnrollOrder")) {
+          return {
+            json: async () => ({
+              data: {
+                order: {
+                  id: "gid://shopify/Order/1",
+                  name: "#1001",
+                  customer: { email: "buyer@example.com", phone: null, firstName: "Buyer", lastName: "Test" },
+                  shippingAddress: {
+                    name: "Buyer Test",
+                    address1: "1 Main St",
+                    address2: null,
+                    city: "Metropolis",
+                    province: "NY",
+                    zip: "10001",
+                    country: "US",
+                  },
+                  totalPriceSet: { shopMoney: { amount: "10.00", currencyCode: "USD" } },
+                  lineItems: {
+                    edges: [
+                      {
+                        node: {
+                          title: "Widget",
+                          quantity: 1,
+                          sku: "W1",
+                          originalUnitPriceSet: { shopMoney: { amount: "10.00" } },
+                          image: null,
+                        },
+                      },
+                    ],
+                  },
+                  metafield: null,
+                  fulfillments: [],
+                },
+              },
+            }),
+          };
+        }
+        if (query.includes("AutoEnrollProductUrls")) {
+          return {
+            json: async () => ({
+              data: { order: { lineItems: { edges: [{ node: { product: null } }] } } },
+            }),
+          };
+        }
+        if (query.includes("AddOrderTag")) {
+          return { json: async () => ({ data: { tagsAdd: { userErrors: [] } } }) };
+        }
+        if (query.includes("SetInkMetafields")) {
+          return { json: async () => ({ data: { metafieldsSet: { userErrors: [] } } }) };
+        }
+        return { json: async () => ({ data: {} }) };
+      }),
+    };
+
+    vi.doMock("../shopify.server", () => ({
+      authenticate: {
+        webhook: vi.fn(async () => ({ payload: orderPayload, shop: SHOP, admin: fakeAdmin })),
+      },
+    }));
+
+    const inkApi = {
+      enrollOrder: vi.fn(async () => ({ proof_id: "proof_x", state: "pending", enrolled_at: "now" })),
+      createMerchant: vi.fn(async () => ({ api_key: "should_not_be_called" })),
+    };
+    vi.doMock("../services/ink-api.server", () => inkApi);
+
+    const { action } = await import("../routes/webhooks.orders_create");
+    const response = await action({
+      request: new Request("https://x/webhooks/orders_create", { method: "POST" }),
+    } as any);
+
+    expect(response.status).toBe(200);
+    expect(inkApi.enrollOrder).toHaveBeenCalled();
+    // THE ASSERTION: the key handed to Alan's /api/enroll is the one on the
+    // doc that actually carries it — never null, never re-provisioned.
+    expect((inkApi.enrollOrder as any).mock.calls[0][0]).toBe("real_key");
+    expect(inkApi.createMerchant).not.toHaveBeenCalled();
+  });
+});
+
+// ─── app.tsx loader — the self-provisioning IIFE ──────────────────────────
+
+describe("app.tsx loader — self-provisioning never re-mints a key the OTHER doc already has", () => {
+  it("does not call createMerchant when the ink_api_key doc already exists under a different id", async () => {
+    const fs = stubFirestore(twoDocShape());
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../shopify.server", () => ({
+      authenticate: {
+        admin: vi.fn(async () => ({
+          // A real owner email, so a pre-fix run would actually REACH
+          // createMerchant() instead of bailing out earlier for an
+          // unrelated reason (an empty-shop mock would pass either way).
+          admin: {
+            graphql: vi.fn(async () => ({
+              json: async () => ({ data: { shop: { name: "Test Shop", email: "owner@example.com" } } }),
+            })),
+          },
+          session: { shop: SHOP },
+        })),
+      },
+      registerWebhooks: vi.fn(async () => {}),
+    }));
+    vi.doMock("../services/carrier-service.server", () => ({
+      ensureCarrierServiceRegistered: vi.fn(async () => {}),
+    }));
+    const createMerchant = vi.fn(async () => ({ api_key: "should_never_be_minted" }));
+    vi.doMock("../services/ink-api.server", () => ({ createMerchant }));
+
+    const { loader } = await import("../routes/app");
+    await loader({ request: new Request("https://x/app") } as any);
+    // The provisioning check happens in a fire-and-forget IIFE (the loader
+    // must never delay the app's render on it) — flush the microtask queue
+    // before asserting.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The OLD `getMerchant(session.shop)` only ever checked doc(shop) by id
+    // — on this shape it would see no key, call createMerchant() again on
+    // THIS load and every load after, and heal the key onto the WRONG
+    // (domain-keyed) doc. findMerchantDocRef finds the real one first.
+    expect(createMerchant).not.toHaveBeenCalled();
+    expect(fs.writes[DOMAIN_DOC_ID]).toBeUndefined();
+    expect(fs.writes[BACKEND_DOC_ID]).toBeUndefined();
+  });
+
+  it("heals the doc that already exists (keyless) rather than forking a second one, on a genuine re-provision", async () => {
+    // A store with ONE doc, keyless (e.g. provisioning died before Alan
+    // answered) — provisioning must write the key onto THAT doc.
+    const fs = stubFirestore([{ id: DOMAIN_DOC_ID, data: { shop: SHOP } }]);
+    vi.doMock("../firestore.server", () => ({ default: fs }));
+    vi.doMock("../shopify.server", () => ({
+      authenticate: {
+        admin: vi.fn(async () => ({
+          admin: {
+            graphql: vi.fn(async () => ({
+              json: async () => ({ data: { shop: { name: "Test Shop", email: "owner@example.com" } } }),
+            })),
+          },
+          session: { shop: SHOP },
+        })),
+      },
+      registerWebhooks: vi.fn(async () => {}),
+    }));
+    vi.doMock("../services/carrier-service.server", () => ({
+      ensureCarrierServiceRegistered: vi.fn(async () => {}),
+    }));
+    const createMerchant = vi.fn(async () => ({ api_key: "newly_minted_key" }));
+    vi.doMock("../services/ink-api.server", () => ({ createMerchant }));
+
+    const { loader } = await import("../routes/app");
+    await loader({ request: new Request("https://x/app") } as any);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(createMerchant).toHaveBeenCalledOnce();
+    expect(fs.writes[DOMAIN_DOC_ID]).toMatchObject({ ink_api_key: "newly_minted_key" });
+  });
+});


### PR DESCRIPTION
## Before → after (what a merchant sees)

**Before:** on a store holding two merchant documents in Firestore — the
embed's own (doc id = the shop domain) and a backend-provisioned one (a
random id carrying `ink_api_key`) — eleven routes and the app's own
self-provisioning loader each guessed which doc to read or write with their
own private, incomplete lookup. Depending on the route, that guess landed
on the wrong doc silently:

- a settings switch (delivery mode, inventory threshold, min-enrollment
  value) saved and did nothing, because nothing downstream ever reads that
  doc;
- the dashboard Communications card and the onboarding checklist said
  "not configured" for a merchant who had already turned notifications on;
- the install date on the Settings page read "Not available" forever;
- warehouse enroll/upload (the PWA sticker flow) could fail to find the
  merchant's real API key at all;
- order auto-enrollment could run with no key, or mint a fresh backend key
  on every 401 instead of ever finding the real one;
- app.tsx's self-provisioning loader — which runs on every embedded page
  load — could call `createMerchant()` again and again instead of finding
  the key that already existed;
- a GDPR shop/redact erasure deleted only the domain-keyed doc, leaving the
  other one (and whatever settings live on it) undeleted.

**After:** every one of those routes resolves the merchant through the same
resolver the fulfillment webhook already trusted (`findMerchantDocRef`, or
a new `findMerchantDocRefByEither` for callers holding either a shop domain
or a backend `merchant_id`). A switch saved on the Settings tab is the
switch the webhook reads. The GDPR erasure deletes both docs when they
differ.

## The audit

Every route in `app/routes/` and service in `app/services/` that reads or
writes a merchant document, file:line, how it resolved the merchant, and
what changed.

### Fixed in this PR

| Route / service | Was | Now | Reads/writes |
|---|---|---|---|
| `app/routes/app.api.settings.delivery-mode.tsx:35-46` | private `getMerchantDoc` — field query on `shopDomain` first, doc-id fallback second (backwards order, one convention) | `findMerchantDocRef` | writes `verified_delivery_mode` |
| `app/routes/app.api.dashboard.comms.tsx:18` | `doc(session.shop).get()`, no fallback | `findMerchantDocRef` | reads `notification_settings` |
| `app/routes/app.api.onboarding.status.tsx:44` | `doc(shop).get()`, no fallback | `findMerchantDocRef` | reads `notification_settings`, `brand_slug` |
| `app/routes/app.settings.tsx:67-73` | doc-id then `where("shopDomain"==…)` | `findMerchantDocRef` | reads `createdAt` (install date) |
| `app/routes/app.api.settings.inventory.tsx:29-47` | private `getMerchantDoc(shopDomain, merchantId)` — merchant_id-as-doc-id then one field convention | new `findMerchantDocRefByEither` | reads/writes `low_inventory_threshold`, `min_enrollment_value` |
| `app/routes/app.api.settings.media.tsx:57-71` | same shape as inventory.tsx | `findMerchantDocRefByEither` (wrapped to keep the doc-snapshot call shape used ~10x below) | reads/writes `merchant_media`, reads `shop_id` |
| `app/routes/app.api.warehouse.enroll.tsx:37-47,150-155` | `getMerchantApiKey` — byte-identical to upload.tsx's; plus a separate inline min-enrollment-value lookup that OR'd shopDomain/merchantId into one string | `findMerchantDocRefByEither`, tried against both identifiers properly | reads `ink_api_key`, `min_enrollment_value` |
| `app/routes/app.api.warehouse.upload.tsx:31-45` | byte-identical duplicate of enroll.tsx's `getMerchantApiKey` | `findMerchantDocRefByEither` | reads `ink_api_key` |
| `app/routes/app.api.auth.login.tsx:97-114,161-168` | two ad hoc upsert lookups (doc-id then one field convention; create-if-absent) | `findMerchantDocRef`, write to the resolved ref, only create when genuinely absent | reads/writes `ink_api_key` |
| `app/routes/webhooks.shop.redact.tsx:24` | `doc(shop).delete()` only — a GDPR erasure that could leave the OTHER doc's data behind | `findMerchantDocRef` resolves the real doc; both it and the domain-keyed doc are deleted when they differ | deletes the merchant doc(s) |
| `app/routes/webhooks.orders_create.ts:16-45,272,324,505-524` (pre-fix line numbers) | two private functions (`getMerchantDeliveryMode`, `getMerchantApiKey`, both field-first/doc-id-second) plus a third ad hoc query on 401 retry — three separate Firestore round trips per webhook | one `findMerchantDocRef` call reused for all three | reads `verified_delivery_mode`, `ink_api_key`; writes a fresh key on 401 self-heal |
| `app/services/merchant.server.ts` (`getMerchant`) used by `app/routes/app.tsx:48-83` | doc-id-only existence check on every embedded page load — could re-provision forever on a store whose real key lives on a different doc | `findMerchantDocRef`; heals the resolved doc if one exists, creates fresh only when genuinely absent; `getMerchant` deleted (fully unused after the fix) | reads/writes `ink_api_key`, `verified_delivery_mode`, `notification_settings` |
| `app/routes/app.tagged-shipments._index.tsx:6` | dead import of `getMerchant`, never called | removed (drive-by; not a functional lookup) | — |

### Already correct — no private lookup, no change

`app/routes/api.jobs.notifications.tsx`, `webhooks.fulfillments_create.tsx`,
`webhooks.fulfillments_update.tsx`, `webhooks.orders_fulfilled.tsx`,
`app/routes/app.orders.$orderId.tsx`, `app/routes/ink.update.tsx` — all
already call `findMerchantDoc`/`findMerchantDocRef`.
`app/routes/app.api.settings.order-door.tsx:96,132` and
`app.api.settings.notifications.tsx:85,145` already use
`findMerchantDocRef` for their main resolution.

### Intentionally different resolver — measured reason, not touched

- `app/routes/webhooks.orders_create.ts:279` (`findActivationDocRef`) — the
  slice's own resolver, prefers the ACTIVE backend doc over the api-key doc
  on purpose (documented in `merchant-doc.server.ts`'s own header; a
  different, already-fixed bug class from 2026-08-28).
- `app/routes/app.api.settings.order-door.tsx:74` and
  `app.api.settings.notifications.tsx:112`, and
  `app/services/brand-page-url.server.ts:107` — each reads the BACKEND doc
  by its own real id, obtained from `getShopIdByDomain()`/the proof's own
  `shop_id` (an authoritative backend answer, not a guessed domain key).
  Precise addressing, not the landmine.

### Fixed in a separate, already-open, HELD PR — not duplicated here

- `app/routes/app.api.settings.branded-tracking-link.tsx` — PR #107 (not
  yet merged as of this branch's base). Re-fixing it here would conflict
  with that PR's larger change (it also adds two new email switches).

### Audited, NOT fixed here — legacy public endpoints, flagged as follow-up

- `app/routes/api.verify.tsx` — six merchant lookups across a 1,045-line
  public NFC-verify handler with zero existing test coverage. One
  (`~L189`, resolve-by-shop_domain for branding) is landmine-shaped; the
  rest (`~L72`,`~L168`,`~L208`,`~L558`,`~L804`) are reverse lookups by
  `ink_api_key` or `shop_id`/`ink_shop_id` — a different identifier space
  `findMerchantDocRef` doesn't cover, since it resolves by a KNOWN shop
  string, not an unknown one from a key.
- `app/routes/api.retrieve.$proofId.tsx:56` — same profile: a
  doc-id-only "Strategy 1" read, but Strategies 2/3 in the same function
  already fall back on the ambiguity, unlike the settings routes' single
  hard-coded path.

Both are legacy PWA/NFC-era endpoints (BOOT.md: the product moved to
QR-first). Rewriting their deeply nested control flow safely needs its own
test harness (mocking Alan's API, the rate limiter, NFC serial conversion) —
disproportionate to bundle into an audit PR. Flagged, not silently dropped.

### Out of scope — different collection, no merchant-doc ambiguity

`app/routes/auth.$.tsx`, `webhooks.app.scopes_update.tsx`,
`webhooks.app.uninstalled.tsx`, `app/routes/app.api.orders.tsx` touch
`shopify_sessions`, not `merchants`. `api.enroll.tsx`, `api.photos.upload.tsx`,
`api.debug-carrier.tsx`, `api.shipping-rates.ts`, `api.return-status.tsx`,
`app.reorder-tags.tsx`, `app.tag-existing-orders.tsx`,
`app.tagged-shipments.tsx`/`.$orderId.tsx`, `app.billing.tsx`,
`app.payment*.tsx`, `app.register-webhook.tsx`, `app.settings_.advanced.tsx`,
`app.help.tsx`, `app.debug.tsx`, `webhooks.customers.*`,
`webhooks.nfs.verify.tsx`, `app.api.users.tsx`, and the
`app.api.dashboard.{insights,inventory,metrics,recent-activity,tap-stats}.tsx`
family delegate entirely to `ink-api.server.ts` (backend HTTP calls) with no
local Firestore merchant lookup of their own.

## Tests — one red-then-green per fixed route

`app/services/settings-routes-two-doc-shape.test.ts` (15 tests) and
`app/services/merchant-doc-either.server.test.ts` (7 tests, the new shared
helper). Every fixed route/file gets a test against the measured two-doc
shape (a domain-keyed doc with no key + a random-id doc carrying
`ink_api_key`, mirroring `smusic-official.myshopify.com`).

Verified by hand: `git stash` the fix files (keeping the tests), confirm
RED, `git stash pop`, confirm GREEN. Two representative examples:

```
FAIL  …two-doc-shape.test.ts > app.api.settings.delivery-mode … writes verified_delivery_mode to the ink_api_key doc, not the domain-keyed one
  expected undefined to match object { verified_delivery_mode: 'background' }
FAIL  …two-doc-shape.test.ts > webhooks.shop.redact … deletes the ink_api_key doc as well as the domain-keyed one
  expected true to be false
```

→ after the fix, all 22 new tests are green. Exact count, verified by
reverting only the 15 fixed source files to `main@35ae253` and re-running
just the two new test files: **19 fail / 3 pass** — the 3 that pass either
way are deliberate regression-safety checks with no ambiguity to catch
(inventory GET when `merchant_id` alone already resolves the doc-id shape;
a single-doc GDPR delete; app.tsx healing a single keyless doc). Restored
and reconfirmed green (154/154) before opening this PR.

## Gates

- `npm run typecheck` (`react-router typegen && tsc --noEmit`): **0 errors**, before and after.
- `npm run build` (`react-router build`): **passes**. Caught one real problem along the way — `flatRoutes()` auto-discovers every file under `app/routes/` as a route, so the first draft of the test file (placed in `app/routes/`) broke the production build (`Server-only module referenced by client`). Moved both new test files to `app/services/` (they still exercise the route modules via `../routes/*` imports); build is clean.
- `npx vitest run`: **154 passed / 154**, across 17 files — 132 pre-existing tests (15 files, untouched) + 22 new (15 in `settings-routes-two-doc-shape.test.ts`, 7 in `merchant-doc-either.server.test.ts`).
- `npm run lint`: **branch 487 problems (448 errors, 39 warnings)** vs. **main@35ae253 baseline 469 problems (431 errors, 38 warnings)** — net **+18**. Breakdown: **−3** from this PR's own fixes (a `let`→`const` in auth.login.tsx, one fewer issue in delivery-mode.tsx, the dead import removed from tagged-shipments); **+1** warning (`import/no-named-as-default` on `import firestore from "../firestore.server"` in app.tsx — the same warning already present on every other route that imports it the same way, e.g. `session-utils.server.ts`); **+20** `@typescript-eslint/no-explicit-any` inside the two new test files' Firestore stubs — the exact same pattern already flagged in the untouched, pre-existing `merchant-doc-ref.server.test.ts` (line 54), so this matches established test-authoring convention in this repo rather than introducing a new one.

## New surfaces

None.

## For Sam

Nothing to press — it deploys with the next merge after Shopify answers.
This PR is HELD (App Store review in flight) and not merged.
